### PR TITLE
Close sidebar via Escape key

### DIFF
--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -68,6 +68,11 @@ document.addEventListener('DOMContentLoaded', function() {
     hamburgerBtn.addEventListener('click', toggleSidebar);
     if (closeBtn) closeBtn.addEventListener('click', closeSidebar);
     if (overlay) overlay.addEventListener('click', closeSidebar);
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+            closeSidebar();
+        }
+    });
 
     // Appliquer la classe d'effet de survol en fonction de la taille de l'écran
     function applyHoverEffect() {


### PR DESCRIPTION
## Summary
- close sidebar when Escape key is pressed

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c638e8a4832e929b102abc1fccec