### PR TITLE
Localize sidebar script strings

### DIFF
--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -82,8 +82,8 @@ jQuery(document).ready(function($) {
         e.preventDefault();
         if (mediaFrame) { mediaFrame.open(); return; }
         mediaFrame = wp.media({
-            title: 'Choisir un logo',
-            button: { text: 'Utiliser ce logo' },
+            title: sidebarJLG.choose_logo,
+            button: { text: sidebarJLG.use_logo },
             multiple: false
         });
         mediaFrame.on('select', function() {

--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -5,8 +5,12 @@ document.addEventListener('DOMContentLoaded', function() {
     const overlay = document.getElementById('sidebar-overlay');
 
     if (!sidebar || !hamburgerBtn) {
-        if (typeof sidebarSettings !== 'undefined' && sidebarSettings.debug_mode == '1') {
-            console.error('Sidebar JLG: Sidebar or hamburger button not found.');
+        if (
+            typeof sidebarSettings !== 'undefined' &&
+            sidebarSettings.debug_mode == '1' &&
+            typeof sidebarJLGPublic !== 'undefined'
+        ) {
+            console.error(sidebarJLGPublic.notFoundMessage);
         }
         return;
     }

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -224,16 +224,21 @@ class Sidebar_JLG {
             'nonce' => wp_create_nonce('jlg_ajax_nonce'),
             'reset_nonce' => wp_create_nonce('jlg_reset_nonce'),
             'options' => get_option('sidebar_jlg_settings', $this->get_default_settings()),
-            'all_icons' => $this->get_all_available_icons()
+            'all_icons' => $this->get_all_available_icons(),
+            'choose_logo' => __('Choisir un logo', 'sidebar-jlg'),
+            'use_logo' => __('Utiliser ce logo', 'sidebar-jlg')
         ]);
     }
 
     public function enqueue_public_assets() {
         wp_enqueue_style( 'sidebar-jlg-public-css', plugin_dir_url( __FILE__ ) . 'assets/css/public-style.css', [], '4.8.0' );
         wp_enqueue_script( 'sidebar-jlg-public-js', plugin_dir_url( __FILE__ ) . 'assets/js/public-script.js', [], '4.8.0', true );
-        
+
         $options = get_option( 'sidebar_jlg_settings', $this->get_default_settings() );
         wp_localize_script( 'sidebar-jlg-public-js', 'sidebarSettings', $options );
+        wp_localize_script( 'sidebar-jlg-public-js', 'sidebarJLGPublic', [
+            'notFoundMessage' => __('Sidebar JLG: Sidebar or hamburger button not found.', 'sidebar-jlg'),
+        ] );
     }
     
     public function render_sidebar_html() {


### PR DESCRIPTION
## Summary
- expose i18n strings for logo selection and public error messages via `wp_localize_script`
- use localized strings in `admin-script.js` and `public-script.js`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l sidebar-jlg/sidebar-jlg.php`
- `node --check sidebar-jlg/assets/js/admin-script.js`
- `node --check sidebar-jlg/assets/js/public-script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7c630aca8832e9b2842810adcfaed