### PR TITLE
Move color picker into Sidebar_JLG class

### DIFF
--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -175,12 +175,12 @@
                 </tr>
                 <tr>
                     <th scope="row"><?php _e( 'Couleur de fond (Desktop)', 'sidebar-jlg' ); ?></th>
-                    <td><?php jlg_color_picker('bg_color', $options); ?></td>
+                    <td><?php $this->color_picker('bg_color', $options); ?></td>
                 </tr>
                 <tr>
                     <th scope="row"><?php _e( 'Couleur d\'accentuation', 'sidebar-jlg' ); ?></th>
                     <td>
-                        <?php jlg_color_picker('accent_color', $options); ?>
+                        <?php $this->color_picker('accent_color', $options); ?>
                         <p class="description"><?php _e('Utilisée pour les liens actifs et certains effets.', 'sidebar-jlg'); ?></p>
                     </td>
                 </tr>
@@ -200,8 +200,8 @@
                     <th scope="row"><?php _e( 'Typographie du menu', 'sidebar-jlg' ); ?></th>
                     <td>
                         <p><label><?php _e( 'Taille de police', 'sidebar-jlg' ); ?></label> <input type="number" name="sidebar_jlg_settings[font_size]" value="<?php echo esc_attr($options['font_size']); ?>" class="small-text" /> px</p>
-                        <p><label><?php _e( 'Couleur du texte', 'sidebar-jlg' ); ?></label> <?php jlg_color_picker('font_color', $options); ?></p>
-                        <p><label><?php _e( 'Couleur du texte (survol)', 'sidebar-jlg' ); ?></label> <?php jlg_color_picker('font_hover_color', $options); ?></p>
+                        <p><label><?php _e( 'Couleur du texte', 'sidebar-jlg' ); ?></label> <?php $this->color_picker('font_color', $options); ?></p>
+                        <p><label><?php _e( 'Couleur du texte (survol)', 'sidebar-jlg' ); ?></label> <?php $this->color_picker('font_hover_color', $options); ?></p>
                     </td>
                 </tr>
              </table>
@@ -418,26 +418,3 @@
         </div>
     </div>
 </script>
-<?php
-function jlg_color_picker($name, $options) {
-    $type = $options[$name.'_type'] ?? 'solid';
-    $solid_color = $options[$name] ?? '#ffffff';
-    $start_color = $options[$name.'_start'] ?? '#000000';
-    $end_color = $options[$name.'_end'] ?? '#ffffff';
-    ?>
-    <div class="color-picker-wrapper" data-color-name="<?php echo esc_attr($name); ?>">
-        <p>
-            <label><input type="radio" name="sidebar_jlg_settings[<?php echo $name; ?>_type]" value="solid" <?php checked($type, 'solid'); ?>> Solide</label>
-            <label><input type="radio" name="sidebar_jlg_settings[<?php echo $name; ?>_type]" value="gradient" <?php checked($type, 'gradient'); ?>> Dégradé</label>
-        </p>
-        <div class="color-solid-field" style="<?php echo $type === 'solid' ? '' : 'display:none;'; ?>">
-            <input type="text" name="sidebar_jlg_settings[<?php echo $name; ?>]" value="<?php echo esc_attr($solid_color); ?>" class="color-picker-rgba"/>
-        </div>
-        <div class="color-gradient-field" style="<?php echo $type === 'gradient' ? '' : 'display:none;'; ?>">
-            <input type="text" name="sidebar_jlg_settings[<?php echo $name; ?>_start]" value="<?php echo esc_attr($start_color); ?>" class="color-picker-rgba"/>
-            <input type="text" name="sidebar_jlg_settings[<?php echo $name; ?>_end]" value="<?php echo esc_attr($end_color); ?>" class="color-picker-rgba"/>
-        </div>
-    </div>
-    <?php
-}
-?>

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -368,7 +368,29 @@ class Sidebar_JLG {
         delete_transient( 'sidebar_jlg_full_html' );
         wp_send_json_success( 'Réglages réinitialisés.' );
     }
-    
+
+    private function color_picker($name, $options) {
+        $type = $options[$name . '_type'] ?? 'solid';
+        $solid_color = $options[$name] ?? '#ffffff';
+        $start_color = $options[$name . '_start'] ?? '#000000';
+        $end_color = $options[$name . '_end'] ?? '#ffffff';
+        ?>
+        <div class="color-picker-wrapper" data-color-name="<?php echo esc_attr($name); ?>">
+            <p>
+                <label><input type="radio" name="sidebar_jlg_settings[<?php echo $name; ?>_type]" value="solid" <?php checked($type, 'solid'); ?>> <?php echo __('Solide', 'sidebar-jlg'); ?></label>
+                <label><input type="radio" name="sidebar_jlg_settings[<?php echo $name; ?>_type]" value="gradient" <?php checked($type, 'gradient'); ?>> <?php echo __('Dégradé', 'sidebar-jlg'); ?></label>
+            </p>
+            <div class="color-solid-field" style="<?php echo $type === 'solid' ? '' : 'display:none;'; ?>">
+                <input type="text" name="sidebar_jlg_settings[<?php echo $name; ?>]" value="<?php echo esc_attr($solid_color); ?>" class="color-picker-rgba"/>
+            </div>
+            <div class="color-gradient-field" style="<?php echo $type === 'gradient' ? '' : 'display:none;'; ?>">
+                <input type="text" name="sidebar_jlg_settings[<?php echo $name; ?>_start]" value="<?php echo esc_attr($start_color); ?>" class="color-picker-rgba"/>
+                <input type="text" name="sidebar_jlg_settings[<?php echo $name; ?>_end]" value="<?php echo esc_attr($end_color); ?>" class="color-picker-rgba"/>
+            </div>
+        </div>
+        <?php
+    }
+
     private function sanitize_rgba_color( $color ) {
         if ( empty( $color ) || is_array( $color ) ) return '';
         if ( false === strpos( $color, 'rgba' ) ) return sanitize_hex_color( $color );


### PR DESCRIPTION
## Summary
- refactor jlg_color_picker into a private method on Sidebar_JLG
- wrap "Solide" and "Dégradé" labels with translation helpers
- update admin-page to call the new method

## Testing
- `php -l sidebar-jlg/sidebar-jlg.php`
- `php -l sidebar-jlg/includes/admin-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68c80e696980832e891a84f8ff65f1e6