### PR TITLE
Use uploads directory for custom sidebar icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Après activation, un menu "Sidebar JLG" apparait dans l'administration. Vous po
 - Choisir le style : couleurs, typographie, effets d'animation, marges…
 - Ajouter des éléments de menu (pages, articles, catégories, liens personnalisés) et des icônes sociales.
 - Activer une recherche intégrée et personnaliser son affichage.
-- Importer vos propres icônes SVG.
+- Importer vos propres icônes SVG en les plaçant dans le dossier `wp-content/uploads/sidebar-jlg/icons/`.
 
 ## Désinstallation
 

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -10,7 +10,7 @@
     ?>
 
     <p><?php _e( 'Personnalisez l\'apparence et le comportement de votre sidebar.', 'sidebar-jlg' ); ?></p>
-    <p><b><?php _e( 'Nouveau :', 'sidebar-jlg' ); ?></b> <?php _e( 'Ajoutez vos propres icônes SVG dans le dossier <code>/wp-content/plugins/sidebar-jlg/assets/icons/</code>. Elles apparaîtront dans les listes de sélection !', 'sidebar-jlg' ); ?></p>
+    <p><b><?php _e( 'Nouveau :', 'sidebar-jlg' ); ?></b> <?php _e( 'Ajoutez vos propres icônes SVG dans le dossier <code>/wp-content/uploads/sidebar-jlg/icons/</code>. Elles apparaîtront dans les listes de sélection !', 'sidebar-jlg' ); ?></p>
 
     <div class="nav-tab-wrapper">
         <a href="#tab-general" class="nav-tab nav-tab-active"><?php _e( 'Général & Comportement', 'sidebar-jlg' ); ?></a>

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -20,7 +20,7 @@ if ( ! defined( 'SIDEBAR_JLG_VERSION' ) ) {
 
 // Créer le dossier d'icônes personnalisées à l'activation
 register_activation_hook(__FILE__, function() {
-    $icons_dir = plugin_dir_path(__FILE__) . 'assets/icons/';
+    $icons_dir = wp_upload_dir()['basedir'] . '/sidebar-jlg/icons/';
     if (!is_dir($icons_dir)) {
         wp_mkdir_p($icons_dir);
     }
@@ -96,13 +96,14 @@ class Sidebar_JLG {
 
     private function get_custom_icons() {
         $custom_icons = [];
-        $icons_dir = plugin_dir_path(__FILE__) . 'assets/icons/';
+        $upload_dir = wp_upload_dir();
+        $icons_dir = $upload_dir['basedir'] . '/sidebar-jlg/icons/';
         if (is_dir($icons_dir)) {
             $files = scandir($icons_dir);
             foreach ($files as $file) {
                 if (pathinfo($file, PATHINFO_EXTENSION) === 'svg') {
                     $icon_name = 'custom_' . sanitize_key(pathinfo($file, PATHINFO_FILENAME));
-                    $custom_icons[$icon_name] = plugin_dir_url(__FILE__) . 'assets/icons/' . $file;
+                    $custom_icons[$icon_name] = $upload_dir['baseurl'] . '/sidebar-jlg/icons/' . $file;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- create custom icons folder in WordPress uploads on plugin activation
- load custom icons from uploads directory
- document new uploads path for custom SVG icons in admin and README

## Testing
- `php -l sidebar-jlg/sidebar-jlg.php`
- `php -l sidebar-jlg/includes/admin-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68c80e6a5a84832eb2cde704974d6c18