### PR TITLE
Add permission checks and pagination to AJAX data sources

### DIFF
--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -393,14 +393,19 @@ jQuery(document).ready(function($) {
         } else if (type === 'post' || type === 'category') {
             const action = type === 'post' ? 'jlg_get_posts' : 'jlg_get_categories';
             const name = `sidebar_jlg_settings[menu_items][${index}][value]`;
-            
+
             let html = '<p><label>' + (type === 'post' ? 'Article' : 'Catégorie') + '</label>';
             html += '<select class="widefat" name="' + name + '"><option value="">Chargement...</option></select></p>';
             valueWrapper.html(html);
-            
+
+            const page = 1;
+            const postsPerPage = 20;
+
             $.post(sidebarJLG.ajax_url, {
                 action: action,
-                nonce: sidebarJLG.nonce
+                nonce: sidebarJLG.nonce,
+                page: page,
+                posts_per_page: postsPerPage
             }).done(function(response) {
                 if (response.success) {
                     const idKey = type === 'post' ? 'id' : 'id';

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -341,7 +341,15 @@ class Sidebar_JLG {
 
     public function ajax_get_posts() {
         check_ajax_referer('jlg_ajax_nonce', 'nonce');
-        $posts = get_posts(['numberposts' => -1]);
+        if ( ! current_user_can('manage_options') ) {
+            wp_send_json_error('Permission refusée.');
+        }
+        $page = isset($_POST['page']) ? max(1, intval($_POST['page'])) : 1;
+        $per_page = isset($_POST['posts_per_page']) ? intval($_POST['posts_per_page']) : 20;
+        $posts = get_posts([
+            'posts_per_page' => $per_page,
+            'paged' => $page,
+        ]);
         $options = [];
         foreach ($posts as $post) {
             $options[] = ['id' => $post->ID, 'title' => $post->post_title];
@@ -351,7 +359,17 @@ class Sidebar_JLG {
 
     public function ajax_get_categories() {
         check_ajax_referer('jlg_ajax_nonce', 'nonce');
-        $categories = get_categories(['hide_empty' => false]);
+        if ( ! current_user_can('manage_options') ) {
+            wp_send_json_error('Permission refusée.');
+        }
+        $page = isset($_POST['page']) ? max(1, intval($_POST['page'])) : 1;
+        $per_page = isset($_POST['posts_per_page']) ? intval($_POST['posts_per_page']) : 20;
+        $offset = ($page - 1) * $per_page;
+        $categories = get_categories([
+            'hide_empty' => false,
+            'number' => $per_page,
+            'offset' => $offset,
+        ]);
         $options = [];
         foreach ($categories as $category) {
             $options[] = ['id' => $category->term_id, 'name' => $category->name];


### PR DESCRIPTION
## Summary
- Secure post and category AJAX handlers with capability checks
- Implement pagination for post and category retrieval
- Send pagination parameters from admin JavaScript

## Testing
- `php -l sidebar-jlg/sidebar-jlg.php`
- `node --check sidebar-jlg/assets/js/admin-script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80e6001f4832e913135e088541d26