### PR TITLE
Handle missing social icon fields gracefully

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -204,9 +204,20 @@ class Sidebar_JLG {
         $sanitized_social_icons = [];
         if (isset($sanitized_input['social_icons']) && is_array($sanitized_input['social_icons'])) {
             foreach ($sanitized_input['social_icons'] as $item) {
+                if (!is_array($item)) {
+                    continue;
+                }
+
+                $url = esc_url_raw($item['url'] ?? '');
+                $icon = sanitize_key($item['icon'] ?? '');
+
+                if ($url === '' || $icon === '') {
+                    continue;
+                }
+
                 $sanitized_item = [
-                    'url' => esc_url_raw($item['url']),
-                    'icon' => sanitize_key($item['icon']),
+                    'url' => $url,
+                    'icon' => $icon,
                 ];
                 $sanitized_social_icons[] = $sanitized_item;
             }


### PR DESCRIPTION
## Summary
- guard social icon sanitization against missing fields to avoid PHP notices
- skip incomplete social icon entries when processing settings

## Testing
- php -l sidebar-jlg/sidebar-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c85d234814832e8ed71b1d13c303ae