### PR TITLE
Escape color picker name attributes

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -472,17 +472,17 @@ class Sidebar_JLG {
         $start_color = $options[$name . '_start'] ?? '#000000';
         $end_color = $options[$name . '_end'] ?? '#ffffff';
         ?>
-        <div class="color-picker-wrapper" data-color-name="<?php echo esc_attr($name); ?>">
+        <div class="color-picker-wrapper" data-color-name="<?php echo esc_attr( $name ); ?>">
             <p>
-                <label><input type="radio" name="sidebar_jlg_settings[<?php echo $name; ?>_type]" value="solid" <?php checked($type, 'solid'); ?>> <?php echo __('Solide', 'sidebar-jlg'); ?></label>
-                <label><input type="radio" name="sidebar_jlg_settings[<?php echo $name; ?>_type]" value="gradient" <?php checked($type, 'gradient'); ?>> <?php echo __('Dégradé', 'sidebar-jlg'); ?></label>
+                <label><input type="radio" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>_type]" value="solid" <?php checked($type, 'solid'); ?>> <?php echo __('Solide', 'sidebar-jlg'); ?></label>
+                <label><input type="radio" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>_type]" value="gradient" <?php checked($type, 'gradient'); ?>> <?php echo __('Dégradé', 'sidebar-jlg'); ?></label>
             </p>
             <div class="color-solid-field" style="<?php echo $type === 'solid' ? '' : 'display:none;'; ?>">
-                <input type="text" name="sidebar_jlg_settings[<?php echo $name; ?>]" value="<?php echo esc_attr($solid_color); ?>" class="color-picker-rgba"/>
+                <input type="text" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>]" value="<?php echo esc_attr( $solid_color ); ?>" class="color-picker-rgba"/>
             </div>
             <div class="color-gradient-field" style="<?php echo $type === 'gradient' ? '' : 'display:none;'; ?>">
-                <input type="text" name="sidebar_jlg_settings[<?php echo $name; ?>_start]" value="<?php echo esc_attr($start_color); ?>" class="color-picker-rgba"/>
-                <input type="text" name="sidebar_jlg_settings[<?php echo $name; ?>_end]" value="<?php echo esc_attr($end_color); ?>" class="color-picker-rgba"/>
+                <input type="text" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>_start]" value="<?php echo esc_attr( $start_color ); ?>" class="color-picker-rgba"/>
+                <input type="text" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>_end]" value="<?php echo esc_attr( $end_color ); ?>" class="color-picker-rgba"/>
             </div>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- escape the dynamic color picker field names with esc_attr() to harden attribute output

## Testing
- php -l sidebar-jlg/sidebar-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c874d22850832e9ec26237f3fb40c1