### PR TITLE
Use escaping helpers in color picker labels

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -474,8 +474,8 @@ class Sidebar_JLG {
         ?>
         <div class="color-picker-wrapper" data-color-name="<?php echo esc_attr( $name ); ?>">
             <p>
-                <label><input type="radio" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>_type]" value="solid" <?php checked($type, 'solid'); ?>> <?php echo __('Solide', 'sidebar-jlg'); ?></label>
-                <label><input type="radio" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>_type]" value="gradient" <?php checked($type, 'gradient'); ?>> <?php echo __('Dégradé', 'sidebar-jlg'); ?></label>
+                <label><input type="radio" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>_type]" value="solid" <?php checked($type, 'solid'); ?>> <?php esc_html_e('Solide', 'sidebar-jlg'); ?></label>
+                <label><input type="radio" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>_type]" value="gradient" <?php checked($type, 'gradient'); ?>> <?php esc_html_e('Dégradé', 'sidebar-jlg'); ?></label>
             </p>
             <div class="color-solid-field" style="<?php echo $type === 'solid' ? '' : 'display:none;'; ?>">
                 <input type="text" name="sidebar_jlg_settings[<?php echo esc_attr( $name ); ?>]" value="<?php echo esc_attr( $solid_color ); ?>" class="color-picker-rgba"/>


### PR DESCRIPTION
## Summary
- update the color picker radio labels to use `esc_html_e` for safer translation output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c888df4d58832e916f73e7971e64f4