### PR TITLE
Secure custom icon loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Après activation, un menu "Sidebar JLG" apparait dans l'administration. Vous po
 - Activer une recherche intégrée et personnaliser son affichage.
 - Importer vos propres icônes SVG en les plaçant dans le dossier `wp-content/uploads/sidebar-jlg/icons/`.
 
+### Icônes personnalisées
+
+- Seuls les fichiers au format `.svg` sont chargés par le plugin. Chaque fichier est contrôlé avec `wp_check_filetype()` avant d'être ajouté à la bibliothèque.
+- Le contenu SVG est validé via `wp_kses`. Les fichiers dont le contenu est altéré par le nettoyage ou qui contiennent des éléments non autorisés sont ignorés pour éviter toute contamination.
+
 ## Désinstallation
 
 La désinstallation supprime les options enregistrées par le plugin.


### PR DESCRIPTION
## Summary
- validate custom SVG icons with wp_check_filetype and sanitize their markup before exposing them in the icon list
- add helper utilities to whitelist SVG elements and normalize files so invalid assets are skipped
- document the custom icon type and content restrictions in the README

## Testing
- php -l WP-sidebar/sidebar-jlg/sidebar-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c91d045a6c832e91435520ea760f4f