### PR TITLE
Sanitize AJAX post parameters with wp_unslash

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -568,9 +568,9 @@ class Sidebar_JLG {
         }
 
         check_ajax_referer( 'jlg_ajax_nonce', 'nonce' );
-        $page = isset($_POST['page']) ? max(1, intval($_POST['page'])) : 1;
+        $page = isset($_POST['page']) ? max(1, intval(wp_unslash($_POST['page']))) : 1;
         $max_per_page = 50;
-        $requested_per_page = isset($_POST['posts_per_page']) ? intval($_POST['posts_per_page']) : 20;
+        $requested_per_page = isset($_POST['posts_per_page']) ? intval(wp_unslash($_POST['posts_per_page'])) : 20;
 
         if ($requested_per_page > $max_per_page) {
             wp_send_json_error( sprintf( 'Le paramètre posts_per_page ne peut pas dépasser %d.', $max_per_page ) );
@@ -596,9 +596,9 @@ class Sidebar_JLG {
         }
 
         check_ajax_referer( 'jlg_ajax_nonce', 'nonce' );
-        $page = isset($_POST['page']) ? max(1, intval($_POST['page'])) : 1;
+        $page = isset($_POST['page']) ? max(1, intval(wp_unslash($_POST['page']))) : 1;
         $max_per_page = 50;
-        $requested_per_page = isset($_POST['posts_per_page']) ? intval($_POST['posts_per_page']) : 20;
+        $requested_per_page = isset($_POST['posts_per_page']) ? intval(wp_unslash($_POST['posts_per_page'])) : 20;
 
         if ($requested_per_page > $max_per_page) {
             wp_send_json_error( sprintf( 'Le paramètre posts_per_page ne peut pas dépasser %d.', $max_per_page ) );


### PR DESCRIPTION
## Summary
- sanitize AJAX pagination parameters by unslashing POST data before casting
- ensure both post and category lookups apply wp_unslash to page and posts_per_page values

## Testing
- php -l sidebar-jlg/sidebar-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c93087ebd4832e9a07486bdd5c2f0a