### PR TITLE
Add size validation for custom SVG icons

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -97,6 +97,8 @@ class Sidebar_JLG {
             return $custom_icons;
         }
 
+        $max_file_size = 200 * 1024; // 200 KB limit
+
         $files = scandir($icons_dir);
         if ( ! is_array($files) ) {
             return $custom_icons;
@@ -117,6 +119,11 @@ class Sidebar_JLG {
 
             $filetype = wp_check_filetype($file_path, $allowed_mimes);
             if (empty($filetype['ext']) || $filetype['ext'] !== 'svg' || empty($filetype['type'])) {
+                continue;
+            }
+
+            $file_size = filesize($file_path);
+            if ($file_size === false || $file_size > $max_file_size) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- enforce a 200 KB size limit for custom SVG icon files before loading them
- skip oversized icons to avoid unnecessary parsing of large files

## Testing
- php -l sidebar-jlg/sidebar-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c945f2af3c832e8b627510501abc6a