### PR TITLE
Set id key constant in admin script

### DIFF
--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -408,7 +408,7 @@ jQuery(document).ready(function($) {
                 posts_per_page: postsPerPage
             }).done(function(response) {
                 if (response.success) {
-                    const idKey = type === 'post' ? 'id' : 'id';
+                    const idKey = 'id';
                     const titleKey = type === 'post' ? 'title' : 'name';
                     html = `<select class="widefat" name="${name}">`;
                     response.data.forEach(opt => {


### PR DESCRIPTION
## Summary
- simplify the id key handling in the admin data builder
- keep option rendering using the shared id key for value lookup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c94cc79144832ea746976f66318689