### PR TITLE
Add namespace for Sidebar_JLG class

### DIFF
--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -24,7 +24,7 @@
     <form action="options.php" method="post" id="sidebar-jlg-form">
         <?php
         settings_fields( 'sidebar_jlg_options_group' );
-        $defaults = Sidebar_JLG::get_instance()->get_default_settings();
+        $defaults = \JLG\Sidebar\Sidebar_JLG::get_instance()->get_default_settings();
         $options_from_db = get_option( 'sidebar_jlg_settings' );
         $options = wp_parse_args( $options_from_db, $defaults );
         ?>

--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -1,8 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-$options = get_option('sidebar_jlg_settings', Sidebar_JLG::get_instance()->get_default_settings());
-$all_icons = Sidebar_JLG::get_instance()->get_all_available_icons();
+$options = get_option('sidebar_jlg_settings', \JLG\Sidebar\Sidebar_JLG::get_instance()->get_default_settings());
+$all_icons = \JLG\Sidebar\Sidebar_JLG::get_instance()->get_all_available_icons();
 
 ob_start();
 ?>

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -11,7 +11,11 @@
  * Domain Path:       /languages
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+namespace JLG\Sidebar;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 // Définir la version du plugin
 if ( ! defined( 'SIDEBAR_JLG_VERSION' ) ) {
@@ -808,5 +812,5 @@ class Sidebar_JLG {
 }
 
 if ( ! defined( 'SIDEBAR_JLG_SKIP_BOOTSTRAP' ) ) {
-    Sidebar_JLG::get_instance();
+    \JLG\Sidebar\Sidebar_JLG::get_instance();
 }

--- a/tests/sanitize_rgba_color_test.php
+++ b/tests/sanitize_rgba_color_test.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use JLG\Sidebar\Sidebar_JLG;
+
 define('ABSPATH', true);
 define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
 


### PR DESCRIPTION
## Summary
- declare the plugin under the `JLG\Sidebar` namespace to avoid global class collisions
- update the admin page and public template to reference the namespaced `Sidebar_JLG` singleton
- adjust the sanitize_rgba_color test harness to import the class from its namespace

## Testing
- php tests/sanitize_rgba_color_test.php

------
https://chatgpt.com/codex/tasks/task_e_68c967208528832e9a0b7f028509aeeb