### PR TITLE
Clear sidebar cache when content changes

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -61,7 +61,21 @@ class Sidebar_JLG {
         add_action( 'wp_ajax_jlg_get_categories', [ $this, 'ajax_get_categories' ] );
         add_action( 'wp_ajax_jlg_reset_settings', [ $this, 'ajax_reset_settings' ] );
         
-        add_action( 'update_option_sidebar_jlg_settings', [ $this, 'clear_menu_cache' ], 10, 2 );
+        add_action( 'update_option_sidebar_jlg_settings', [ $this, 'clear_menu_cache' ], 10, 0 );
+
+        $content_change_hooks = [
+            'save_post',
+            'deleted_post',
+            'trashed_post',
+            'untrashed_post',
+            'edited_term',
+            'delete_term',
+            'created_term',
+        ];
+
+        foreach ( $content_change_hooks as $hook ) {
+            add_action( $hook, [ $this, 'clear_menu_cache' ], 10, 0 );
+        }
     }
 
     public function get_all_available_icons() {


### PR DESCRIPTION
## Summary
- hook `clear_menu_cache()` into additional post and term lifecycle events so cached sidebar HTML is regenerated after content updates
- ensure all hooks register with zero accepted arguments so the parameterless cache clearer remains compatible

## Testing
- php -l sidebar-jlg/sidebar-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cfab1c20832eb3f0e095879adcd6