### PR TITLE
Load lucide before admin script and add icon modal markup

### DIFF
--- a/sidebar-jlg/assets/css/admin-style.css
+++ b/sidebar-jlg/assets/css/admin-style.css
@@ -30,6 +30,7 @@ input:checked + .jlg-slider:before { transform: translateX(26px); }
 }
 
 /* Modale d'icônes */
+#icon-library-modal { display: none; }
 #icon-library-modal .modal-backdrop { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.7); z-index: 100000; }
 #icon-library-modal .modal-content { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 90%; max-width: 800px; height: 80%; background: #fff; z-index: 100001; padding: 20px; display: flex; flex-direction: column; }
 #icon-library-modal .modal-close { position: absolute; top: 10px; right: 10px; font-size: 1.5em; background: none; border: none; cursor: pointer; }

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -374,6 +374,16 @@
     </form>
 </div>
 
+<div id="icon-library-modal" style="display:none;">
+    <div class="modal-backdrop"></div>
+    <div class="modal-content">
+        <button type="button" class="modal-close" aria-label="<?php esc_attr_e( 'Fermer la modale', 'sidebar-jlg' ); ?>">&times;</button>
+        <h2><?php esc_html_e( 'Bibliothèque d\'icônes', 'sidebar-jlg' ); ?></h2>
+        <input type="search" id="icon-search" placeholder="<?php esc_attr_e( 'Rechercher une icône…', 'sidebar-jlg' ); ?>" />
+        <div id="icon-grid"></div>
+    </div>
+</div>
+
 <!-- Templates JS -->
 <script type="text/html" id="tmpl-menu-item">
     <div class="menu-item-box">

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -583,7 +583,10 @@ class Sidebar_JLG {
         wp_enqueue_media();
         wp_enqueue_style( 'sidebar-jlg-admin-css', plugin_dir_url( __FILE__ ) . 'assets/css/admin-style.css', [], SIDEBAR_JLG_VERSION );
 
-        wp_enqueue_script( 'sidebar-jlg-admin-js', plugin_dir_url( __FILE__ ) . 'assets/js/admin-script.js', [ 'jquery', 'wp-color-picker', 'jquery-ui-sortable', 'wp-util' ], SIDEBAR_JLG_VERSION, true );
+        wp_register_script( 'sidebar-jlg-lucide', plugin_dir_url( __FILE__ ) . 'assets/js/lucide.min.js', [], SIDEBAR_JLG_VERSION, true );
+        wp_enqueue_script( 'sidebar-jlg-lucide' );
+
+        wp_enqueue_script( 'sidebar-jlg-admin-js', plugin_dir_url( __FILE__ ) . 'assets/js/admin-script.js', [ 'jquery', 'wp-color-picker', 'jquery-ui-sortable', 'wp-util', 'sidebar-jlg-lucide' ], SIDEBAR_JLG_VERSION, true );
 
         wp_localize_script('sidebar-jlg-admin-js', 'sidebarJLG', [
             'ajax_url' => admin_url('admin-ajax.php'),


### PR DESCRIPTION
## Summary
- register and enqueue the lucide bundle before the admin script so window.lucide is available
- add the hidden icon library modal markup that the admin JavaScript expects
- hide the modal container by default in the admin stylesheet so script-driven toggling works

## Testing
- php -l sidebar-jlg/sidebar-jlg.php
- php -l sidebar-jlg/includes/admin-page.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cfabf658832ea80a30d5a5ad2ef8