### PR TITLE
Use dimension sanitizer for header padding

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -495,7 +495,10 @@ class Sidebar_JLG {
         $sanitized['header_logo_size'] = absint($input['header_logo_size'] ?? $existing_options['header_logo_size']);
         $sanitized['header_alignment_desktop'] = sanitize_key($input['header_alignment_desktop'] ?? $existing_options['header_alignment_desktop']);
         $sanitized['header_alignment_mobile'] = sanitize_key($input['header_alignment_mobile'] ?? $existing_options['header_alignment_mobile']);
-        $sanitized['header_padding_top'] = sanitize_text_field($input['header_padding_top'] ?? $existing_options['header_padding_top']);
+        $sanitized['header_padding_top'] = $this->sanitize_css_dimension(
+            $input['header_padding_top'] ?? null,
+            $existing_options['header_padding_top'] ?? ''
+        );
         $sanitized['font_size'] = absint($input['font_size'] ?? $existing_options['font_size']);
         $sanitized['mobile_bg_color'] = $this->sanitize_rgba_color($input['mobile_bg_color'] ?? $existing_options['mobile_bg_color']);
         $sanitized['mobile_bg_opacity'] = floatval($input['mobile_bg_opacity'] ?? $existing_options['mobile_bg_opacity']);

--- a/tests/sanitize_css_dimension_test.php
+++ b/tests/sanitize_css_dimension_test.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Sidebar_JLG;
+
+define('ABSPATH', true);
+define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
+
+if (!function_exists('register_activation_hook')) {
+    function register_activation_hook($file, $callback): void {
+        // No-op for tests.
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value): string {
+        if (is_array($value) || is_object($value)) {
+            return '';
+        }
+
+        $value = (string) $value;
+        $value = strip_tags($value);
+        $value = preg_replace('/[\r\n\t ]+/', ' ', $value);
+
+        return trim($value);
+    }
+}
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$reflection = new ReflectionClass(Sidebar_JLG::class);
+$instance = $reflection->newInstanceWithoutConstructor();
+$method = $reflection->getMethod('sanitize_css_dimension');
+$method->setAccessible(true);
+
+$tests = [
+    'valid_px' => [
+        'input'    => '24px',
+        'fallback' => '2.5rem',
+        'expected' => '24px',
+    ],
+    'valid_rem' => [
+        'input'    => '1.5rem',
+        'fallback' => '2.5rem',
+        'expected' => '1.5rem',
+    ],
+    'valid_vh' => [
+        'input'    => '50vh',
+        'fallback' => '2.5rem',
+        'expected' => '50vh',
+    ],
+    'negative_value' => [
+        'input'    => '-10px',
+        'fallback' => '2.5rem',
+        'expected' => '-10px',
+    ],
+    'zero_without_unit' => [
+        'input'    => '0',
+        'fallback' => '2.5rem',
+        'expected' => '0',
+    ],
+    'zero_decimal' => [
+        'input'    => '0.0',
+        'fallback' => '2.5rem',
+        'expected' => '0',
+    ],
+    'empty_input_uses_fallback' => [
+        'input'    => '',
+        'fallback' => '2.5rem',
+        'expected' => '2.5rem',
+    ],
+    'invalid_input_uses_fallback' => [
+        'input'    => 'auto',
+        'fallback' => '2.5rem',
+        'expected' => '2.5rem',
+    ],
+];
+
+$allPassed = true;
+foreach ($tests as $name => $test) {
+    $result = $method->invoke($instance, $test['input'], $test['fallback']);
+    if ($result === $test['expected']) {
+        echo sprintf("[PASS] %s\n", $name);
+        continue;
+    }
+
+    $allPassed = false;
+    echo sprintf(
+        "[FAIL] %s - expected %s got %s\n",
+        $name,
+        var_export($test['expected'], true),
+        var_export($result, true)
+    );
+}
+
+if ($allPassed) {
+    echo "All sanitize_css_dimension tests passed.\n";
+    exit(0);
+}
+
+echo "sanitize_css_dimension tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- sanitize the `header_padding_top` option with the CSS dimension helper so only expected units are accepted
- add unit coverage for `sanitize_css_dimension` to confirm valid units and fallback handling

## Testing
- php tests/sanitize_css_dimension_test.php
- php tests/sanitize_rgba_color_test.php

------
https://chatgpt.com/codex/tasks/task_e_68c9d6737304832ea6065b10bdeb139f