### PR TITLE
Call clear_menu_cache when resetting settings

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -887,7 +887,7 @@ class Sidebar_JLG {
 
         check_ajax_referer( 'jlg_reset_nonce', 'nonce' );
         delete_option( 'sidebar_jlg_settings' );
-        delete_transient( 'sidebar_jlg_full_html' );
+        $this->clear_menu_cache();
         wp_send_json_success( 'Réglages réinitialisés.' );
     }
 


### PR DESCRIPTION
## Summary
- call `clear_menu_cache()` when resetting settings to remove cached sidebar output and locales
- remove redundant transient deletion handled by the cache clearing helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cac0310b1c832eb0036d44918e0e15