### PR TITLE
Document cache clearing during settings reset

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -887,6 +887,7 @@ class Sidebar_JLG {
 
         check_ajax_referer( 'jlg_reset_nonce', 'nonce' );
         delete_option( 'sidebar_jlg_settings' );
+        // Also clear cached HTML so all locale-specific transients are removed.
         $this->clear_menu_cache();
         wp_send_json_success( 'Réglages réinitialisés.' );
     }


### PR DESCRIPTION
## Summary
- add a short inline comment explaining the cache invalidation performed during the AJAX reset handler

## Testing
- php -l sidebar-jlg/sidebar-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68cac466a06c832eb0c62c52dd53af59