### PR TITLE
Clean cached locale transients on uninstall

### DIFF
--- a/sidebar-jlg/uninstall.php
+++ b/sidebar-jlg/uninstall.php
@@ -18,8 +18,26 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // C'est ici que tous les réglages de la sidebar sont stockés.
 delete_option( 'sidebar_jlg_settings' );
 
-// 2. Supprimer le transient (cache) du menu.
-// Cela garantit qu'aucune donnée temporaire ne reste dans la base de données.
+// 2. Supprimer tous les transients de cache générés pour les locales mémorisées.
+$cached_locales = get_option( 'sidebar_jlg_cached_locales', [] );
+
+if ( ! is_array( $cached_locales ) ) {
+    $cached_locales = [];
+}
+
+foreach ( $cached_locales as $locale ) {
+    $normalized = preg_replace( '/[^A-Za-z0-9_\-]/', '', (string) $locale );
+
+    if ( null === $normalized || '' === $normalized ) {
+        $normalized = 'default';
+    }
+
+    delete_transient( 'sidebar_jlg_full_html_' . $normalized );
+}
+
+// 3. Après la boucle, supprimer la liste des locales mises en cache
+//    ainsi que le transient générique existant.
+delete_option( 'sidebar_jlg_cached_locales' );
 delete_transient( 'sidebar_jlg_full_html' );
 
 // Note pour l'avenir : 


### PR DESCRIPTION
## Summary
- remove all locale-specific sidebar cache transients during uninstall
- drop the cached locales option and the generic sidebar cache transient to leave no residual data

## Testing
- php -l sidebar-jlg/uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68cb0193efe4832ea147fa6f0a0fad45