### PR TITLE
Handle color sanitation fallbacks

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -482,10 +482,22 @@ class Sidebar_JLG {
             $sanitized[$type_key] = $color_type;
 
             if ($color_type === 'gradient') {
-                $sanitized[$color_key . '_start'] = $this->sanitize_rgba_color($input[$color_key . '_start'] ?? $existing_options[$color_key . '_start']);
-                $sanitized[$color_key . '_end'] = $this->sanitize_rgba_color($input[$color_key . '_end'] ?? $existing_options[$color_key . '_end']);
+                $start_key = $color_key . '_start';
+                $end_key = $color_key . '_end';
+
+                $sanitized[$start_key] = $this->sanitize_color_with_existing(
+                    $input[$start_key] ?? null,
+                    $existing_options[$start_key] ?? ''
+                );
+                $sanitized[$end_key] = $this->sanitize_color_with_existing(
+                    $input[$end_key] ?? null,
+                    $existing_options[$end_key] ?? ''
+                );
             } else {
-                $sanitized[$color_key] = $this->sanitize_rgba_color($input[$color_key] ?? $existing_options[$color_key]);
+                $sanitized[$color_key] = $this->sanitize_color_with_existing(
+                    $input[$color_key] ?? null,
+                    $existing_options[$color_key] ?? ''
+                );
             }
         }
 
@@ -500,7 +512,10 @@ class Sidebar_JLG {
             $existing_options['header_padding_top'] ?? ''
         );
         $sanitized['font_size'] = absint($input['font_size'] ?? $existing_options['font_size']);
-        $sanitized['mobile_bg_color'] = $this->sanitize_rgba_color($input['mobile_bg_color'] ?? $existing_options['mobile_bg_color']);
+        $sanitized['mobile_bg_color'] = $this->sanitize_color_with_existing(
+            $input['mobile_bg_color'] ?? null,
+            $existing_options['mobile_bg_color'] ?? ''
+        );
         $sanitized['mobile_bg_opacity'] = floatval($input['mobile_bg_opacity'] ?? $existing_options['mobile_bg_opacity']);
         $sanitized['mobile_blur'] = absint($input['mobile_blur'] ?? $existing_options['mobile_blur']);
 
@@ -921,6 +936,25 @@ class Sidebar_JLG {
             </div>
         </div>
         <?php
+    }
+
+    private function sanitize_color_with_existing($value, $existing_value) {
+        $existing_value = (is_string($existing_value) || is_numeric($existing_value))
+            ? (string) $existing_value
+            : '';
+
+        $candidate = $value;
+        if ($candidate === null) {
+            $candidate = $existing_value;
+        }
+
+        $sanitized = $this->sanitize_rgba_color($candidate);
+
+        if ($sanitized === '' && $existing_value !== '') {
+            return $existing_value;
+        }
+
+        return $sanitized;
     }
 
     private function sanitize_rgba_color( $color ) {

--- a/tests/sanitize_style_settings_test.php
+++ b/tests/sanitize_style_settings_test.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Sidebar_JLG;
+
+define('ABSPATH', true);
+define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
+
+if (!function_exists('register_activation_hook')) {
+    function register_activation_hook($file, $callback): void {
+        // No-op for tests.
+    }
+}
+
+if (!function_exists('sanitize_hex_color')) {
+    function sanitize_hex_color($color): string {
+        $color = trim((string) $color);
+        if (preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $color)) {
+            return strtolower($color);
+        }
+
+        return '';
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key): string {
+        $key = strtolower((string) $key);
+        return preg_replace('/[^a-z0-9_\-]/', '', $key);
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value): string {
+        $value = (string) $value;
+        $value = strip_tags($value);
+        $value = preg_replace('/[\r\n\t\0\x0B]/', '', $value);
+
+        return trim($value);
+    }
+}
+
+if (!function_exists('esc_url_raw')) {
+    function esc_url_raw($value): string {
+        return (string) $value;
+    }
+}
+
+if (!function_exists('absint')) {
+    function absint($value): int {
+        return abs((int) $value);
+    }
+}
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$reflection = new ReflectionClass(Sidebar_JLG::class);
+$instance = $reflection->newInstanceWithoutConstructor();
+$method = $reflection->getMethod('sanitize_style_settings');
+$method->setAccessible(true);
+
+$existing_options = [
+    'style_preset'             => 'default',
+    'bg_color_type'            => 'solid',
+    'bg_color'                 => 'rgba(10,20,30,0.4)',
+    'accent_color_type'        => 'solid',
+    'accent_color'             => '#112233',
+    'font_color_type'          => 'gradient',
+    'font_color_start'         => '#000000',
+    'font_color_end'           => '#ffffff',
+    'font_hover_color_type'    => 'solid',
+    'font_hover_color'         => '#ff0000',
+    'header_logo_type'         => 'text',
+    'app_name'                 => 'Existing App',
+    'header_logo_image'        => 'http://example.com/logo.png',
+    'header_logo_size'         => 80,
+    'header_alignment_desktop' => 'left',
+    'header_alignment_mobile'  => 'center',
+    'header_padding_top'       => '10px',
+    'font_size'                => 16,
+    'mobile_bg_color'          => 'rgba(0,0,0,0.6)',
+    'mobile_bg_opacity'        => 0.6,
+    'mobile_blur'              => 4,
+];
+
+$input = [
+    'style_preset'             => 'custom',
+    'bg_color_type'            => 'solid',
+    'bg_color'                 => 'invalid-color',
+    'accent_color_type'        => 'solid',
+    'accent_color'             => '#445566',
+    'font_color_type'          => 'gradient',
+    'font_color_start'         => 'rgba(512,0,0,0.5)',
+    'font_color_end'           => 'not-a-color',
+    'font_hover_color_type'    => 'solid',
+    'font_hover_color'         => 'rgba(1,2,3,0.5)',
+    'header_logo_type'         => 'image',
+    'app_name'                 => 'New App',
+    'header_logo_image'        => 'http://example.com/new-logo.png',
+    'header_logo_size'         => 100,
+    'header_alignment_desktop' => 'right',
+    'header_alignment_mobile'  => 'right',
+    'header_padding_top'       => '20px',
+    'font_size'                => 18,
+    'mobile_bg_color'          => 'rgba(999,0,0,1)',
+    'mobile_bg_opacity'        => 0.8,
+    'mobile_blur'              => 6,
+];
+
+$result = $method->invoke($instance, $input, $existing_options);
+
+$testsPassed = true;
+
+function assertSame($expected, $actual, string $message): void {
+    global $testsPassed;
+
+    if ($expected === $actual) {
+        echo "[PASS] {$message}\n";
+        return;
+    }
+
+    $testsPassed = false;
+    echo sprintf(
+        "[FAIL] %s - expected %s got %s\n",
+        $message,
+        var_export($expected, true),
+        var_export($actual, true)
+    );
+}
+
+assertSame('rgba(10,20,30,0.4)', $result['bg_color'], 'Fallback preserves existing solid color');
+assertSame('#000000', $result['font_color_start'], 'Fallback preserves existing gradient start color');
+assertSame('#ffffff', $result['font_color_end'], 'Fallback preserves existing gradient end color');
+assertSame('#445566', $result['accent_color'], 'Valid solid color is sanitized normally');
+assertSame('rgba(0,0,0,0.6)', $result['mobile_bg_color'], 'Fallback preserves existing mobile background color');
+
+if ($testsPassed) {
+    echo "All sanitize_style_settings tests passed.\n";
+    exit(0);
+}
+
+echo "sanitize_style_settings tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- ensure style color sanitation reuses existing values when new inputs sanitize to empty, including gradient variants and mobile overlay
- add a helper to centralize RGBA sanitizing with fallbacks
- cover the fallback behavior with a dedicated sanitize_style_settings test

## Testing
- php tests/sanitize_style_settings_test.php
- php tests/sanitize_rgba_color_test.php

------
https://chatgpt.com/codex/tasks/task_e_68cb01946e50832eb1e71184cf60a008