### PR TITLE
Ensure sidebar aria-label translations are escaped

### DIFF
--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -6,7 +6,7 @@ $all_icons = \JLG\Sidebar\Sidebar_JLG::get_instance()->get_all_available_icons()
 
 ob_start();
 ?>
-<nav class="sidebar-navigation" role="navigation" aria-label="<?php _e('Navigation principale', 'sidebar-jlg'); ?>">
+<nav class="sidebar-navigation" role="navigation" aria-label="<?php esc_attr_e('Navigation principale', 'sidebar-jlg'); ?>">
     <ul class="sidebar-menu">
         <?php
         if (!empty($options['menu_items'])) {
@@ -137,7 +137,7 @@ $dynamic_styles .= "}";
 
 <div class="sidebar-overlay" id="sidebar-overlay"></div>
 
-<button class="hamburger-menu" id="hamburger-btn" aria-label="<?php _e('Ouvrir le menu', 'sidebar-jlg'); ?>" aria-controls="pro-sidebar" aria-expanded="false">
+<button class="hamburger-menu" id="hamburger-btn" aria-label="<?php esc_attr_e('Ouvrir le menu', 'sidebar-jlg'); ?>" aria-controls="pro-sidebar" aria-expanded="false">
     <div class="hamburger-icon">
         <div class="icon-1"></div>
         <div class="icon-2"></div>
@@ -154,7 +154,7 @@ $dynamic_styles .= "}";
         <?php endif; ?>
         
         <?php if ($options['show_close_button']): ?>
-            <button class="close-sidebar-btn" aria-label="<?php _e('Fermer le menu', 'sidebar-jlg'); ?>">
+            <button class="close-sidebar-btn" aria-label="<?php esc_attr_e('Fermer le menu', 'sidebar-jlg'); ?>">
                 <?php echo $all_icons['close_white']; ?>
             </button>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- replace translation helper `_e()` with `esc_attr_e()` for sidebar aria-label attributes to ensure proper escaping

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb0d683564832ea83dd785e29bcfaf