### PR TITLE
Adjust mobile sidebar background opacity handling

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -46,9 +46,10 @@ body { transition: padding-left var(--transition-speed, 0.4s) ease; }
 
 /* Logique de visibilité */
 @media (max-width: 992px) {
-    .pro-sidebar { 
-        visibility: hidden; 
+    .pro-sidebar {
+        visibility: hidden;
         background-color: var(--mobile-bg-color);
+        background-color: color-mix(in srgb, var(--mobile-bg-color) calc(var(--mobile-bg-opacity) * 100%), transparent);
         -webkit-backdrop-filter: blur(var(--mobile-blur));
         backdrop-filter: blur(var(--mobile-blur));
     }


### PR DESCRIPTION
## Summary
- use CSS color-mix to combine the mobile sidebar background color with the configured opacity value so the transparency slider has an effect on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb185e421c832ebda7c26acfc6991a