### PR TITLE
Handle inline custom SVG icons

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -137,7 +137,11 @@ body { transition: padding-left var(--transition-speed, 0.4s) ease; }
     background-image: var(--primary-accent-image);
     color: var(--sidebar-text-hover-color); 
 }
-.menu-icon.svg-icon img { width: 24px; height: 24px; }
+.menu-icon.svg-icon svg,
+.menu-icon.svg-icon img {
+    width: 24px;
+    height: 24px;
+}
 
 /* Alignement du menu */
 @media (min-width: 993px) {

--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -18,13 +18,15 @@ ob_start();
                 
                 echo '<li><a href="' . esc_url( $url ) . '">';
                 if ( ! empty( $item['icon'] ) ) {
-                    if ( ! empty( $item['icon_type'] ) && $item['icon_type'] === 'svg_url' && filter_var($item['icon'], FILTER_VALIDATE_URL)) {
-                        echo '<span class="menu-icon svg-icon"><img src="' . esc_url($item['icon']) . '" alt=""></span>';
-                    } elseif (isset($all_icons[$item['icon']])) {
-                        if (strpos($item['icon'], 'custom_') === 0) {
-                            echo '<span class="menu-icon svg-icon"><img src="' . esc_url($all_icons[$item['icon']]) . '" alt=""></span>';
+                    if ( ! empty( $item['icon_type'] ) && $item['icon_type'] === 'svg_url' && filter_var($item['icon'], FILTER_VALIDATE_URL) ) {
+                        echo '<span class="menu-icon svg-icon"><img src="' . esc_url( $item['icon'] ) . '" alt=""></span>';
+                    } elseif ( isset( $all_icons[ $item['icon'] ] ) ) {
+                        $icon_markup = $all_icons[ $item['icon'] ];
+
+                        if ( strpos( $item['icon'], 'custom_' ) === 0 ) {
+                            echo '<span class="menu-icon svg-icon">' . $icon_markup . '</span>';
                         } else {
-                            echo '<span class="menu-icon">' . $all_icons[$item['icon']] . '</span>';
+                            echo '<span class="menu-icon">' . $icon_markup . '</span>';
                         }
                     }
                 }
@@ -43,11 +45,7 @@ ob_start();
                         $icon_label = (isset($icon_parts[0]) && $icon_parts[0] !== '') ? $icon_parts[0] : 'unknown';
 
                         echo '<a href="' . esc_url($social['url']) . '" target="_blank" rel="noopener noreferrer" aria-label="' . esc_attr($icon_label) . '">';
-                        if (strpos($social['icon'], 'custom_') === 0) {
-                            echo '<img class="social-svg-icon" src="' . esc_url($all_icons[$social['icon']]) . '" alt="">';
-                        } else {
-                            echo $all_icons[$social['icon']]; 
-                        }
+                        echo $all_icons[$social['icon']];
                         echo '</a>';
                     }
                 }
@@ -70,11 +68,7 @@ if ($options['social_position'] === 'footer' && !empty($options['social_icons'])
                 $icon_label = (isset($icon_parts[0]) && $icon_parts[0] !== '') ? $icon_parts[0] : 'unknown';
 
                 echo '<a href="' . esc_url($social['url']) . '" target="_blank" rel="noopener noreferrer" aria-label="' . esc_attr($icon_label) . '">';
-                if (strpos($social['icon'], 'custom_') === 0) {
-                    echo '<img class="social-svg-icon" src="' . esc_url($all_icons[$social['icon']]) . '" alt="">';
-                } else {
-                    echo $all_icons[$social['icon']]; 
-                }
+                echo $all_icons[$social['icon']];
                 echo '</a>';
             }
         }

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -36,6 +36,7 @@ class Sidebar_JLG {
     private $options;
     private $all_icons = null;
     private $rejected_custom_icons = [];
+    private $custom_icon_sources = [];
 
     public static function get_instance() {
         if ( null === self::$instance ) self::$instance = new self();
@@ -111,6 +112,7 @@ class Sidebar_JLG {
     private function get_custom_icons() {
         $custom_icons = [];
         $this->rejected_custom_icons = [];
+        $this->custom_icon_sources = [];
         $upload_dir = wp_upload_dir();
         $icons_dir = trailingslashit($upload_dir['basedir']) . 'sidebar-jlg/icons/';
 
@@ -177,10 +179,23 @@ class Sidebar_JLG {
             }
 
             $icon_name = 'custom_' . $icon_key;
-            $custom_icons[$icon_name] = trailingslashit($upload_dir['baseurl']) . 'sidebar-jlg/icons/' . rawurlencode($file);
+            $relative_path = 'sidebar-jlg/icons/' . $file;
+            $encoded_file = rawurlencode($file);
+
+            $this->custom_icon_sources[$icon_name] = [
+                'relative_path' => $relative_path,
+                'encoded_filename' => $encoded_file,
+                'url' => trailingslashit($upload_dir['baseurl']) . 'sidebar-jlg/icons/' . $encoded_file,
+            ];
+
+            $custom_icons[$icon_name] = $sanitized_contents;
         }
 
         return $custom_icons;
+    }
+
+    public function get_custom_icon_source($icon_key) {
+        return $this->custom_icon_sources[$icon_key] ?? null;
     }
 
     public function render_custom_icon_notice() {


### PR DESCRIPTION
## Summary
- store sanitized inline SVG fragments for custom icons along with metadata about the original upload
- render custom menu and social icons inline in the sidebar template to avoid loading them as external images
- tweak sidebar icon styles to size inline SVGs consistently

## Testing
- php -l sidebar-jlg/sidebar-jlg.php
- php -l sidebar-jlg/includes/sidebar-template.php

------
https://chatgpt.com/codex/tasks/task_e_68cb27e70c04832e9f22a0d0f5ed3023