### PR TITLE
Allow calc expressions in CSS dimension sanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Après activation, un menu "Sidebar JLG" apparait dans l'administration. Vous po
 
 - Activer ou désactiver la sidebar.
 - Choisir le style : couleurs, typographie, effets d'animation, marges…
+- Renseigner les dimensions en utilisant des unités classiques (`px`, `rem`, `vh`, etc.) ou des expressions `calc()` composées d'opérateurs arithmétiques autorisés.
 - Ajouter des éléments de menu (pages, articles, catégories, liens personnalisés) et des icônes sociales.
 - Activer une recherche intégrée et personnaliser son affichage.
 - Importer vos propres icônes SVG en les plaçant dans le dossier `wp-content/uploads/sidebar-jlg/icons/`.

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -417,13 +417,27 @@ class Sidebar_JLG {
 
         $value = sanitize_text_field($value);
 
-        static $pattern = null;
-        if ($pattern === null) {
+        static $cache = null;
+        if ($cache === null) {
             $allowed_units = ['px', 'rem', 'em', '%', 'vh', 'vw', 'vmin', 'vmax', 'ch'];
-            $pattern = '/^-?(?:\d+|\d*\.\d+)(?:' . implode('|', array_map('preg_quote', $allowed_units)) . ')$/i';
+            $unit_pattern = '(?:' . implode('|', array_map(static function ($unit) {
+                return preg_quote($unit, '/');
+            }, $allowed_units)) . ')';
+
+            $cache = [
+                'numeric_pattern'   => '/^-?(?:\d+|\d*\.\d+)(?:' . $unit_pattern . ')$/i',
+                'dimension_pattern' => '/^[-+]?(?:\d+|\d*\.\d+)(?:' . $unit_pattern . ')?$/i',
+            ];
         }
 
-        if (preg_match($pattern, $value)) {
+        $numeric_pattern = $cache['numeric_pattern'];
+        $dimension_pattern = $cache['dimension_pattern'];
+
+        if (preg_match($numeric_pattern, $value)) {
+            return $value;
+        }
+
+        if ($this->is_valid_calc_expression($value, $dimension_pattern)) {
             return $value;
         }
 
@@ -432,6 +446,107 @@ class Sidebar_JLG {
         }
 
         return $sanitized_fallback;
+    }
+
+    private function is_valid_calc_expression($value, $dimension_pattern) {
+        if (!preg_match('/^calc\((.*)\)$/i', $value, $matches)) {
+            return false;
+        }
+
+        $expression = trim($matches[1]);
+
+        if ($expression === '') {
+            return false;
+        }
+
+        if (!preg_match('/^[0-9+\-*\/().%a-z\s]+$/i', $expression)) {
+            return false;
+        }
+
+        $expression = preg_replace('/\s+/', '', $expression);
+
+        if ($expression === '') {
+            return false;
+        }
+
+        $length = strlen($expression);
+        $tokens = [];
+        $current = '';
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $expression[$i];
+
+            if ($char === '+' || $char === '-') {
+                $previous_char = $i > 0 ? $expression[$i - 1] : null;
+
+                if ($current === '' && ($i === 0 || in_array($previous_char, ['+', '-', '*', '/', '('], true))) {
+                    $current = $char;
+                    continue;
+                }
+            }
+
+            if ($char === '+' || $char === '-' || $char === '*' || $char === '/' || $char === '(' || $char === ')') {
+                if ($current !== '') {
+                    $tokens[] = $current;
+                    $current = '';
+                }
+
+                $tokens[] = $char;
+                continue;
+            }
+
+            $current .= $char;
+        }
+
+        if ($current !== '') {
+            $tokens[] = $current;
+        }
+
+        $expect_operand = true;
+        $parentheses = 0;
+
+        foreach ($tokens as $token) {
+            if ($token === '(') {
+                if (! $expect_operand) {
+                    return false;
+                }
+
+                $parentheses++;
+                continue;
+            }
+
+            if ($token === ')') {
+                if ($expect_operand) {
+                    return false;
+                }
+
+                $parentheses--;
+
+                if ($parentheses < 0) {
+                    return false;
+                }
+
+                $expect_operand = false;
+                continue;
+            }
+
+            if ($token === '+' || $token === '-' || $token === '*' || $token === '/') {
+                if ($expect_operand) {
+                    return false;
+                }
+
+                $expect_operand = true;
+                continue;
+            }
+
+            if (!preg_match($dimension_pattern, $token)) {
+                return false;
+            }
+
+            $expect_operand = false;
+        }
+
+        return $parentheses === 0 && ! $expect_operand;
     }
 
     private function sanitize_general_settings($input, $existing_options) {

--- a/tests/sanitize_css_dimension_test.php
+++ b/tests/sanitize_css_dimension_test.php
@@ -64,6 +64,16 @@ $tests = [
         'fallback' => '2.5rem',
         'expected' => '0',
     ],
+    'valid_calc_expression' => [
+        'input'    => 'calc(100% - 20px)',
+        'fallback' => '2.5rem',
+        'expected' => 'calc(100% - 20px)',
+    ],
+    'invalid_calc_disallowed_unit' => [
+        'input'    => 'calc(100% - 20pt)',
+        'fallback' => '2.5rem',
+        'expected' => '2.5rem',
+    ],
     'empty_input_uses_fallback' => [
         'input'    => '',
         'fallback' => '2.5rem',


### PR DESCRIPTION
## Summary
- allow the CSS dimension sanitizer to accept calc() expressions with strict token validation
- add dedicated tests that cover valid and invalid calc() cases
- document the new calc() support in the configuration section of the README

## Testing
- php tests/sanitize_css_dimension_test.php

------
https://chatgpt.com/codex/tasks/task_e_68cb27437590832e82791e8e5730d6ed