### PR TITLE
Fix menu item sanitization for SVG icons

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -725,9 +725,11 @@ class Sidebar_JLG {
                     $sanitized_item['icon'] = sanitize_key($item['icon'] ?? '');
                 }
 
-                $sanitized_item['value'] = ($item_type === 'custom' || $icon_type === 'svg_url')
-                    ? esc_url_raw($item['value'] ?? '')
-                    : absint($item['value'] ?? 0);
+                if ($item_type === 'custom') {
+                    $sanitized_item['value'] = esc_url_raw($item['value'] ?? '');
+                } else {
+                    $sanitized_item['value'] = absint($item['value'] ?? 0);
+                }
 
                 $sanitized_menu_items[] = $sanitized_item;
             }


### PR DESCRIPTION
## Summary
- ensure menu item values are sanitized based on item type so post and category IDs stay numeric even with SVG icons
- extend the locale cache test to cover SVG icon menu items and verify generated menu links target the expected resources

## Testing
- php tests/sanitize_css_dimension_test.php
- php tests/sanitize_rgba_color_test.php
- php tests/sanitize_style_settings_test.php
- php tests/sidebar_locale_cache_test.php

------
https://chatgpt.com/codex/tasks/task_e_68cc4950b0b4832e93fae0322b56ac8f