### PR TITLE
Use localized icons for admin selection

### DIFF
--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -1,5 +1,6 @@
 jQuery(document).ready(function($) {
     const options = sidebarJLG.options;
+    const availableIcons = sidebarJLG.all_icons || {};
     const debugMode = options.debug_mode == '1';
     const ajaxCache = { posts: {}, categories: {} };
 
@@ -172,18 +173,23 @@ jQuery(document).ready(function($) {
         const grid = $('#icon-grid');
         grid.empty();
         
-        if (typeof lucide !== 'undefined' && lucide.icons) {
-            Object.keys(lucide.icons).forEach(iconName => {
-                const iconNode = lucide.icons[iconName];
-                const svgElement = createLucideSvg(iconNode);
-                const btn = $(`<button type="button" data-icon-name="${iconName}" title="${iconName}">${svgElement} <span>${iconName}</span></button>`);
-                grid.append(btn);
-            });
-        }
-    }
+        Object.keys(availableIcons).forEach(iconName => {
+            const svgMarkup = availableIcons[iconName];
 
-    function createLucideSvg(iconNode) {
-        return lucide.createElement(iconNode);
+            if (typeof svgMarkup !== 'string' || svgMarkup.trim() === '') {
+                return;
+            }
+
+            const $button = $('<button>', {
+                type: 'button',
+                'data-icon-name': iconName,
+                title: iconName
+            });
+
+            $button.append(svgMarkup);
+            $button.append($('<span></span>').text(iconName));
+            grid.append($button);
+        });
     }
 
     function updateIconPreview(input, $preview) {
@@ -196,9 +202,8 @@ jQuery(document).ready(function($) {
         const iconType = $(input).closest('.menu-item-box').find('.menu-item-icon-type').val();
         if (iconType === 'svg_url') {
             $preview.html(iconValue.startsWith('http') ? `<img src="${iconValue}" alt="preview">` : '');
-        } else if (typeof lucide !== 'undefined' && lucide.icons && lucide.icons[iconValue]) {
-            const iconNode = lucide.icons[iconValue];
-            $preview.html(createLucideSvg(iconNode));
+        } else if (availableIcons[iconValue]) {
+            $preview.html(availableIcons[iconValue]);
         } else {
             $preview.empty();
         }
@@ -592,7 +597,7 @@ jQuery(document).ready(function($) {
     });
 
     // --- Builder pour les icônes sociales ---
-    const standardIcons = sidebarJLG.all_icons || {};
+    const standardIcons = availableIcons;
     
     function populateStandardIconsDropdown($select, selectedValue) {
         $select.empty();

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -777,10 +777,7 @@ class Sidebar_JLG {
         wp_enqueue_media();
         wp_enqueue_style( 'sidebar-jlg-admin-css', plugin_dir_url( __FILE__ ) . 'assets/css/admin-style.css', [], SIDEBAR_JLG_VERSION );
 
-        wp_register_script( 'sidebar-jlg-lucide', plugin_dir_url( __FILE__ ) . 'assets/js/lucide.min.js', [], SIDEBAR_JLG_VERSION, true );
-        wp_enqueue_script( 'sidebar-jlg-lucide' );
-
-        wp_enqueue_script( 'sidebar-jlg-admin-js', plugin_dir_url( __FILE__ ) . 'assets/js/admin-script.js', [ 'jquery', 'wp-color-picker', 'jquery-ui-sortable', 'wp-util', 'sidebar-jlg-lucide' ], SIDEBAR_JLG_VERSION, true );
+        wp_enqueue_script( 'sidebar-jlg-admin-js', plugin_dir_url( __FILE__ ) . 'assets/js/admin-script.js', [ 'jquery', 'wp-color-picker', 'jquery-ui-sortable', 'wp-util' ], SIDEBAR_JLG_VERSION, true );
 
         wp_localize_script('sidebar-jlg-admin-js', 'sidebarJLG', [
             'ajax_url' => admin_url('admin-ajax.php'),


### PR DESCRIPTION
## Summary
- build the admin icon library grid from the localized `sidebarJLG.all_icons` list so it matches front-end availability
- render icon previews directly from the localized SVG markup instead of Lucide helpers
- drop the unused Lucide script dependency from admin asset loading

## Testing
- php -l sidebar-jlg/sidebar-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68cc495103b8832e8dfdad9d1a5ac6b9