### PR TITLE
Add support for linking pages in sidebar menu

### DIFF
--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -398,6 +398,7 @@
                 <select class="widefat menu-item-type" name="sidebar_jlg_settings[menu_items][{{ data.index }}][type]">
                     <option value="custom" <# if (data.type === 'custom') { #>selected<# } #>>Lien personnalisé</option>
                     <option value="post" <# if (data.type === 'post') { #>selected<# } #>>Article</option>
+                    <option value="page" <# if (data.type === 'page') { #>selected<# } #>>Page</option>
                     <option value="category" <# if (data.type === 'category') { #>selected<# } #>>Catégorie</option>
                 </select>
             </p>

--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -18,6 +18,8 @@ ob_start();
                     $raw_url = $item['value'] ?? '';
                 } elseif ($item['type'] === 'post') {
                     $raw_url = get_permalink(absint($item['value']));
+                } elseif ($item['type'] === 'page') {
+                    $raw_url = get_permalink(absint($item['value']));
                 } elseif ($item['type'] === 'category') {
                     $raw_url = get_category_link(absint($item['value']));
                 }

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -1028,6 +1028,19 @@ class Sidebar_JLG {
         }
 
         $per_page = min( max(1, $requested_per_page), $max_per_page );
+
+        $allowed_post_types = [ 'post', 'page' ];
+        $post_type = 'post';
+
+        if ( isset( $_POST['post_type'] ) ) {
+            $requested_type = sanitize_key( wp_unslash( $_POST['post_type'] ) );
+            if ( in_array( $requested_type, $allowed_post_types, true ) ) {
+                $post_type = $requested_type;
+            } else {
+                wp_send_json_error( 'Type de contenu non pris en charge.' );
+            }
+        }
+
         $include_ids = [];
         if ( isset( $_POST['include'] ) ) {
             $raw_include = wp_unslash( $_POST['include'] );
@@ -1038,6 +1051,7 @@ class Sidebar_JLG {
         $posts = get_posts([
             'posts_per_page' => $per_page,
             'paged' => $page,
+            'post_type' => $post_type,
         ]);
 
         $options_by_id = [];
@@ -1054,6 +1068,7 @@ class Sidebar_JLG {
                     'posts_per_page' => count($missing_ids),
                     'post__in'       => $missing_ids,
                     'orderby'        => 'post__in',
+                    'post_type'      => $post_type,
                 ]);
 
                 foreach ($additional_posts as $post) {


### PR DESCRIPTION
## Summary
- allow selecting WordPress pages from the admin menu item template
- fetch pages through the existing AJAX endpoint with a configurable post type
- resolve page permalinks on the frontend when rendering menu items

## Testing
- php -l sidebar-jlg/sidebar-jlg.php
- php -l sidebar-jlg/includes/sidebar-template.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6d9f54c0832e8fb83d4e2311b3b2