### PR TITLE
Clamp mobile background opacity values

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -678,7 +678,9 @@ class Sidebar_JLG {
             $input['mobile_bg_color'] ?? null,
             $existing_options['mobile_bg_color'] ?? ''
         );
-        $sanitized['mobile_bg_opacity'] = floatval($input['mobile_bg_opacity'] ?? $existing_options['mobile_bg_opacity']);
+        $opacity_value = $input['mobile_bg_opacity'] ?? $existing_options['mobile_bg_opacity'];
+        $opacity_value = floatval($opacity_value);
+        $sanitized['mobile_bg_opacity'] = max(0.0, min(1.0, $opacity_value));
         $sanitized['mobile_blur'] = absint($input['mobile_blur'] ?? $existing_options['mobile_blur']);
 
         return $sanitized;

--- a/tests/sanitize_style_settings_test.php
+++ b/tests/sanitize_style_settings_test.php
@@ -133,6 +133,24 @@ assertSame('#000000', $result['font_color_start'], 'Fallback preserves existing 
 assertSame('#ffffff', $result['font_color_end'], 'Fallback preserves existing gradient end color');
 assertSame('#445566', $result['accent_color'], 'Valid solid color is sanitized normally');
 assertSame('rgba(0,0,0,0.6)', $result['mobile_bg_color'], 'Fallback preserves existing mobile background color');
+assertSame(0.8, $result['mobile_bg_opacity'], 'Valid opacity within range is preserved');
+
+$inputBelowMin = $input;
+$inputBelowMin['mobile_bg_opacity'] = -0.5;
+$resultBelowMin = $method->invoke($instance, $inputBelowMin, $existing_options);
+assertSame(0.0, $resultBelowMin['mobile_bg_opacity'], 'Opacity below 0 clamps to 0.0');
+
+$inputAboveMax = $input;
+$inputAboveMax['mobile_bg_opacity'] = 3.14;
+$resultAboveMax = $method->invoke($instance, $inputAboveMax, $existing_options);
+assertSame(1.0, $resultAboveMax['mobile_bg_opacity'], 'Opacity above 1 clamps to 1.0');
+
+$existingOpacityOutOfRange = $existing_options;
+$existingOpacityOutOfRange['mobile_bg_opacity'] = 2.5;
+$inputWithoutOpacity = $input;
+unset($inputWithoutOpacity['mobile_bg_opacity']);
+$resultExistingClamp = $method->invoke($instance, $inputWithoutOpacity, $existingOpacityOutOfRange);
+assertSame(1.0, $resultExistingClamp['mobile_bg_opacity'], 'Fallback opacity clamps existing value to 1.0');
 
 if ($testsPassed) {
     echo "All sanitize_style_settings tests passed.\n";


### PR DESCRIPTION
## Summary
- clamp the sanitized mobile background opacity between 0 and 1 before saving style settings
- extend sanitize style settings tests to cover opacity preservation and clamping cases

## Testing
- php tests/render_sidebar_html_error_handling_test.php
- php tests/sanitize_rgba_color_test.php
- php tests/sidebar_locale_cache_test.php
- php tests/sanitize_css_dimension_test.php
- php tests/sanitize_style_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68cd75ca1db0832ea7c7675872bb242d