### PR TITLE
Ensure sidebar options include defaults

### DIFF
--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -1,8 +1,9 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-$options = get_option('sidebar_jlg_settings', \JLG\Sidebar\Sidebar_JLG::get_instance()->get_default_settings());
-$all_icons = \JLG\Sidebar\Sidebar_JLG::get_instance()->get_all_available_icons();
+$plugin = \JLG\Sidebar\Sidebar_JLG::get_instance();
+$options = wp_parse_args( get_option( 'sidebar_jlg_settings', [] ), $plugin->get_default_settings() );
+$all_icons = $plugin->get_all_available_icons();
 
 ob_start();
 ?>


### PR DESCRIPTION
## Summary
- reuse the Sidebar_JLG instance for option and icon retrieval
- merge saved settings with plugin defaults so all expected keys exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cda8df12f4832ea8a3eee07e4c69bf