### PR TITLE
Add close-on-link-click option and frontend behavior

### DIFF
--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -68,6 +68,23 @@ document.addEventListener('DOMContentLoaded', function() {
     hamburgerBtn.addEventListener('click', toggleSidebar);
     if (closeBtn) closeBtn.addEventListener('click', closeSidebar);
     if (overlay) overlay.addEventListener('click', closeSidebar);
+
+    const shouldCloseOnLinkClick = typeof sidebarSettings !== 'undefined'
+        && (sidebarSettings.close_on_link_click === true
+            || sidebarSettings.close_on_link_click === 1
+            || sidebarSettings.close_on_link_click === '1');
+
+    if (shouldCloseOnLinkClick) {
+        const selectors = ['.sidebar-menu a', '.social-icons a'];
+        selectors.forEach((selector) => {
+            sidebar.querySelectorAll(selector).forEach((element) => {
+                element.addEventListener('click', () => {
+                    setTimeout(closeSidebar, 50);
+                });
+            });
+        });
+    }
+
     document.addEventListener('keydown', function(e) {
         if (e.key === 'Escape') {
             closeSidebar();

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -99,6 +99,13 @@
                     </td>
                 </tr>
                 <tr>
+                    <th scope="row"><?php esc_html_e( 'Fermeture automatique', 'sidebar-jlg' ); ?></th>
+                    <td>
+                        <label><input type="checkbox" name="sidebar_jlg_settings[close_on_link_click]" value="1" <?php checked( $options['close_on_link_click'], 1 ); ?> /> <?php esc_html_e( 'Fermer la sidebar après un clic sur un lien ou une icône sociale.', 'sidebar-jlg' ); ?></label>
+                        <p class="description"><?php esc_html_e( 'Recommandé sur mobile pour éviter qu\'elle reste ouverte après navigation.', 'sidebar-jlg' ); ?></p>
+                    </td>
+                </tr>
+                <tr>
                     <th scope="row"><?php esc_html_e( 'Barre de recherche', 'sidebar-jlg' ); ?></th>
                     <td>
                         <label><input type="checkbox" name="sidebar_jlg_settings[enable_search]" value="1" <?php checked( $options['enable_search'], 1 ); ?> /> <?php esc_html_e( 'Activer la barre de recherche.', 'sidebar-jlg' ); ?></label>

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -72,6 +72,7 @@ class SettingsSanitizer
         $sanitized['search_alignment'] = sanitize_key($input['search_alignment'] ?? $existingOptions['search_alignment']);
         $sanitized['debug_mode'] = !empty($input['debug_mode']);
         $sanitized['show_close_button'] = !empty($input['show_close_button']);
+        $sanitized['close_on_link_click'] = !empty($input['close_on_link_click']);
         $sanitized['hamburger_top_position'] = $this->sanitize_css_dimension(
             $input['hamburger_top_position'] ?? $existingOptions['hamburger_top_position'],
             $existingOptions['hamburger_top_position']

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -29,6 +29,7 @@ class DefaultSettings
             'search_alignment'  => 'flex-start',
             'debug_mode'        => false,
             'show_close_button' => true,
+            'close_on_link_click' => false,
             'hamburger_top_position' => '4rem',
             'header_logo_type'  => 'text',
             'header_logo_image' => '',

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -143,6 +143,20 @@ $result_valid = $method->invoke($sanitizer, $input_valid, $existing_options);
 assertSame('#abcdef', $result_valid['overlay_color'] ?? '', 'Overlay color accepts valid hex values');
 assertSame(0.4, $result_valid['overlay_opacity'] ?? null, 'Overlay opacity falls back to existing value when missing');
 
+$input_close_on_click = [
+    'close_on_link_click' => '1',
+];
+
+$result_close_on = $method->invoke($sanitizer, $input_close_on_click, $existing_options);
+
+assertSame(true, $result_close_on['close_on_link_click'] ?? null, 'Close-on-click option is enabled when checkbox is set');
+
+$input_close_on_click_disabled = [];
+
+$result_close_off = $method->invoke($sanitizer, $input_close_on_click_disabled, $existing_options);
+
+assertSame(false, $result_close_off['close_on_link_click'] ?? null, 'Close-on-click option defaults to disabled when missing');
+
 $input_min = [
     'overlay_opacity' => -0.3,
 ];


### PR DESCRIPTION
## Summary
- add a default setting and admin UI checkbox for closing the sidebar after link clicks
- sanitize and persist the new option in the general settings sanitizer
- close the sidebar on menu or social link clicks when the option is enabled and cover the sanitizer with a unit test

## Testing
- php tests/sanitize_general_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68ce62817044832e96c4079ae1f1e02b