### PR TITLE
Add shared bootstrap for PHP tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,750 @@
+<?php
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', true);
+}
+
+if (!defined('SIDEBAR_JLG_SKIP_BOOTSTRAP')) {
+    define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
+}
+
+$GLOBALS['wp_test_options'] = $GLOBALS['wp_test_options'] ?? [];
+$GLOBALS['wp_test_transients'] = $GLOBALS['wp_test_transients'] ?? [];
+$GLOBALS['wp_test_current_locale'] = $GLOBALS['wp_test_current_locale'] ?? 'fr_FR';
+$GLOBALS['wp_test_translations'] = $GLOBALS['wp_test_translations'] ?? [
+    'fr_FR' => [
+        'Navigation principale' => 'Navigation principale',
+        'Ouvrir le menu'        => 'Ouvrir le menu',
+        'Fermer le menu'        => 'Fermer le menu',
+    ],
+];
+$GLOBALS['wp_test_function_overrides'] = $GLOBALS['wp_test_function_overrides'] ?? [];
+
+if (!function_exists('wp_test_call_override')) {
+    function wp_test_call_override(string $function, array $args, ?bool &$handled = null)
+    {
+        $handled = false;
+        if (!isset($GLOBALS['wp_test_function_overrides'][$function])) {
+            return null;
+        }
+
+        $override = $GLOBALS['wp_test_function_overrides'][$function];
+        if (!is_callable($override)) {
+            return null;
+        }
+
+        $handled = true;
+
+        return $override(...$args);
+    }
+}
+
+if (!class_exists('WP_Error')) {
+    class WP_Error
+    {
+        private $code;
+        private $message;
+
+        public function __construct($code = '', $message = '')
+        {
+            $this->code = $code;
+            $this->message = $message;
+        }
+
+        public function get_error_code()
+        {
+            return $this->code;
+        }
+
+        public function get_error_message()
+        {
+            return $this->message;
+        }
+    }
+}
+
+if (!function_exists('is_wp_error')) {
+    function is_wp_error($thing): bool
+    {
+        return $thing instanceof WP_Error;
+    }
+}
+
+if (!function_exists('register_activation_hook')) {
+    function register_activation_hook($file, $callback): void
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return;
+        }
+    }
+}
+
+if (!function_exists('wp_upload_dir')) {
+    function wp_upload_dir(): array
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return [
+            'basedir' => rtrim(sys_get_temp_dir(), '/\\') . '/sidebar-jlg-test',
+            'baseurl' => 'http://example.com/uploads',
+        ];
+    }
+}
+
+if (!function_exists('wp_mkdir_p')) {
+    function wp_mkdir_p(string $dir): bool
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (bool) $result;
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1): void
+    {
+        $handled = false;
+        wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return;
+        }
+    }
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $callback, $priority = 10, $accepted_args = 1): void
+    {
+        $handled = false;
+        wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return;
+        }
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value, ...$args)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return $value;
+    }
+}
+
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = [])
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        if (is_object($args)) {
+            $args = get_object_vars($args);
+        } elseif (!is_array($args)) {
+            $args = [];
+        }
+
+        if (!is_array($defaults)) {
+            $defaults = [];
+        }
+
+        return array_merge($defaults, $args);
+    }
+}
+
+if (!function_exists('trailingslashit')) {
+    function trailingslashit($value): string
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        return rtrim((string) $value, "/\\") . '/';
+    }
+}
+
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path($file): string
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        return trailingslashit(dirname((string) $file));
+    }
+}
+
+if (!function_exists('plugin_dir_url')) {
+    function plugin_dir_url($file): string
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        return 'http://example.com/plugin/';
+    }
+}
+
+if (!function_exists('wp_enqueue_style')) {
+    function wp_enqueue_style(...$args): void
+    {
+        $handled = false;
+        wp_test_call_override(__FUNCTION__, $args, $handled);
+        if ($handled) {
+            return;
+        }
+    }
+}
+
+if (!function_exists('wp_enqueue_script')) {
+    function wp_enqueue_script(...$args): void
+    {
+        $handled = false;
+        wp_test_call_override(__FUNCTION__, $args, $handled);
+        if ($handled) {
+            return;
+        }
+    }
+}
+
+if (!function_exists('wp_register_script')) {
+    function wp_register_script(...$args): void
+    {
+        $handled = false;
+        wp_test_call_override(__FUNCTION__, $args, $handled);
+        if ($handled) {
+            return;
+        }
+    }
+}
+
+if (!function_exists('wp_enqueue_media')) {
+    function wp_enqueue_media(): void
+    {
+        $handled = false;
+        wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return;
+        }
+    }
+}
+
+if (!function_exists('wp_localize_script')) {
+    function wp_localize_script(...$args): void
+    {
+        $handled = false;
+        wp_test_call_override(__FUNCTION__, $args, $handled);
+        if ($handled) {
+            return;
+        }
+    }
+}
+
+if (!function_exists('wp_create_nonce')) {
+    function wp_create_nonce($action): string
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        return 'nonce-' . $action;
+    }
+}
+
+if (!function_exists('admin_url')) {
+    function admin_url($path = ''): string
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        return 'http://example.com/wp-admin/' . ltrim((string) $path, '/');
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($name, $default = false)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        if (array_key_exists($name, $GLOBALS['wp_test_options'])) {
+            return $GLOBALS['wp_test_options'][$name];
+        }
+
+        return $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($name, $value, $autoload = null): bool
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (bool) $result;
+        }
+
+        $GLOBALS['wp_test_options'][$name] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('add_option')) {
+    function add_option($name, $value, $deprecated = '', $autoload = 'yes'): bool
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (bool) $result;
+        }
+
+        if (array_key_exists($name, $GLOBALS['wp_test_options'])) {
+            return false;
+        }
+
+        $GLOBALS['wp_test_options'][$name] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_option')) {
+    function delete_option($name): bool
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (bool) $result;
+        }
+
+        if (array_key_exists($name, $GLOBALS['wp_test_options'])) {
+            unset($GLOBALS['wp_test_options'][$name]);
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('get_transient')) {
+    function get_transient($key)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return $GLOBALS['wp_test_transients'][$key] ?? false;
+    }
+}
+
+if (!function_exists('set_transient')) {
+    function set_transient($key, $value, $expiration = 0): bool
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (bool) $result;
+        }
+
+        $GLOBALS['wp_test_transients'][$key] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_transient')) {
+    function delete_transient($key): bool
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (bool) $result;
+        }
+
+        if (array_key_exists($key, $GLOBALS['wp_test_transients'])) {
+            unset($GLOBALS['wp_test_transients'][$key]);
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('determine_locale')) {
+    function determine_locale(): string
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        return $GLOBALS['wp_test_current_locale'];
+    }
+}
+
+if (!function_exists('get_locale')) {
+    function get_locale(): string
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        return determine_locale();
+    }
+}
+
+if (!function_exists('switch_to_locale')) {
+    function switch_to_locale(string $locale): bool
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (bool) $result;
+        }
+
+        $GLOBALS['wp_test_current_locale'] = $locale;
+
+        return true;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr($value)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return $value;
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($value)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return $value;
+    }
+}
+
+if (!function_exists('esc_url')) {
+    function esc_url($value)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return $value;
+    }
+}
+
+if (!function_exists('esc_attr_e')) {
+    function esc_attr_e($text, $domain = 'default'): void
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return;
+        }
+
+        echo esc_attr(__($text, $domain));
+    }
+}
+
+if (!function_exists('esc_url_raw')) {
+    function esc_url_raw($value)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return (string) $value;
+    }
+}
+
+if (!function_exists('absint')) {
+    function absint($value): int
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (int) $result;
+        }
+
+        return abs((int) $value);
+    }
+}
+
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return $value;
+    }
+}
+
+if (!function_exists('wp_check_filetype')) {
+    function wp_check_filetype($file, $allowed = [])
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        $extension = pathinfo((string) $file, PATHINFO_EXTENSION);
+
+        if ($extension === '') {
+            return ['ext' => '', 'type' => ''];
+        }
+
+        return [
+            'ext'  => $extension,
+            'type' => $allowed[$extension] ?? 'image/' . $extension,
+        ];
+    }
+}
+
+if (!function_exists('wp_kses')) {
+    function wp_kses($string, $allowed_html = [])
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return $string;
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        if (is_array($value) || is_object($value)) {
+            return '';
+        }
+
+        $value = (string) $value;
+        $value = strip_tags($value);
+        $value = preg_replace('/[\r\n\t\0\x0B]+/', '', $value);
+
+        return trim($value);
+    }
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        $key = strtolower((string) $key);
+
+        return preg_replace('/[^a-z0-9_\-]/', '', $key);
+    }
+}
+
+if (!function_exists('sanitize_hex_color')) {
+    function sanitize_hex_color($color)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        $color = trim((string) $color);
+        if (preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $color)) {
+            return strtolower($color);
+        }
+
+        return '';
+    }
+}
+
+if (!function_exists('get_permalink')) {
+    function get_permalink($post_id)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return 'http://example.com/post/' . $post_id;
+    }
+}
+
+if (!function_exists('get_category_link')) {
+    function get_category_link($cat_id)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        if (isset($GLOBALS['test_category_link_return']) && $GLOBALS['test_category_link_return'] !== '') {
+            return $GLOBALS['test_category_link_return'];
+        }
+
+        return 'http://example.com/category/' . $cat_id;
+    }
+}
+
+if (!function_exists('get_bloginfo')) {
+    function get_bloginfo($show = '', $filter = 'raw')
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return 'Test Blog';
+    }
+}
+
+if (!function_exists('do_shortcode')) {
+    function do_shortcode($content)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return $content;
+    }
+}
+
+if (!function_exists('do_action')) {
+    function do_action($hook, ...$args): void
+    {
+        $handled = false;
+        wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return;
+        }
+    }
+}
+
+if (!function_exists('get_search_form')) {
+    function get_search_form(): string
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        return 'SEARCH_FORM';
+    }
+}
+
+if (!function_exists('wp_kses_post')) {
+    function wp_kses_post($string)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return $string;
+    }
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = 'default')
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        $locale = determine_locale();
+        $translations = $GLOBALS['wp_test_translations'];
+
+        if (isset($translations[$locale][$text])) {
+            return $translations[$locale][$text];
+        }
+
+        return $text;
+    }
+}
+
+if (!function_exists('_e')) {
+    function _e($text, $domain = 'default'): void
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return;
+        }
+
+        echo __($text, $domain);
+    }
+}

--- a/tests/render_sidebar_html_error_handling_test.php
+++ b/tests/render_sidebar_html_error_handling_test.php
@@ -3,17 +3,8 @@ declare(strict_types=1);
 
 use function JLG\Sidebar\plugin;
 
-if (!defined('ABSPATH')) {
-    define('ABSPATH', true);
-}
+require __DIR__ . '/bootstrap.php';
 
-if (!defined('SIDEBAR_JLG_SKIP_BOOTSTRAP')) {
-    define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
-}
-
-$GLOBALS['wp_test_options'] = [];
-$GLOBALS['wp_test_transients'] = [];
-$GLOBALS['wp_test_current_locale'] = 'fr_FR';
 $GLOBALS['wp_test_translations'] = [
     'fr_FR' => [
         'Navigation principale' => 'Navigation principale',
@@ -21,220 +12,6 @@ $GLOBALS['wp_test_translations'] = [
         'Fermer le menu'        => 'Fermer le menu',
     ],
 ];
-
-class WP_Error {
-    private $code;
-    private $message;
-
-    public function __construct($code = '', $message = '') {
-        $this->code = $code;
-        $this->message = $message;
-    }
-
-    public function get_error_code() {
-        return $this->code;
-    }
-
-    public function get_error_message() {
-        return $this->message;
-    }
-}
-
-function is_wp_error($thing): bool {
-    return $thing instanceof WP_Error;
-}
-
-function register_activation_hook($file, $callback): void {}
-function wp_upload_dir(): array {
-    return [
-        'basedir' => sys_get_temp_dir() . '/sidebar-jlg-test',
-        'baseurl' => 'http://example.com/uploads',
-    ];
-}
-function wp_mkdir_p(string $dir): bool { return true; }
-function add_action($hook, $callback, $priority = 10, $accepted_args = 1): void {}
-function add_filter($hook, $callback, $priority = 10, $accepted_args = 1): void {}
-function apply_filters($hook, $value, ...$args) {
-    return $value;
-}
-function wp_parse_args($args, $defaults = []) {
-    if (is_object($args)) {
-        $args = get_object_vars($args);
-    } elseif (!is_array($args)) {
-        $args = [];
-    }
-
-    if (!is_array($defaults)) {
-        $defaults = [];
-    }
-
-    return array_merge($defaults, $args);
-}
-function trailingslashit($value): string {
-    return rtrim($value, "/\\") . '/';
-}
-function plugin_dir_path($file): string {
-    return trailingslashit(dirname($file));
-}
-function plugin_dir_url($file): string {
-    return 'http://example.com/plugin/';
-}
-function wp_enqueue_style(...$args): void {}
-function wp_enqueue_script(...$args): void {}
-function wp_register_script(...$args): void {}
-function wp_enqueue_media(): void {}
-function wp_localize_script(...$args): void {}
-function wp_create_nonce($action): string {
-    return 'nonce-' . $action;
-}
-function admin_url($path = ''): string {
-    return 'http://example.com/wp-admin/' . ltrim($path, '/');
-}
-function get_option($name, $default = false) {
-    global $wp_test_options;
-    if (array_key_exists($name, $wp_test_options)) {
-        return $wp_test_options[$name];
-    }
-
-    return $default;
-}
-function update_option($name, $value, $autoload = null): bool {
-    global $wp_test_options;
-    $wp_test_options[$name] = $value;
-
-    return true;
-}
-function add_option($name, $value, $deprecated = '', $autoload = 'yes'): bool {
-    global $wp_test_options;
-    if (array_key_exists($name, $wp_test_options)) {
-        return false;
-    }
-
-    $wp_test_options[$name] = $value;
-
-    return true;
-}
-function delete_option($name): bool {
-    global $wp_test_options;
-    if (array_key_exists($name, $wp_test_options)) {
-        unset($wp_test_options[$name]);
-    }
-
-    return true;
-}
-function get_transient($key) {
-    global $wp_test_transients;
-    return $wp_test_transients[$key] ?? false;
-}
-function set_transient($key, $value, $expiration = 0): bool {
-    global $wp_test_transients;
-    $wp_test_transients[$key] = $value;
-
-    return true;
-}
-function delete_transient($key): bool {
-    global $wp_test_transients;
-    if (array_key_exists($key, $wp_test_transients)) {
-        unset($wp_test_transients[$key]);
-    }
-
-    return true;
-}
-function determine_locale(): string {
-    return $GLOBALS['wp_test_current_locale'];
-}
-function get_locale(): string {
-    return determine_locale();
-}
-function switch_to_locale(string $locale): bool {
-    $GLOBALS['wp_test_current_locale'] = $locale;
-
-    return true;
-}
-function esc_attr($value) {
-    return $value;
-}
-function esc_html($value) {
-    return $value;
-}
-function esc_url($value) {
-    return $value;
-}
-function esc_attr_e($text, $domain = 'default'): void {
-    echo esc_attr(__($text, $domain));
-}
-function esc_url_raw($value) {
-    return $value;
-}
-function absint($value): int {
-    return abs((int) $value);
-}
-function wp_unslash($value) {
-    return $value;
-}
-function wp_check_filetype($file, $allowed = []) {
-    $extension = pathinfo($file, PATHINFO_EXTENSION);
-
-    if ($extension === '') {
-        return ['ext' => '', 'type' => ''];
-    }
-
-    return [
-        'ext'  => $extension,
-        'type' => $allowed[$extension] ?? 'image/' . $extension,
-    ];
-}
-function wp_kses($string, $allowed_html = []) {
-    return $string;
-}
-function sanitize_text_field($value) {
-    if (is_array($value) || is_object($value)) {
-        return '';
-    }
-
-    $value = (string) $value;
-    $value = strip_tags($value);
-    $value = preg_replace('/[\r\n\t ]+/', ' ', $value);
-
-    return trim($value);
-}
-function sanitize_key($key) {
-    $key = strtolower((string) $key);
-    return preg_replace('/[^a-z0-9_\-]/', '', $key);
-}
-function get_permalink($post_id) {
-    return 'http://example.com/post/' . $post_id;
-}
-$GLOBALS['test_category_link_return'] = '';
-function get_category_link($cat_id) {
-    return $GLOBALS['test_category_link_return'];
-}
-function get_bloginfo($show = '', $filter = 'raw') {
-    return 'Test Blog';
-}
-function do_shortcode($content) {
-    return $content;
-}
-function do_action($hook, ...$args): void {}
-function get_search_form(): string {
-    return 'SEARCH_FORM';
-}
-function wp_kses_post($string) {
-    return $string;
-}
-function __($text, $domain = 'default') {
-    $locale = determine_locale();
-    $translations = $GLOBALS['wp_test_translations'];
-
-    if (isset($translations[$locale][$text])) {
-        return $translations[$locale][$text];
-    }
-
-    return $text;
-}
-function _e($text, $domain = 'default'): void {
-    echo __($text, $domain);
-}
 
 require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
@@ -246,11 +23,11 @@ $menuCache = $plugin->getMenuCache();
 $default_settings = $settingsRepository->getDefaultSettings();
 $default_settings['menu_items'] = [
     [
-        'label' => 'Category Error Item',
-        'type' => 'category',
+        'label'     => 'Category Error Item',
+        'type'      => 'category',
         'icon_type' => 'svg_inline',
-        'icon' => '',
-        'value' => 123,
+        'icon'      => '',
+        'value'     => 123,
     ],
 ];
 $default_settings['social_icons'] = [];

--- a/tests/sanitize_css_dimension_test.php
+++ b/tests/sanitize_css_dimension_test.php
@@ -5,68 +5,11 @@ use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
 
-define('ABSPATH', true);
-define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
+require __DIR__ . '/bootstrap.php';
 
-if (!function_exists('register_activation_hook')) {
-    function register_activation_hook($file, $callback): void {
-        // No-op for tests.
-    }
-}
-
-if (!function_exists('plugin_dir_path')) {
-    function plugin_dir_path($file): string {
-        return rtrim(dirname($file), "/\\") . '/';
-    }
-}
-
-if (!function_exists('trailingslashit')) {
-    function trailingslashit($value): string {
-        return rtrim($value, "/\\") . '/';
-    }
-}
-
-if (!function_exists('wp_upload_dir')) {
-    function wp_upload_dir(): array {
-        return [
-            'basedir' => sys_get_temp_dir(),
-            'baseurl' => 'http://example.com/uploads',
-        ];
-    }
-}
-
-if (!function_exists('wp_check_filetype')) {
-    function wp_check_filetype($file, $allowed = []): array {
-        return ['ext' => '', 'type' => ''];
-    }
-}
-
-if (!function_exists('wp_kses')) {
-    function wp_kses($string, $allowed_html = []) {
-        return $string;
-    }
-}
-
-if (!function_exists('sanitize_key')) {
-    function sanitize_key($key): string {
-        $key = strtolower((string) $key);
-        return preg_replace('/[^a-z0-9_\-]/', '', $key);
-    }
-}
-
-if (!function_exists('sanitize_text_field')) {
-    function sanitize_text_field($value): string {
-        if (is_array($value) || is_object($value)) {
-            return '';
-        }
-
-        $value = (string) $value;
-        $value = strip_tags($value);
-        $value = preg_replace('/[\r\n\t ]+/', ' ', $value);
-
-        return trim($value);
-    }
-}
+$GLOBALS['wp_test_function_overrides']['wp_check_filetype'] = static function ($file, $allowed = []) {
+    return ['ext' => '', 'type' => ''];
+};
 
 require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -5,98 +5,11 @@ use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
 
-define('ABSPATH', true);
-define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
+require __DIR__ . '/bootstrap.php';
 
-if (!function_exists('register_activation_hook')) {
-    function register_activation_hook($file, $callback): void
-    {
-        // No-op for tests.
-    }
-}
-
-if (!function_exists('plugin_dir_path')) {
-    function plugin_dir_path($file): string
-    {
-        return rtrim(dirname($file), "/\\") . '/';
-    }
-}
-
-if (!function_exists('trailingslashit')) {
-    function trailingslashit($value): string
-    {
-        return rtrim($value, "/\\") . '/';
-    }
-}
-
-if (!function_exists('wp_upload_dir')) {
-    function wp_upload_dir(): array
-    {
-        return [
-            'basedir' => sys_get_temp_dir(),
-            'baseurl' => 'http://example.com/uploads',
-        ];
-    }
-}
-
-if (!function_exists('wp_check_filetype')) {
-    function wp_check_filetype($file, $allowed = []): array
-    {
-        return ['ext' => '', 'type' => ''];
-    }
-}
-
-if (!function_exists('wp_kses')) {
-    function wp_kses($string, $allowed_html = [])
-    {
-        return $string;
-    }
-}
-
-if (!function_exists('sanitize_key')) {
-    function sanitize_key($key): string
-    {
-        $key = strtolower((string) $key);
-        return preg_replace('/[^a-z0-9_\-]/', '', $key);
-    }
-}
-
-if (!function_exists('sanitize_hex_color')) {
-    function sanitize_hex_color($color): string
-    {
-        $color = trim((string) $color);
-        if (preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $color)) {
-            return strtolower($color);
-        }
-
-        return '';
-    }
-}
-
-if (!function_exists('sanitize_text_field')) {
-    function sanitize_text_field($value): string
-    {
-        $value = (string) $value;
-        $value = strip_tags($value);
-        $value = preg_replace('/[\r\n\t\0\x0B]/', '', $value);
-
-        return trim($value);
-    }
-}
-
-if (!function_exists('esc_url_raw')) {
-    function esc_url_raw($value): string
-    {
-        return (string) $value;
-    }
-}
-
-if (!function_exists('absint')) {
-    function absint($value): int
-    {
-        return abs((int) $value);
-    }
-}
+$GLOBALS['wp_test_function_overrides']['wp_check_filetype'] = static function ($file, $allowed = []) {
+    return ['ext' => '', 'type' => ''];
+};
 
 require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 

--- a/tests/sanitize_rgba_color_test.php
+++ b/tests/sanitize_rgba_color_test.php
@@ -5,65 +5,11 @@ use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
 
-define('ABSPATH', true);
-define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
+require __DIR__ . '/bootstrap.php';
 
-if (!function_exists('register_activation_hook')) {
-    function register_activation_hook($file, $callback): void {
-        // No-op for tests.
-    }
-}
-
-if (!function_exists('plugin_dir_path')) {
-    function plugin_dir_path($file): string {
-        return rtrim(dirname($file), "/\\") . '/';
-    }
-}
-
-if (!function_exists('trailingslashit')) {
-    function trailingslashit($value): string {
-        return rtrim($value, "/\\") . '/';
-    }
-}
-
-if (!function_exists('wp_upload_dir')) {
-    function wp_upload_dir(): array {
-        return [
-            'basedir' => sys_get_temp_dir(),
-            'baseurl' => 'http://example.com/uploads',
-        ];
-    }
-}
-
-if (!function_exists('wp_check_filetype')) {
-    function wp_check_filetype($file, $allowed = []): array {
-        return ['ext' => '', 'type' => ''];
-    }
-}
-
-if (!function_exists('wp_kses')) {
-    function wp_kses($string, $allowed_html = []) {
-        return $string;
-    }
-}
-
-if (!function_exists('sanitize_key')) {
-    function sanitize_key($key): string {
-        $key = strtolower((string) $key);
-        return preg_replace('/[^a-z0-9_\-]/', '', $key);
-    }
-}
-
-if (!function_exists('sanitize_hex_color')) {
-    function sanitize_hex_color($color): string {
-        $color = trim((string) $color);
-        if (preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $color)) {
-            return strtolower($color);
-        }
-
-        return '';
-    }
-}
+$GLOBALS['wp_test_function_overrides']['wp_check_filetype'] = static function ($file, $allowed = []) {
+    return ['ext' => '', 'type' => ''];
+};
 
 require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
@@ -160,9 +106,7 @@ foreach ($tests as $name => $test) {
 }
 
 if ($allPassed) {
-    echo "All sanitize_rgba_color tests passed.\n";
     exit(0);
 }
 
-echo "sanitize_rgba_color tests failed.\n";
 exit(1);

--- a/tests/sanitize_style_settings_test.php
+++ b/tests/sanitize_style_settings_test.php
@@ -5,94 +5,11 @@ use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
 
-define('ABSPATH', true);
-define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
+require __DIR__ . '/bootstrap.php';
 
-if (!function_exists('register_activation_hook')) {
-    function register_activation_hook($file, $callback): void {
-        // No-op for tests.
-    }
-}
-
-if (!function_exists('plugin_dir_path')) {
-    function plugin_dir_path($file): string {
-        return rtrim(dirname($file), "/\\") . '/';
-    }
-}
-
-if (!function_exists('trailingslashit')) {
-    function trailingslashit($value): string {
-        return rtrim($value, "/\\") . '/';
-    }
-}
-
-if (!function_exists('wp_upload_dir')) {
-    function wp_upload_dir(): array {
-        return [
-            'basedir' => sys_get_temp_dir(),
-            'baseurl' => 'http://example.com/uploads',
-        ];
-    }
-}
-
-if (!function_exists('wp_check_filetype')) {
-    function wp_check_filetype($file, $allowed = []): array {
-        return ['ext' => '', 'type' => ''];
-    }
-}
-
-if (!function_exists('wp_kses')) {
-    function wp_kses($string, $allowed_html = []) {
-        return $string;
-    }
-}
-
-if (!function_exists('sanitize_key')) {
-    function sanitize_key($key): string {
-        $key = strtolower((string) $key);
-        return preg_replace('/[^a-z0-9_\-]/', '', $key);
-    }
-}
-
-if (!function_exists('sanitize_hex_color')) {
-    function sanitize_hex_color($color): string {
-        $color = trim((string) $color);
-        if (preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $color)) {
-            return strtolower($color);
-        }
-
-        return '';
-    }
-}
-
-if (!function_exists('sanitize_key')) {
-    function sanitize_key($key): string {
-        $key = strtolower((string) $key);
-        return preg_replace('/[^a-z0-9_\-]/', '', $key);
-    }
-}
-
-if (!function_exists('sanitize_text_field')) {
-    function sanitize_text_field($value): string {
-        $value = (string) $value;
-        $value = strip_tags($value);
-        $value = preg_replace('/[\r\n\t\0\x0B]/', '', $value);
-
-        return trim($value);
-    }
-}
-
-if (!function_exists('esc_url_raw')) {
-    function esc_url_raw($value): string {
-        return (string) $value;
-    }
-}
-
-if (!function_exists('absint')) {
-    function absint($value): int {
-        return abs((int) $value);
-    }
-}
+$GLOBALS['wp_test_function_overrides']['wp_check_filetype'] = static function ($file, $allowed = []) {
+    return ['ext' => '', 'type' => ''];
+};
 
 require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 

--- a/tests/sidebar_locale_cache_test.php
+++ b/tests/sidebar_locale_cache_test.php
@@ -3,12 +3,8 @@ declare(strict_types=1);
 
 use function JLG\Sidebar\plugin;
 
-define('ABSPATH', true);
-define('SIDEBAR_JLG_SKIP_BOOTSTRAP', true);
+require __DIR__ . '/bootstrap.php';
 
-$GLOBALS['wp_test_options']    = [];
-$GLOBALS['wp_test_transients'] = [];
-$GLOBALS['wp_test_current_locale'] = 'fr_FR';
 $GLOBALS['wp_test_translations'] = [
     'fr_FR' => [
         'Navigation principale' => 'Navigation principale',
@@ -22,207 +18,11 @@ $GLOBALS['wp_test_translations'] = [
     ],
 ];
 
-function register_activation_hook($file, $callback): void {}
-function wp_upload_dir(): array {
-    return [
-        'basedir' => sys_get_temp_dir() . '/sidebar-jlg-test',
-        'baseurl' => 'http://example.com/uploads',
-    ];
-}
-function wp_mkdir_p(string $dir): bool { return true; }
-function add_action($hook, $callback, $priority = 10, $accepted_args = 1): void {}
-function add_filter($hook, $callback, $priority = 10, $accepted_args = 1): void {}
-function apply_filters($hook, $value, ...$args) {
-    return $value;
-}
-function wp_parse_args($args, $defaults = []) {
-    if (is_object($args)) {
-        $args = get_object_vars($args);
-    } elseif (!is_array($args)) {
-        $args = [];
-    }
-
-    if (!is_array($defaults)) {
-        $defaults = [];
-    }
-
-    return array_merge($defaults, $args);
-}
-function trailingslashit($value): string {
-    return rtrim($value, "/\\") . '/';
-}
-function plugin_dir_path($file): string {
-    return trailingslashit(dirname($file));
-}
-function plugin_dir_url($file): string {
-    return 'http://example.com/plugin/';
-}
-function wp_enqueue_style(...$args): void {}
-function wp_enqueue_script(...$args): void {}
-function wp_register_script(...$args): void {}
-function wp_enqueue_media(): void {}
-function wp_localize_script(...$args): void {}
-function wp_create_nonce($action): string {
-    return 'nonce-' . $action;
-}
-function admin_url($path = ''): string {
-    return 'http://example.com/wp-admin/' . ltrim($path, '/');
-}
-function get_option($name, $default = false) {
-    global $wp_test_options;
-    if (array_key_exists($name, $wp_test_options)) {
-        return $wp_test_options[$name];
-    }
-
-    return $default;
-}
-function update_option($name, $value, $autoload = null): bool {
-    global $wp_test_options;
-    $wp_test_options[$name] = $value;
-
-    return true;
-}
-function add_option($name, $value, $deprecated = '', $autoload = 'yes'): bool {
-    global $wp_test_options;
-    if (array_key_exists($name, $wp_test_options)) {
-        return false;
-    }
-
-    $wp_test_options[$name] = $value;
-
-    return true;
-}
-function delete_option($name): bool {
-    global $wp_test_options;
-    if (array_key_exists($name, $wp_test_options)) {
-        unset($wp_test_options[$name]);
-    }
-
-    return true;
-}
-function get_transient($key) {
-    global $wp_test_transients;
-    return $wp_test_transients[$key] ?? false;
-}
-function set_transient($key, $value, $expiration = 0): bool {
-    global $wp_test_transients;
-    $wp_test_transients[$key] = $value;
-
-    return true;
-}
-function delete_transient($key): bool {
-    global $wp_test_transients;
-    if (array_key_exists($key, $wp_test_transients)) {
-        unset($wp_test_transients[$key]);
-    }
-
-    return true;
-}
-function determine_locale(): string {
-    return $GLOBALS['wp_test_current_locale'];
-}
-function get_locale(): string {
-    return determine_locale();
-}
-function switch_to_locale(string $locale): bool {
-    $GLOBALS['wp_test_current_locale'] = $locale;
-
-    return true;
-}
-function esc_attr($value) {
-    return $value;
-}
-function esc_html($value) {
-    return $value;
-}
-function esc_url($value) {
-    return $value;
-}
-function esc_attr_e($text, $domain = 'default'): void {
-    echo esc_attr(__($text, $domain));
-}
-function esc_url_raw($value) {
-    return $value;
-}
-function absint($value): int {
-    return abs((int) $value);
-}
-function wp_unslash($value) {
-    return $value;
-}
-function wp_check_filetype($file, $allowed = []) {
-    $extension = pathinfo($file, PATHINFO_EXTENSION);
-
-    if ($extension === '') {
-        return ['ext' => '', 'type' => ''];
-    }
-
-    return [
-        'ext'  => $extension,
-        'type' => $allowed[$extension] ?? 'image/' . $extension,
-    ];
-}
-function wp_kses($string, $allowed_html = []) {
-    return $string;
-}
-function sanitize_hex_color($color) {
-    $color = trim((string) $color);
-    if (preg_match('/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $color)) {
-        return strtolower($color);
-    }
-
-    return '';
-}
-
-function sanitize_text_field($value) {
-    if (is_array($value) || is_object($value)) {
-        return '';
-    }
-
-    $value = (string) $value;
-    $value = strip_tags($value);
-    $value = preg_replace('/[\r\n\t ]+/', ' ', $value);
-
-    return trim($value);
-}
-function sanitize_key($key) {
-    $key = strtolower((string) $key);
-    return preg_replace('/[^a-z0-9_\-]/', '', $key);
-}
-function get_permalink($post_id) {
-    return 'http://example.com/post/' . $post_id;
-}
-function get_category_link($cat_id) {
-    return 'http://example.com/category/' . $cat_id;
-}
-function get_bloginfo($show = '', $filter = 'raw') {
-    return 'Test Blog';
-}
-function do_shortcode($content) {
+$GLOBALS['wp_test_function_overrides']['do_shortcode'] = static function ($content) {
     $GLOBALS['wp_test_shortcode_calls'] = ($GLOBALS['wp_test_shortcode_calls'] ?? 0) + 1;
 
     return $content . ' #' . $GLOBALS['wp_test_shortcode_calls'];
-}
-function do_action($hook, ...$args): void {}
-function get_search_form(): string {
-    return 'SEARCH_FORM';
-}
-function wp_kses_post($string) {
-    return $string;
-}
-function __($text, $domain = 'default') {
-    $locale = determine_locale();
-    $translations = $GLOBALS['wp_test_translations'];
-
-    if (isset($translations[$locale][$text])) {
-        return $translations[$locale][$text];
-    }
-
-    return $text;
-}
-function _e($text, $domain = 'default'): void {
-    echo __($text, $domain);
-}
+};
 
 require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
@@ -231,43 +31,6 @@ $settingsRepository = $plugin->getSettingsRepository();
 $sanitizer = $plugin->getSanitizer();
 $renderer = $plugin->getSidebarRenderer();
 $menuCache = $plugin->getMenuCache();
-
-$default_settings = $settingsRepository->getDefaultSettings();
-$default_settings['social_icons'] = [];
-update_option('sidebar_jlg_settings', $default_settings);
-
-$input_settings = [
-    'menu_items' => [
-        [
-            'label' => 'Article SVG',
-            'type' => 'post',
-            'icon_type' => 'svg_url',
-            'icon' => 'https://example.com/icon.svg',
-            'value' => '789',
-        ],
-        [
-            'label' => 'Catégorie liens',
-            'type' => 'category',
-            'icon_type' => 'svg_inline',
-            'icon' => 'folder',
-            'value' => '321',
-        ],
-    ],
-];
-
-$sanitized_settings = $sanitizer->sanitize_settings($input_settings);
-$sanitized_settings['enable_sidebar'] = true;
-
-assertTrue(
-    isset($sanitized_settings['menu_items'][0]['value']) && $sanitized_settings['menu_items'][0]['value'] === 789,
-    'Post ID sanitized with absint even when icon type is svg_url'
-);
-assertTrue(
-    isset($sanitized_settings['menu_items'][1]['value']) && $sanitized_settings['menu_items'][1]['value'] === 321,
-    'Category ID preserved after sanitization'
-);
-
-update_option('sidebar_jlg_settings', $sanitized_settings);
 
 $testsPassed = true;
 function assertTrue($condition, string $message): void {
@@ -288,6 +51,43 @@ function assertContains(string $needle, string $haystack, string $message): void
 function assertNotContains(string $needle, string $haystack, string $message): void {
     assertTrue(strpos($haystack, $needle) === false, $message);
 }
+
+$default_settings = $settingsRepository->getDefaultSettings();
+$default_settings['social_icons'] = [];
+update_option('sidebar_jlg_settings', $default_settings);
+
+$input_settings = [
+    'menu_items' => [
+        [
+            'label'     => 'Article SVG',
+            'type'      => 'post',
+            'icon_type' => 'svg_url',
+            'icon'      => 'https://example.com/icon.svg',
+            'value'     => '789',
+        ],
+        [
+            'label'     => 'Catégorie liens',
+            'type'      => 'category',
+            'icon_type' => 'svg_inline',
+            'icon'      => 'folder',
+            'value'     => '321',
+        ],
+    ],
+];
+
+$sanitized_settings = $sanitizer->sanitize_settings($input_settings);
+$sanitized_settings['enable_sidebar'] = true;
+
+assertTrue(
+    isset($sanitized_settings['menu_items'][0]['value']) && $sanitized_settings['menu_items'][0]['value'] === 789,
+    'Post ID sanitized with absint even when icon type is svg_url'
+);
+assertTrue(
+    isset($sanitized_settings['menu_items'][1]['value']) && $sanitized_settings['menu_items'][1]['value'] === 321,
+    'Category ID preserved after sanitization'
+);
+
+update_option('sidebar_jlg_settings', $sanitized_settings);
 
 $menuCache->clear();
 $GLOBALS['wp_test_transients'] = [];


### PR DESCRIPTION
## Summary
- add a shared tests/bootstrap.php that centralizes WordPress stubs and opt-in overrides for tests
- update the sidebar rendering, locale cache, and sanitizer tests to load the shared bootstrap instead of duplicating helpers
- configure per-test overrides (e.g. do_shortcode, wp_check_filetype) where custom behaviour is required

## Testing
- php tests/render_sidebar_html_error_handling_test.php
- php tests/sidebar_locale_cache_test.php
- php tests/sanitize_general_settings_test.php
- php tests/sanitize_style_settings_test.php
- php tests/sanitize_rgba_color_test.php
- php tests/sanitize_css_dimension_test.php


------
https://chatgpt.com/codex/tasks/task_e_68ce66678804832e82d2ec8f4430d9ae