### PR TITLE
Wrap admin menu strings in translation calls

### DIFF
--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -42,8 +42,8 @@ class MenuPage
     public function addAdminMenu(): void
     {
         add_menu_page(
-            'Sidebar JLG Settings',
-            'Sidebar JLG',
+            __('Sidebar JLG Settings', 'sidebar-jlg'),
+            __('Sidebar JLG', 'sidebar-jlg'),
             'manage_options',
             'sidebar-jlg',
             [$this, 'render'],


### PR DESCRIPTION
## Summary
- wrap the admin menu page title and menu label in translation calls using the plugin text domain so they can be localized

## Testing
- php -r 'function wp_reset_postdata(){}; require "tests/ajax_endpoints_test.php";'
- php tests/sanitize_css_dimension_test.php
- php tests/sanitize_general_settings_test.php
- php tests/sanitize_rgba_color_test.php
- php tests/sanitize_style_settings_test.php
- php tests/render_sidebar_html_error_handling_test.php
- php tests/sidebar_locale_cache_test.php

------
https://chatgpt.com/codex/tasks/task_e_68ce665d2910832eb544148e3e35dc3a