### PR TITLE
Wrap AJAX endpoint messages in translation helpers

### DIFF
--- a/sidebar-jlg/src/Ajax/Endpoints.php
+++ b/sidebar-jlg/src/Ajax/Endpoints.php
@@ -4,6 +4,7 @@ namespace JLG\Sidebar\Ajax;
 
 use JLG\Sidebar\Cache\MenuCache;
 use JLG\Sidebar\Settings\SettingsRepository;
+use function __;
 
 class Endpoints
 {
@@ -34,7 +35,7 @@ class Endpoints
         $capability = $this->get_ajax_capability();
 
         if (!current_user_can($capability)) {
-            wp_send_json_error('Permission refusée.');
+            wp_send_json_error(__('Permission refusée.', 'sidebar-jlg'));
         }
 
         check_ajax_referer('jlg_ajax_nonce', 'nonce');
@@ -43,7 +44,7 @@ class Endpoints
         $requestedPerPage = isset($_POST['posts_per_page']) ? intval(wp_unslash($_POST['posts_per_page'])) : 20;
 
         if ($requestedPerPage > $maxPerPage) {
-            wp_send_json_error(sprintf('Le paramètre posts_per_page ne peut pas dépasser %d.', $maxPerPage));
+            wp_send_json_error(sprintf(__('Le paramètre posts_per_page ne peut pas dépasser %d.', 'sidebar-jlg'), $maxPerPage));
         }
 
         $perPage = min(max(1, $requestedPerPage), $maxPerPage);
@@ -108,7 +109,7 @@ class Endpoints
         $capability = $this->get_ajax_capability();
 
         if (!current_user_can($capability)) {
-            wp_send_json_error('Permission refusée.');
+            wp_send_json_error(__('Permission refusée.', 'sidebar-jlg'));
         }
 
         check_ajax_referer('jlg_ajax_nonce', 'nonce');
@@ -117,7 +118,7 @@ class Endpoints
         $requestedPerPage = isset($_POST['posts_per_page']) ? intval(wp_unslash($_POST['posts_per_page'])) : 20;
 
         if ($requestedPerPage > $maxPerPage) {
-            wp_send_json_error(sprintf('Le paramètre posts_per_page ne peut pas dépasser %d.', $maxPerPage));
+            wp_send_json_error(sprintf(__('Le paramètre posts_per_page ne peut pas dépasser %d.', 'sidebar-jlg'), $maxPerPage));
         }
 
         $perPage = min(max(1, $requestedPerPage), $maxPerPage);
@@ -178,13 +179,13 @@ class Endpoints
         $capability = $this->get_ajax_capability();
 
         if (!current_user_can($capability)) {
-            wp_send_json_error('Permission refusée.');
+            wp_send_json_error(__('Permission refusée.', 'sidebar-jlg'));
         }
 
         check_ajax_referer('jlg_reset_nonce', 'nonce');
         $this->settings->deleteOptions();
         $this->cache->clear();
-        wp_send_json_success('Réglages réinitialisés.');
+        wp_send_json_success(__('Réglages réinitialisés.', 'sidebar-jlg'));
     }
 
     private function get_ajax_capability(): string

--- a/tests/ajax_endpoints_test.php
+++ b/tests/ajax_endpoints_test.php
@@ -194,6 +194,10 @@ function esc_attr_e($text, $domain = 'default'): void
 {
     echo esc_attr($text);
 }
+function __($text, $domain = 'default')
+{
+    return $text;
+}
 function esc_url_raw($value)
 {
     return $value;


### PR DESCRIPTION
## Summary
- wrap all AJAX success and error responses in the translation helper with the sidebar text domain
- import the translation helper within the endpoints class and stub it in the AJAX endpoint test harness

## Testing
- php tests/ajax_endpoints_test.php
- php tests/render_sidebar_html_error_handling_test.php
- php tests/sanitize_css_dimension_test.php
- php tests/sanitize_general_settings_test.php
- php tests/sanitize_rgba_color_test.php
- php tests/sanitize_style_settings_test.php
- php tests/sidebar_locale_cache_test.php

------
https://chatgpt.com/codex/tasks/task_e_68ce69ef0dbc832e8c84b413ca013336