### PR TITLE
Handle automatic sidebar closing after menu clicks

### DIFF
--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -69,10 +69,9 @@ document.addEventListener('DOMContentLoaded', function() {
     if (closeBtn) closeBtn.addEventListener('click', closeSidebar);
     if (overlay) overlay.addEventListener('click', closeSidebar);
 
+    const closeOnClickTruthyValues = new Set([true, 1, '1', 'true']);
     const shouldCloseOnLinkClick = typeof sidebarSettings !== 'undefined'
-        && (sidebarSettings.close_on_link_click === true
-            || sidebarSettings.close_on_link_click === 1
-            || sidebarSettings.close_on_link_click === '1');
+        && closeOnClickTruthyValues.has(sidebarSettings.close_on_link_click);
 
     if (shouldCloseOnLinkClick) {
         const selectors = ['.sidebar-menu a', '.social-icons a'];

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -101,8 +101,8 @@
                 <tr>
                     <th scope="row"><?php esc_html_e( 'Fermeture automatique', 'sidebar-jlg' ); ?></th>
                     <td>
-                        <label><input type="checkbox" name="sidebar_jlg_settings[close_on_link_click]" value="1" <?php checked( $options['close_on_link_click'], 1 ); ?> /> <?php esc_html_e( 'Fermer la sidebar après un clic sur un lien ou une icône sociale.', 'sidebar-jlg' ); ?></label>
-                        <p class="description"><?php esc_html_e( 'Recommandé sur mobile pour éviter qu\'elle reste ouverte après navigation.', 'sidebar-jlg' ); ?></p>
+                        <label><input type="checkbox" name="sidebar_jlg_settings[close_on_link_click]" value="1" <?php checked( $options['close_on_link_click'], 1 ); ?> /> <?php esc_html_e( 'Fermer automatiquement la sidebar après un clic sur un lien ou une icône sociale.', 'sidebar-jlg' ); ?></label>
+                        <p class="description"><?php esc_html_e( 'Recommandé sur mobile pour éviter qu\'elle reste ouverte après la navigation.', 'sidebar-jlg' ); ?></p>
                     </td>
                 </tr>
                 <tr>

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -72,6 +72,7 @@ class SettingsSanitizer
         $sanitized['search_alignment'] = sanitize_key($input['search_alignment'] ?? $existingOptions['search_alignment']);
         $sanitized['debug_mode'] = !empty($input['debug_mode']);
         $sanitized['show_close_button'] = !empty($input['show_close_button']);
+        // Checkbox -> boolean conversion for the automatic closing behaviour.
         $sanitized['close_on_link_click'] = !empty($input['close_on_link_click']);
         $sanitized['hamburger_top_position'] = $this->sanitize_css_dimension(
             $input['hamburger_top_position'] ?? $existingOptions['hamburger_top_position'],

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -29,6 +29,7 @@ class DefaultSettings
             'search_alignment'  => 'flex-start',
             'debug_mode'        => false,
             'show_close_button' => true,
+            // Automatically close the sidebar after clicking menu or social links.
             'close_on_link_click' => false,
             'hamburger_top_position' => '4rem',
             'header_logo_type'  => 'text',

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -151,11 +151,27 @@ $result_close_on = $method->invoke($sanitizer, $input_close_on_click, $existing_
 
 assertSame(true, $result_close_on['close_on_link_click'] ?? null, 'Close-on-click option is enabled when checkbox is set');
 
+$input_close_on_click_true_string = [
+    'close_on_link_click' => 'true',
+];
+
+$result_close_on_true_string = $method->invoke($sanitizer, $input_close_on_click_true_string, $existing_options);
+
+assertSame(true, $result_close_on_true_string['close_on_link_click'] ?? null, 'Close-on-click option accepts "true" as a truthy value');
+
 $input_close_on_click_disabled = [];
 
 $result_close_off = $method->invoke($sanitizer, $input_close_on_click_disabled, $existing_options);
 
 assertSame(false, $result_close_off['close_on_link_click'] ?? null, 'Close-on-click option defaults to disabled when missing');
+
+$input_close_on_click_zero = [
+    'close_on_link_click' => '0',
+];
+
+$result_close_zero = $method->invoke($sanitizer, $input_close_on_click_zero, $existing_options);
+
+assertSame(false, $result_close_zero['close_on_link_click'] ?? null, 'Close-on-click option treats "0" as disabled');
 
 $input_min = [
     'overlay_opacity' => -0.3,


### PR DESCRIPTION
## Summary
- document the close-on-link-click toggle in the default settings and sanitizer
- clarify the admin UI label for the option and make the public script honour truthy values when closing on menu or social links
- extend the sanitize_general_settings test coverage for the new toggle

## Testing
- php tests/sanitize_general_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68ce69fa3630832e9c2f7a6beda4390a