### PR TITLE
Respect search toggle when determining dynamic sidebar

### DIFF
--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -133,8 +133,12 @@ class SidebarRenderer
             $options = $this->settings->getOptions();
         }
 
-        $searchMethod = $options['search_method'] ?? 'default';
-        $isDynamic = in_array($searchMethod, ['shortcode', 'hook'], true);
+        if (empty($options['enable_search'])) {
+            $isDynamic = false;
+        } else {
+            $searchMethod = $options['search_method'] ?? 'default';
+            $isDynamic = in_array($searchMethod, ['shortcode', 'hook'], true);
+        }
 
         return (bool) \apply_filters('sidebar_jlg_is_dynamic', $isDynamic, $options);
     }


### PR DESCRIPTION
## Summary
- ensure `SidebarRenderer::is_sidebar_output_dynamic()` honours the search enable flag before inspecting the search method
- extend the locale cache integration test to cover a disabled search combined with the shortcode method and confirm caching stays enabled

## Testing
- php tests/sidebar_locale_cache_test.php

------
https://chatgpt.com/codex/tasks/task_e_68ce7440dff4832e94f324ede41fb112