### PR TITLE
Ensure cache clears during settings revalidation

### DIFF
--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -54,12 +54,12 @@ class Plugin
 
     public function register(): void
     {
+        add_action('update_option_sidebar_jlg_settings', [$this->cache, 'clear'], 10, 0);
+
         $this->settings->revalidateStoredOptions();
         $this->menuPage->registerHooks();
         $this->renderer->registerHooks();
         $this->ajax->registerHooks();
-
-        add_action('update_option_sidebar_jlg_settings', [$this->cache, 'clear'], 10, 0);
 
         $contentChangeHooks = [
             'save_post',


### PR DESCRIPTION
## Summary
- register the sidebar settings update hook before triggering stored option revalidation so transient caches clear during updates
- extend the sidebar locale cache test suite to cover invalid icon cleanup and verify cache purging during revalidation

## Testing
- for file in tests/*_test.php; do php $file || exit 1; echo; done

------
https://chatgpt.com/codex/tasks/task_e_68ce74382e88832ebf182e79c035b6a2