### PR TITLE
Handle calc content margin expressions

### DIFF
--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -128,7 +128,21 @@ $dynamic_styles .= "--header-alignment-desktop: " . esc_attr($options['header_al
 $dynamic_styles .= "--header-alignment-mobile: " . esc_attr($options['header_alignment_mobile']) . ";";
 $dynamic_styles .= "--header-logo-size: " . esc_attr($options['header_logo_size']) . "px;";
 $dynamic_styles .= "--hamburger-top-position: " . esc_attr($options['hamburger_top_position']) . ";";
-$dynamic_styles .= "--content-margin: calc(var(--sidebar-width-desktop) + " . esc_attr($options['content_margin']) . ");";
+$content_margin_value = $options['content_margin'] ?? '';
+if (is_string($content_margin_value) || is_numeric($content_margin_value)) {
+    $content_margin_value = (string) $content_margin_value;
+    $content_margin_trimmed = trim($content_margin_value);
+
+    if (preg_match('/^calc\((.*)\)$/i', $content_margin_trimmed, $matches)) {
+        $content_margin_value = $matches[1];
+    } else {
+        $content_margin_value = $content_margin_trimmed;
+    }
+} else {
+    $content_margin_value = '';
+}
+
+$dynamic_styles .= "--content-margin: calc(var(--sidebar-width-desktop) + " . esc_attr($content_margin_value) . ");";
 $dynamic_styles .= "--floating-vertical-margin: " . esc_attr($options['floating_vertical_margin']) . ";";
 $dynamic_styles .= "--border-radius: " . esc_attr($options['border_radius']) . ";";
 $dynamic_styles .= "--border-width: " . esc_attr($options['border_width']) . "px;";

--- a/tests/sidebar_locale_cache_test.php
+++ b/tests/sidebar_locale_cache_test.php
@@ -77,6 +77,7 @@ $input_settings = [
 
 $sanitized_settings = $sanitizer->sanitize_settings($input_settings);
 $sanitized_settings['enable_sidebar'] = true;
+$sanitized_settings['content_margin'] = 'calc(10px + 5%)';
 
 assertTrue(
     isset($sanitized_settings['menu_items'][0]['value']) && $sanitized_settings['menu_items'][0]['value'] === 789,
@@ -100,6 +101,8 @@ $french_html = ob_get_clean();
 assertContains('Ouvrir le menu', $french_html, 'French menu label rendered');
 assertContains('href="http://example.com/post/789"', $french_html, 'Post menu item links to the correct article');
 assertContains('href="http://example.com/category/321"', $french_html, 'Category menu item links to the correct term');
+assertContains('calc(var(--sidebar-width-desktop) + 10px + 5%)', $french_html, 'Content margin calc expression flattened');
+assertNotContains('calc(calc', $french_html, 'Content margin does not contain nested calc');
 assertNotContains('Open menu', $french_html, 'English menu label absent in French cache');
 assertTrue(isset($GLOBALS['wp_test_transients']['sidebar_jlg_full_html_fr_FR']), 'French transient stored');
 


### PR DESCRIPTION
## Summary
- flatten calc-based content margin expressions before composing the sidebar CSS to avoid nested calc() calls
- add a regression test ensuring calc expressions are emitted without nested calc wrappers

## Testing
- php tests/sidebar_locale_cache_test.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8a1d7210832e8daef6a89af122d9