### PR TITLE
Sanitize existing color fallbacks

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -361,6 +361,8 @@ class SettingsSanitizer
             ? (string) $existingValue
             : '';
 
+        $sanitizedExisting = $this->sanitize_rgba_color($existingValue);
+
         $candidate = $value;
         if ($candidate === null) {
             $candidate = $existingValue;
@@ -368,11 +370,15 @@ class SettingsSanitizer
 
         $sanitized = $this->sanitize_rgba_color($candidate);
 
-        if ($sanitized === '' && $existingValue !== '') {
-            return $existingValue;
+        if ($sanitized !== '') {
+            return $sanitized;
         }
 
-        return $sanitized;
+        if ($sanitizedExisting !== '') {
+            return $sanitizedExisting;
+        }
+
+        return '';
     }
 
     private function sanitize_rgba_color($color): string

--- a/tests/sanitize_style_settings_test.php
+++ b/tests/sanitize_style_settings_test.php
@@ -114,6 +114,13 @@ unset($inputWithoutOpacity['mobile_bg_opacity']);
 $resultExistingClamp = $method->invoke($sanitizer, $inputWithoutOpacity, $existingOpacityOutOfRange);
 assertSame(1.0, $resultExistingClamp['mobile_bg_opacity'], 'Fallback opacity clamps existing value to 1.0');
 
+$existingPayloadOptions = $existing_options;
+$existingPayloadOptions['bg_color'] = 'rgba(10,20,30,0.4);background-image:url(javascript:alert(1))';
+$inputWithoutBgColor = $input;
+unset($inputWithoutBgColor['bg_color']);
+$resultSanitizedPayload = $method->invoke($sanitizer, $inputWithoutBgColor, $existingPayloadOptions);
+assertSame('', $resultSanitizedPayload['bg_color'], 'Existing bg color payload is sanitized to empty string');
+
 if ($testsPassed) {
     echo "All sanitize_style_settings tests passed.\n";
     exit(0);


### PR DESCRIPTION
## Summary
- sanitize stored fallback colors before reuse and default to empty when invalid
- add regression test ensuring malicious existing colors are cleared

## Testing
- php tests/sanitize_style_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8f4559c0832ea93a855030b475aa