### PR TITLE
Sanitize fallback colors before reuse

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -361,19 +361,17 @@ class SettingsSanitizer
             ? (string) $existingValue
             : '';
 
-        $sanitizedExisting = $this->sanitize_rgba_color($existingValue);
-
         $candidate = $value;
         if ($candidate === null) {
             $candidate = $existingValue;
         }
 
-        $sanitized = $this->sanitize_rgba_color($candidate);
-
-        if ($sanitized !== '') {
-            return $sanitized;
+        $sanitizedCandidate = $this->sanitize_rgba_color($candidate);
+        if ($sanitizedCandidate !== '') {
+            return $sanitizedCandidate;
         }
 
+        $sanitizedExisting = $this->sanitize_rgba_color($existingValue);
         if ($sanitizedExisting !== '') {
             return $sanitizedExisting;
         }

--- a/tests/sanitize_style_settings_test.php
+++ b/tests/sanitize_style_settings_test.php
@@ -121,6 +121,13 @@ unset($inputWithoutBgColor['bg_color']);
 $resultSanitizedPayload = $method->invoke($sanitizer, $inputWithoutBgColor, $existingPayloadOptions);
 assertSame('', $resultSanitizedPayload['bg_color'], 'Existing bg color payload is sanitized to empty string');
 
+$existingAccentPayload = $existing_options;
+$existingAccentPayload['accent_color'] = '#112233;background-image:url(javascript:alert(1))';
+$inputWithoutAccent = $input;
+unset($inputWithoutAccent['accent_color']);
+$resultSanitizedAccentPayload = $method->invoke($sanitizer, $inputWithoutAccent, $existingAccentPayload);
+assertSame('', $resultSanitizedAccentPayload['accent_color'], 'Existing accent color payload is sanitized to empty string');
+
 if ($testsPassed) {
     echo "All sanitize_style_settings tests passed.\n";
     exit(0);


### PR DESCRIPTION
## Summary
- ensure `sanitize_color_with_existing` sanitizes fallback colors and drops invalid values
- extend style settings sanitizer tests with a payload scenario for existing accent colors

## Testing
- php tests/sanitize_style_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68ce90522824832e9bac8666a4dedc5c