### PR TITLE
Handle corrupted sidebar settings option

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -20,14 +20,20 @@ class SettingsSanitizer
     {
         $defaults = $this->defaults->all();
         $existingOptions = get_option('sidebar_jlg_settings', $defaults);
+        if (!is_array($existingOptions)) {
+            if (function_exists('error_log')) {
+                error_log('Sidebar JLG settings option was not an array. Resetting to defaults.');
+            }
+            $existingOptions = $defaults;
+        }
         $preparedInput = is_array($input) ? $input : [];
 
         $sanitizedInput = array_merge(
-            $this->sanitize_general_settings($preparedInput, $existingOptions),
-            $this->sanitize_style_settings($preparedInput, $existingOptions),
-            $this->sanitize_effects_settings($preparedInput, $existingOptions),
-            $this->sanitize_menu_settings($preparedInput, $existingOptions),
-            $this->sanitize_social_settings($preparedInput, $existingOptions)
+            $this->sanitize_general_settings($preparedInput, $existingOptions) ?: [],
+            $this->sanitize_style_settings($preparedInput, $existingOptions) ?: [],
+            $this->sanitize_effects_settings($preparedInput, $existingOptions) ?: [],
+            $this->sanitize_menu_settings($preparedInput, $existingOptions) ?: [],
+            $this->sanitize_social_settings($preparedInput, $existingOptions) ?: []
         );
 
         return array_merge($existingOptions, $sanitizedInput);

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -25,6 +25,7 @@ $existing_options = array_merge($defaults->all(), [
     'overlay_color'   => 'rgba(10, 20, 30, 0.8)',
     'overlay_opacity' => 0.4,
 ]);
+$expected_overlay_existing = preg_replace('/\s+/', '', $existing_options['overlay_color']);
 
 $testsPassed = true;
 
@@ -44,7 +45,7 @@ $input_invalid = [
 
 $result_invalid = $method->invoke($sanitizer, $input_invalid, $existing_options);
 
-assertSame('rgba(10, 20, 30, 0.8)', $result_invalid['overlay_color'] ?? '', 'Overlay color falls back to existing value on invalid input');
+assertSame($expected_overlay_existing, $result_invalid['overlay_color'] ?? '', 'Overlay color falls back to existing value on invalid input');
 assertSame(1.0, $result_invalid['overlay_opacity'] ?? null, 'Overlay opacity is capped at 1.0');
 
 $input_valid = [

--- a/tests/sanitize_settings_corrupted_option_test.php
+++ b/tests/sanitize_settings_corrupted_option_test.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Admin\SettingsSanitizer;
+use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\DefaultSettings;
+
+require __DIR__ . '/bootstrap.php';
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$defaults = new DefaultSettings();
+$icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
+$sanitizer = new SettingsSanitizer($defaults, $icons);
+
+$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = 'totally-invalid-settings';
+
+$input = [
+    'enable_sidebar' => '1',
+];
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+function assertSame($expected, $actual, string $message): void
+{
+    if ($expected === $actual) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    global $testsPassed;
+    $testsPassed = false;
+    echo "[FAIL] {$message}. Expected `" . var_export($expected, true) . "`, got `" . var_export($actual, true) . "`.\n";
+}
+
+$sanitized = $sanitizer->sanitize_settings($input);
+$defaultSettings = $defaults->all();
+$normalizedOverlayDefault = preg_replace('/\s+/', '', $defaultSettings['overlay_color']);
+
+assertTrue(is_array($sanitized), 'Sanitized settings returns an array for corrupted stored options');
+assertSame(true, $sanitized['enable_sidebar'] ?? null, 'Enable sidebar flag keeps submitted truthy value');
+assertSame($defaultSettings['layout_style'], $sanitized['layout_style'] ?? null, 'Layout style falls back to default when missing from input');
+assertSame($normalizedOverlayDefault, $sanitized['overlay_color'] ?? null, 'Overlay color falls back to default when missing from input');
+assertSame($defaultSettings['social_position'], $sanitized['social_position'] ?? null, 'Social position falls back to default when missing from input');
+
+if (!$testsPassed) {
+    exit(1);
+}
+
+echo "All tests passed.\n";


### PR DESCRIPTION
## Summary
- guard the settings sanitizer against corrupted stored option values before running section sanitizers
- ensure the merged sanitize payload always works with arrays and log when defaults are restored
- add regression coverage for corrupted options and adjust assertions for normalized RGBA fallbacks

## Testing
- php tests/sanitize_settings_corrupted_option_test.php
- php tests/sanitize_general_settings_test.php
- php tests/sanitize_style_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68cf185f97f8832e8aa81ee0c9ab30d9