### PR TITLE
Invalidate cache on plugin version changes

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -29,6 +29,10 @@ register_activation_hook(__FILE__, static function () {
     if (!is_dir($iconsDir)) {
         wp_mkdir_p($iconsDir);
     }
+
+    update_option('sidebar_jlg_plugin_version', SIDEBAR_JLG_VERSION);
+
+    plugin()->getMenuCache()->clear();
 });
 
 function plugin(): Plugin

--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -54,6 +54,8 @@ class Plugin
 
     public function register(): void
     {
+        $this->maybeInvalidateCacheOnVersionChange();
+
         $this->settings->revalidateStoredOptions();
         $this->menuPage->registerHooks();
         $this->renderer->registerHooks();
@@ -73,6 +75,16 @@ class Plugin
 
         foreach ($contentChangeHooks as $hook) {
             add_action($hook, [$this->cache, 'clear'], 10, 0);
+        }
+    }
+
+    private function maybeInvalidateCacheOnVersionChange(): void
+    {
+        $storedVersion = get_option('sidebar_jlg_plugin_version');
+
+        if ($storedVersion !== $this->version) {
+            $this->cache->clear();
+            update_option('sidebar_jlg_plugin_version', $this->version);
         }
     }
 


### PR DESCRIPTION
## Summary
- track the plugin version in a dedicated option and invalidate the cache when it changes
- initialize the stored version and clear the menu cache during activation to cover manual reactivations

## Testing
- php -l sidebar-jlg/src/Plugin.php
- php -l sidebar-jlg/sidebar-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68cf38c210f4832eaba4ce8b55515c51