### PR TITLE
Validate custom SVG use references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Après activation, un menu "Sidebar JLG" apparait dans l'administration. Vous po
 
 - Seuls les fichiers au format `.svg` sont chargés par le plugin. Chaque fichier est contrôlé avec `wp_check_filetype()` avant d'être ajouté à la bibliothèque.
 - Le contenu SVG est validé via `wp_kses`. Les fichiers dont le contenu est altéré par le nettoyage ou qui contiennent des éléments non autorisés sont ignorés pour éviter toute contamination.
+- Un contrôle supplémentaire inspecte les attributs `href`/`xlink:href` des balises `<use>` afin de s'assurer qu'ils pointent uniquement vers un identifiant local ou vers un média de la bibliothèque (`wp-content/uploads`). Les validations spécifiques sont centralisées dans `Sidebar\JLG\Icons\IconLibrary::validateSanitizedSvg()` pour simplifier l'ajout de nouvelles règles de sécurité.
 
 ## Désinstallation
 


### PR DESCRIPTION
## Summary
- parse sanitized custom SVGs before accepting them into the icon library
- flag unsafe <use> href/xlink:href values and blank them during post-processing while rejecting icons we cannot reserialize
- document the new SVG validation hook point for future contributors

## Testing
- php -l sidebar-jlg/src/Icons/IconLibrary.php

------
https://chatgpt.com/codex/tasks/task_e_68cf41246604832e913239b1e8b9b106