### PR TITLE
Harden custom icon <use> validation

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -182,6 +182,54 @@ if (!function_exists('trailingslashit')) {
     }
 }
 
+if (!function_exists('wp_normalize_path')) {
+    function wp_normalize_path($path)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        $path = (string) $path;
+
+        if ($path === '') {
+            return '';
+        }
+
+        $path = str_replace("\\", '/', $path);
+
+        while (strpos($path, '//') !== false) {
+            $path = str_replace('//', '/', $path);
+        }
+
+        if (strlen($path) > 1 && ':' === substr($path, 1, 1)) {
+            $path = ucfirst($path);
+        }
+
+        return $path;
+    }
+}
+
+if (!function_exists('wp_parse_url')) {
+    function wp_parse_url($url, $component = -1)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        if ($component === -1) {
+            $parts = parse_url((string) $url);
+
+            return $parts === false ? false : $parts;
+        }
+
+        return parse_url((string) $url, $component);
+    }
+}
+
 if (!function_exists('plugin_dir_path')) {
     function plugin_dir_path($file): string
     {

--- a/tests/custom_icon_traversal_rejection_test.php
+++ b/tests/custom_icon_traversal_rejection_test.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Icons\IconLibrary;
+
+require __DIR__ . '/bootstrap.php';
+
+$uploads = wp_upload_dir();
+$uploadsBaseDir = rtrim((string) ($uploads['basedir'] ?? ''), "/\\");
+$iconsRootDir = $uploadsBaseDir . '/sidebar-jlg';
+$iconsDir = $iconsRootDir . '/icons';
+
+if ($uploadsBaseDir === '') {
+    echo "[FAIL] Upload base directory is not defined.\n";
+    exit(1);
+}
+
+if (is_dir($iconsRootDir)) {
+    $iterator = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($iconsRootDir, \FilesystemIterator::SKIP_DOTS),
+        \RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($iterator as $file) {
+        if ($file->isDir()) {
+            rmdir($file->getPathname());
+            continue;
+        }
+
+        unlink($file->getPathname());
+    }
+}
+
+if (!is_dir($iconsDir) && !mkdir($iconsDir, 0777, true) && !is_dir($iconsDir)) {
+    echo "[FAIL] Unable to prepare custom icons directory.\n";
+    exit(1);
+}
+
+$evilSvgPath = $uploadsBaseDir . '/evil.svg';
+file_put_contents($evilSvgPath, '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+
+$baseUrl = trailingslashit((string) ($uploads['baseurl'] ?? '')) . 'sidebar-jlg/icons';
+$maliciousSvg = <<<SVG
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <use xlink:href="{$baseUrl}/../evil.svg" />
+</svg>
+SVG;
+
+file_put_contents($iconsDir . '/bad.svg', $maliciousSvg);
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$iconLibrary = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
+$allIcons = $iconLibrary->getAllIcons();
+$rejected = $iconLibrary->consumeRejectedCustomIcons();
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+function assertFalse($condition, string $message): void
+{
+    assertTrue(!$condition, $message);
+}
+
+function assertContains(string $needle, array $haystack, string $message): void
+{
+    assertTrue(in_array($needle, $haystack, true), $message);
+}
+
+assertFalse(isset($allIcons['custom_bad']), 'Malicious icon is rejected from the library');
+assertContains('bad.svg', $rejected, 'Malicious icon is reported as rejected');
+
+@unlink($iconsDir . '/bad.svg');
+@unlink($evilSvgPath);
+if (is_dir($iconsDir)) {
+    @rmdir($iconsDir);
+}
+if (is_dir($iconsRootDir)) {
+    @rmdir($iconsRootDir);
+}
+
+if ($testsPassed) {
+    echo "Custom icon traversal rejection test passed.\n";
+    exit(0);
+}
+
+echo "Custom icon traversal rejection test failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- parse and validate external <use> references to ensure they stay within the uploads directory
- fail SVG sanitization when an unsafe <use> reference is encountered
- add regression coverage and bootstrap stubs for the new WordPress helpers

## Testing
- `for test in tests/*_test.php; do php "$test" || break; echo; done`


------
https://chatgpt.com/codex/tasks/task_e_68cfdf7e0af0832eb1d3208cd3046aad