### PR TITLE
Sanitize and normalize sidebar border color

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -54,7 +54,10 @@ class SettingsSanitizer
             $existingOptions['border_radius']
         );
         $sanitized['border_width'] = absint($input['border_width'] ?? $existingOptions['border_width']);
-        $sanitized['border_color'] = sanitize_text_field($input['border_color'] ?? $existingOptions['border_color']);
+        $sanitized['border_color'] = $this->sanitize_color_with_existing(
+            $input['border_color'] ?? null,
+            $existingOptions['border_color'] ?? ''
+        );
         $sanitized['desktop_behavior'] = sanitize_key($input['desktop_behavior'] ?? $existingOptions['desktop_behavior']);
         $sanitized['overlay_color'] = $this->sanitize_color_with_existing(
             $input['overlay_color'] ?? null,

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -41,21 +41,29 @@ function assertSame($expected, $actual, string $message): void
 $input_invalid = [
     'overlay_color'   => 'not-a-color',
     'overlay_opacity' => 1.7,
+    'border_color'    => '#fff; background: url(javascript:alert(1))',
 ];
 
 $result_invalid = $method->invoke($sanitizer, $input_invalid, $existing_options);
 
 assertSame($expected_overlay_existing, $result_invalid['overlay_color'] ?? '', 'Overlay color falls back to existing value on invalid input');
 assertSame(1.0, $result_invalid['overlay_opacity'] ?? null, 'Overlay opacity is capped at 1.0');
+assertSame(
+    $existing_options['border_color'],
+    $result_invalid['border_color'] ?? '',
+    'Border color falls back to existing value when sanitized input is invalid'
+);
 
 $input_valid = [
     'overlay_color'   => '#ABCDEF',
+    'border_color'    => '#EECCDD',
 ];
 
 $result_valid = $method->invoke($sanitizer, $input_valid, $existing_options);
 
 assertSame('#abcdef', $result_valid['overlay_color'] ?? '', 'Overlay color accepts valid hex values');
 assertSame(0.4, $result_valid['overlay_opacity'] ?? null, 'Overlay opacity falls back to existing value when missing');
+assertSame('#eeccdd', $result_valid['border_color'] ?? '', 'Border color accepts valid hex values without modification');
 
 $input_close_on_click = [
     'close_on_link_click' => '1',


### PR DESCRIPTION
## Summary
- sanitize the border color setting using the same color-specific helper as other color fields
- normalize stored border color options when revalidating saved settings
- extend general settings sanitization tests to cover valid and malicious border color inputs

## Testing
- php tests/sanitize_general_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68cfea8ec6a4832ea452b52119b178df