### PR TITLE
Sanitize stored border color values

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -42,6 +42,7 @@ class SettingsSanitizer
     private function sanitize_general_settings(array $input, array $existingOptions): array
     {
         $sanitized = [];
+        $defaults = $this->defaults->all();
 
         $sanitized['enable_sidebar'] = !empty($input['enable_sidebar']);
         $sanitized['layout_style'] = sanitize_key($input['layout_style'] ?? $existingOptions['layout_style']);
@@ -54,9 +55,12 @@ class SettingsSanitizer
             $existingOptions['border_radius']
         );
         $sanitized['border_width'] = absint($input['border_width'] ?? $existingOptions['border_width']);
+        $existingBorderColor = array_key_exists('border_color', $existingOptions)
+            ? $existingOptions['border_color']
+            : ($defaults['border_color'] ?? '');
         $sanitized['border_color'] = $this->sanitize_color_with_existing(
             $input['border_color'] ?? null,
-            $existingOptions['border_color'] ?? ''
+            $existingBorderColor
         );
         $sanitized['desktop_behavior'] = sanitize_key($input['desktop_behavior'] ?? $existingOptions['desktop_behavior']);
         $sanitized['overlay_color'] = $this->sanitize_color_with_existing(

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -63,9 +63,10 @@ class SettingsRepository
         $merged = wp_parse_args($stored, $defaults);
         $revalidated = $this->revalidateCustomIcons($merged);
 
+        $fallbackBorderColor = $defaults['border_color'] ?? '';
         $normalizedBorderColor = $this->normalizeColorWithExisting(
             $revalidated['border_color'] ?? null,
-            $defaults['border_color'] ?? ''
+            $fallbackBorderColor
         );
 
         if (($revalidated['border_color'] ?? '') !== $normalizedBorderColor) {

--- a/tests/revalidate_border_color_test.php
+++ b/tests/revalidate_border_color_test.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
+
+require __DIR__ . '/bootstrap.php';
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$defaults = new DefaultSettings();
+$icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
+$repository = new SettingsRepository($defaults, $icons);
+
+$defaultSettings = $defaults->all();
+$defaultBorderColor = $defaultSettings['border_color'];
+
+$testsPassed = true;
+
+function assertSame($expected, $actual, string $message): void
+{
+    if ($expected === $actual) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    global $testsPassed;
+    $testsPassed = false;
+    echo "[FAIL] {$message}. Expected `" . var_export($expected, true) . "`, got `" . var_export($actual, true) . "`.\n";
+}
+
+$maliciousBorderColor = '#fff; background: url(javascript:alert(1))';
+$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
+    'border_color' => $maliciousBorderColor,
+];
+
+$repository->revalidateStoredOptions();
+$storedAfterRevalidation = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+
+assertSame(
+    $defaultBorderColor,
+    $storedAfterRevalidation['border_color'] ?? null,
+    'Border color falls back to the default when persisted value includes CSS injection'
+);
+
+$validBorderColor = '#123abc';
+$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
+    'border_color' => $validBorderColor,
+];
+
+$repository->revalidateStoredOptions();
+$storedAfterValidRevalidation = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+
+assertSame(
+    $validBorderColor,
+    $storedAfterValidRevalidation['border_color'] ?? null,
+    'Border color keeps a valid persisted value after revalidation'
+);
+
+if (!$testsPassed) {
+    exit(1);
+}
+
+echo "All tests passed.\n";


### PR DESCRIPTION
## Summary
- ensure general settings reuse the color sanitizer for border colors with a fallback value
- normalize persisted border colors during stored option revalidation
- add a regression test covering malicious and valid border color values

## Testing
- php tests/sanitize_general_settings_test.php
- php tests/revalidate_border_color_test.php

------
https://chatgpt.com/codex/tasks/task_e_68cfef24a328832ea4555d50e5195af0