### PR TITLE
Use esc_url for header logo image

### DIFF
--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -166,9 +166,9 @@
                         </div>
                         <div class="header-image-options" style="<?php echo $options['header_logo_type'] === 'image' ? '' : 'display:none;'; ?>">
                             <p>
-                                <input type="hidden" name="sidebar_jlg_settings[header_logo_image]" class="header-logo-image-url" value="<?php echo esc_attr($options['header_logo_image']); ?>">
+                                <input type="hidden" name="sidebar_jlg_settings[header_logo_image]" class="header-logo-image-url" value="<?php echo esc_url($options['header_logo_image']); ?>">
                                 <button type="button" class="button upload-logo-button"><?php esc_html_e('Choisir un logo', 'sidebar-jlg'); ?></button>
-                                <span class="logo-preview"><img src="<?php echo esc_attr($options['header_logo_image']); ?>" style="<?php echo empty($options['header_logo_image']) ? 'display:none;' : ''; ?>"></span>
+                                <span class="logo-preview"><img src="<?php echo esc_url($options['header_logo_image']); ?>" style="<?php echo empty($options['header_logo_image']) ? 'display:none;' : ''; ?>"></span>
                             </p>
                             <p><label><?php esc_html_e( 'Largeur du logo', 'sidebar-jlg' ); ?></label> <input type="number" name="sidebar_jlg_settings[header_logo_size]" value="<?php echo esc_attr( $options['header_logo_size'] ); ?>" class="small-text"/> px</p>
                         </div>


### PR DESCRIPTION
## Summary
- replace esc_attr with esc_url for the header logo URL in the admin page to ensure it is correctly escaped for use in src and value attributes

## Testing
- not run (WordPress environment not available)

------
https://chatgpt.com/codex/tasks/task_e_68d045c6aed8832eb09001d5addcb999