### PR TITLE
Replace str_starts_with usage for PHP 7

### DIFF
--- a/sidebar-jlg/src/Icons/IconLibrary.php
+++ b/sidebar-jlg/src/Icons/IconLibrary.php
@@ -338,7 +338,7 @@ class IconLibrary
             return true;
         }
 
-        if (str_starts_with($value, '#')) {
+        if (strncmp($value, '#', 1) === 0) {
             return (bool) preg_match('/^#[A-Za-z0-9_][A-Za-z0-9:._-]*$/', $value);
         }
 
@@ -404,7 +404,7 @@ class IconLibrary
         $normalizedReferencePath = wp_normalize_path($decodedReferencePath);
         $expectedPrefix = $normalizedBasePath === '' ? '/' : $normalizedBasePath . '/';
 
-        if (!str_starts_with($normalizedReferencePath, $expectedPrefix)) {
+        if (strncmp($normalizedReferencePath, $expectedPrefix, strlen($expectedPrefix)) !== 0) {
             return false;
         }
 
@@ -418,6 +418,6 @@ class IconLibrary
         $normalizedUploadsDirWithSlash = trailingslashit($normalizedUploadsDir);
         $resolvedPath = wp_normalize_path($normalizedUploadsDirWithSlash . $relativePath);
 
-        return str_starts_with($resolvedPath, $normalizedUploadsDirWithSlash);
+        return strncmp($resolvedPath, $normalizedUploadsDirWithSlash, strlen($normalizedUploadsDirWithSlash)) === 0;
     }
 }


### PR DESCRIPTION
## Summary
- replace str_starts_with checks in IconLibrary::isSafeUseReference with strncmp equivalents to support PHP 7 environments

## Testing
- php -l sidebar-jlg/src/Icons/IconLibrary.php

------
https://chatgpt.com/codex/tasks/task_e_68d05c6d7fe8832e9b3141257fd4e009