### PR TITLE
Load plugin text domain on plugins_loaded

### DIFF
--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -56,6 +56,8 @@ class Plugin
     {
         $this->maybeInvalidateCacheOnVersionChange();
 
+        add_action('plugins_loaded', [$this, 'loadTextdomain']);
+
         $this->settings->revalidateStoredOptions();
         $this->menuPage->registerHooks();
         $this->renderer->registerHooks();
@@ -76,6 +78,11 @@ class Plugin
         foreach ($contentChangeHooks as $hook) {
             add_action($hook, [$this->cache, 'clear'], 10, 0);
         }
+    }
+
+    public function loadTextdomain(): void
+    {
+        load_plugin_textdomain('sidebar-jlg', false, dirname(plugin_basename($this->pluginFile)) . '/languages');
     }
 
     private function maybeInvalidateCacheOnVersionChange(): void


### PR DESCRIPTION
## Summary
- hook into `plugins_loaded` during plugin registration
- load the `sidebar-jlg` text domain from the plugin languages directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d07e032448832e9a58ec5f5af37dd4