### PR TITLE
Ensure cache clearing when settings are revalidated

### DIFF
--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -57,13 +57,12 @@ class Plugin
         $this->maybeInvalidateCacheOnVersionChange();
 
         add_action('plugins_loaded', [$this, 'loadTextdomain']);
+        add_action('update_option_sidebar_jlg_settings', [$this->cache, 'clear'], 10, 0);
 
         $this->settings->revalidateStoredOptions();
         $this->menuPage->registerHooks();
         $this->renderer->registerHooks();
         $this->ajax->registerHooks();
-
-        add_action('update_option_sidebar_jlg_settings', [$this->cache, 'clear'], 10, 0);
 
         $contentChangeHooks = [
             'save_post',


### PR DESCRIPTION
## Summary
- register the sidebar settings update hook before revalidating stored options so cache clear runs during corrections
- extend the locale cache test suite to confirm revalidation purges cached transients when fixing corrupted options

## Testing
- php tests/sidebar_locale_cache_test.php
- php tests/revalidate_border_color_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d1813a1ce8832e8051f675a9d23473