### PR TITLE
Normalize stored CSS dimensions during revalidation

### DIFF
--- a/tests/revalidate_css_dimension_test.php
+++ b/tests/revalidate_css_dimension_test.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+use function JLG\Sidebar\plugin;
+
+require __DIR__ . '/bootstrap.php';
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$plugin = plugin();
+$repository = $plugin->getSettingsRepository();
+$renderer = $plugin->getSidebarRenderer();
+$menuCache = $plugin->getMenuCache();
+
+$defaults = $repository->getDefaultSettings();
+$defaultContentMargin = $defaults['content_margin'] ?? '';
+
+$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
+    'enable_sidebar' => true,
+    'content_margin' => '',
+];
+
+$menuCache->clear();
+$repository->revalidateStoredOptions();
+
+$storedAfterRevalidation = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+
+$testsPassed = true;
+
+function assertSame($expected, $actual, string $message): void
+{
+    if ($expected === $actual) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    global $testsPassed;
+    $testsPassed = false;
+    echo "[FAIL] {$message}. Expected `" . var_export($expected, true) . "`, got `" . var_export($actual, true) . "`.\n";
+}
+
+function assertContains(string $needle, string $haystack, string $message): void
+{
+    if (strpos($haystack, $needle) !== false) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    global $testsPassed;
+    $testsPassed = false;
+    echo "[FAIL] {$message}. Needle `{$needle}` not found.\n";
+}
+
+assertSame(
+    $defaultContentMargin,
+    $storedAfterRevalidation['content_margin'] ?? null,
+    'Content margin reverts to default when stored value is empty'
+);
+
+ob_start();
+$renderer->render();
+$html = ob_get_clean();
+
+$expectedCss = '--content-margin: calc(var(--sidebar-width-desktop) + ' . $defaultContentMargin . ');';
+assertContains($expectedCss, $html, 'Rendered CSS uses default content margin after revalidation');
+
+if (!$testsPassed) {
+    exit(1);
+}
+
+echo "All tests passed.\n";


### PR DESCRIPTION
## Summary
- normalize stored CSS dimension options during repository revalidation
- reuse sanitizer logic to accept valid units/calc expressions and fall back to defaults
- add regression test ensuring the default content margin is restored when the stored value is empty

## Testing
- php tests/revalidate_css_dimension_test.php
- php tests/revalidate_border_color_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d26ba77664832e8250d577783cd9d5