### PR TITLE
Refactor dimension normalization keys

### DIFF
--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -6,6 +6,14 @@ use JLG\Sidebar\Icons\IconLibrary;
 
 class SettingsRepository
 {
+    private const DIMENSION_OPTION_KEYS = [
+        'content_margin',
+        'floating_vertical_margin',
+        'border_radius',
+        'hamburger_top_position',
+        'header_padding_top',
+    ];
+
     private DefaultSettings $defaults;
     private IconLibrary $icons;
 
@@ -73,15 +81,7 @@ class SettingsRepository
             $revalidated['border_color'] = $normalizedBorderColor;
         }
 
-        $dimensionDefaults = [
-            'content_margin',
-            'floating_vertical_margin',
-            'border_radius',
-            'hamburger_top_position',
-            'header_padding_top',
-        ];
-
-        foreach ($dimensionDefaults as $dimensionKey) {
+        foreach (self::DIMENSION_OPTION_KEYS as $dimensionKey) {
             $defaultValue = $defaults[$dimensionKey] ?? '';
             $normalizedValue = $this->normalizeCssDimension($revalidated[$dimensionKey] ?? null, $defaultValue);
 


### PR DESCRIPTION
## Summary
- declare a class constant listing the dimension option keys that need normalization
- use the constant when normalizing stored dimension options for clarity

## Testing
- php tests/revalidate_css_dimension_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d2702db668832e9bc1fed7d05b9081