### PR TITLE
Add search filtering controls to menu item selectors

### DIFF
--- a/sidebar-jlg/assets/css/admin-style.css
+++ b/sidebar-jlg/assets/css/admin-style.css
@@ -20,6 +20,36 @@ input:checked + .jlg-slider:before { transform: translateX(26px); }
 .menu-item-content { padding: 10px; border-top: 1px solid #ddd; }
 .menu-item-content p { margin-top: 0; }
 .menu-item-content .widefat { width: 100%; }
+.menu-item-value-wrapper .menu-item-search-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+.menu-item-value-wrapper .menu-item-search-row > label {
+    min-width: 90px;
+}
+.menu-item-search-container {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    flex: 1 1 260px;
+}
+.menu-item-search-container select.widefat {
+    width: auto;
+    flex: 1 1 220px;
+}
+.menu-item-search-container .menu-item-search-input {
+    flex: 1 1 200px;
+    min-width: 180px;
+    padding: 4px 8px;
+}
+.menu-item-async-message {
+    margin-top: 6px;
+    font-style: italic;
+    color: #50575e;
+}
 .icon-preview svg, .icon-preview img { width: 20px; height: 20px; vertical-align: middle; margin-left: 10px; }
 .menu-item-placeholder { border: 2px dashed #ccc; background-color: #f0f0f0; height: 50px; margin-bottom: 10px; }
 

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -420,7 +420,14 @@
                     <option value="category" <# if (data.type === 'category') { #>selected<# } #>>Catégorie</option>
                 </select>
             </p>
-            <div class="menu-item-value-wrapper"></div>
+            <div class="menu-item-value-wrapper">
+                <div class="menu-item-value-fields">
+                    <div class="menu-item-search-container" style="display:none;">
+                        <input type="search" class="menu-item-search-input" placeholder="<?php esc_attr_e( 'Rechercher…', 'sidebar-jlg' ); ?>" />
+                    </div>
+                </div>
+                <div class="menu-item-async-message" aria-live="polite"></div>
+            </div>
             <p><label>Icône</label>
                 <select class="widefat menu-item-icon-type" name="sidebar_jlg_settings[menu_items][{{ data.index }}][icon_type]">
                     <option value="svg_inline" <# if (data.icon_type === 'svg_inline') { #>selected<# } #>>Icône de la bibliothèque</option>

--- a/sidebar-jlg/src/Ajax/Endpoints.php
+++ b/sidebar-jlg/src/Ajax/Endpoints.php
@@ -39,6 +39,10 @@ class Endpoints
         }
 
         check_ajax_referer('jlg_ajax_nonce', 'nonce');
+        $searchTerm = '';
+        if (isset($_POST['search'])) {
+            $searchTerm = sanitize_text_field(wp_unslash($_POST['search']));
+        }
         $page = isset($_POST['page']) ? max(1, intval(wp_unslash($_POST['page']))) : 1;
         $maxPerPage = 50;
         $requestedPerPage = isset($_POST['posts_per_page']) ? intval(wp_unslash($_POST['posts_per_page'])) : 20;
@@ -58,11 +62,17 @@ class Endpoints
             $includeIds = array_filter(array_map('absint', $includeSource));
         }
 
-        $posts = get_posts([
+        $postArgs = [
             'posts_per_page' => $perPage,
             'paged' => $page,
             'post_type' => $postType,
-        ]);
+        ];
+
+        if ($searchTerm !== '') {
+            $postArgs['s'] = $searchTerm;
+        }
+
+        $posts = get_posts($postArgs);
 
         $optionsById = [];
         foreach ($posts as $post) {
@@ -113,6 +123,10 @@ class Endpoints
         }
 
         check_ajax_referer('jlg_ajax_nonce', 'nonce');
+        $searchTerm = '';
+        if (isset($_POST['search'])) {
+            $searchTerm = sanitize_text_field(wp_unslash($_POST['search']));
+        }
         $page = isset($_POST['page']) ? max(1, intval(wp_unslash($_POST['page']))) : 1;
         $maxPerPage = 50;
         $requestedPerPage = isset($_POST['posts_per_page']) ? intval(wp_unslash($_POST['posts_per_page'])) : 20;
@@ -130,11 +144,17 @@ class Endpoints
             $includeIds = array_filter(array_map('absint', $includeSource));
         }
 
-        $categories = get_categories([
+        $categoryArgs = [
             'hide_empty' => false,
             'number' => $perPage,
             'offset' => $offset,
-        ]);
+        ];
+
+        if ($searchTerm !== '') {
+            $categoryArgs['search'] = $searchTerm;
+        }
+
+        $categories = get_categories($categoryArgs);
 
         $optionsById = [];
         foreach ($categories as $category) {

--- a/tests/ajax_endpoints_test.php
+++ b/tests/ajax_endpoints_test.php
@@ -360,6 +360,23 @@ assertSame('post__in', $GLOBALS['test_get_posts_requests'][1]['orderby'] ?? null
 assertSame('post', $GLOBALS['test_get_posts_requests'][1]['post_type'] ?? null, 'Posts include lookup respects post type');
 
 reset_test_environment();
+$GLOBALS['test_get_posts_queue'] = [
+    ['return' => []],
+];
+$_POST = [
+    'nonce' => 'posts-search',
+    'page' => '2',
+    'post_type' => 'page',
+    'search' => '  <b>Focus</b>  ',
+];
+invoke_endpoint($endpoints, 'ajax_get_posts');
+assertSame('Focus', $GLOBALS['test_get_posts_requests'][0]['s'] ?? null, 'Posts search parameter sanitized');
+assertSame(2, $GLOBALS['test_get_posts_requests'][0]['paged'] ?? null, 'Posts search respects requested page');
+assertSame('page', $GLOBALS['test_get_posts_requests'][0]['post_type'] ?? null, 'Posts search respects requested post type');
+assertSame(1, count($GLOBALS['test_get_posts_requests']), 'Posts search performs a single query without include lookup');
+assertSame([], $GLOBALS['json_success_payloads'][0] ?? null, 'Posts search request returns results array');
+
+reset_test_environment();
 $GLOBALS['test_current_user_can'] = false;
 invoke_endpoint($endpoints, 'ajax_get_categories');
 assertSame('Permission refusée.', $GLOBALS['json_error_payloads'][0] ?? null, 'Unauthorized categories request rejected');
@@ -413,6 +430,23 @@ assertSame(false, $GLOBALS['test_get_categories_requests'][1]['hide_empty'] ?? n
 assertSame([9, 10], array_values($GLOBALS['test_get_categories_requests'][1]['include'] ?? []), 'Categories include lookup requests missing IDs in order');
 assertSame(2, $GLOBALS['test_get_categories_requests'][1]['number'] ?? null, 'Categories include lookup limited to missing IDs');
 assertSame('include', $GLOBALS['test_get_categories_requests'][1]['orderby'] ?? null, 'Categories include lookup orders by requested IDs');
+
+reset_test_environment();
+$GLOBALS['test_get_categories_queue'] = [
+    ['return' => []],
+];
+$_POST = [
+    'nonce' => 'cats-search',
+    'page' => '3',
+    'posts_per_page' => '2',
+    'search' => '  chats ',
+];
+invoke_endpoint($endpoints, 'ajax_get_categories');
+assertSame('chats', $GLOBALS['test_get_categories_requests'][0]['search'] ?? null, 'Categories search parameter sanitized');
+assertSame(2, $GLOBALS['test_get_categories_requests'][0]['number'] ?? null, 'Categories search respects per-page value');
+assertSame(4, $GLOBALS['test_get_categories_requests'][0]['offset'] ?? null, 'Categories search computes offset from page');
+assertSame(1, count($GLOBALS['test_get_categories_requests']), 'Categories search performs a single query');
+assertSame([], $GLOBALS['json_success_payloads'][0] ?? null, 'Categories search request returns results array');
 
 reset_test_environment();
 $GLOBALS['test_current_user_can'] = false;


### PR DESCRIPTION
## Summary
- add a reusable search input and message container next to the AJAX-powered menu item selector
- debounce search input in the admin script, include the search term in cache keys and AJAX payloads, and clear caches on search change
- accept sanitized `search` parameters in post and category endpoints, and add endpoint tests for the new filtering behaviour
- tweak admin styles to lay out the new search control and feedback text

## Testing
- php tests/ajax_endpoints_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d27cb27b90832e9407f5f5bdea8d51