### PR TITLE
Fix cache toggle and custom SVG validation

### DIFF
--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -70,7 +70,7 @@ class SidebarRenderer
         $currentLocale = $this->cache->getLocaleForCache();
         $transientKey = $this->cache->getTransientKey($currentLocale);
 
-        $cacheEnabled = \apply_filters(
+        $cacheEnabled = (bool) \apply_filters(
             'sidebar_jlg_cache_enabled',
             !$this->is_sidebar_output_dynamic($options),
             $options,

--- a/sidebar-jlg/src/Icons/IconLibrary.php
+++ b/sidebar-jlg/src/Icons/IconLibrary.php
@@ -348,9 +348,23 @@ class IconLibrary
             }
         }
 
-        return [
-            'svg' => $sanitizedSvg,
+        $exportedSvg = $dom->saveXML($dom->documentElement);
+
+        if (!is_string($exportedSvg)) {
+            return null;
+        }
+
+        $exportedSvg = trim($exportedSvg);
+
+        $result = [
+            'svg' => $exportedSvg,
         ];
+
+        if ($this->normalizeSvgContent($sanitizedSvg) !== $this->normalizeSvgContent($exportedSvg)) {
+            $result['modified'] = true;
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
## Summary
- cast the sidebar cache toggle filter result to boolean so falsy values disable caching as expected
- re-export sanitized SVGs through DOMDocument and flag harmless normalizations to avoid rejecting valid custom icons

## Testing
- php -l sidebar-jlg/src/Frontend/SidebarRenderer.php
- php -l sidebar-jlg/src/Icons/IconLibrary.php

------
https://chatgpt.com/codex/tasks/task_e_68d3a5e356dc832e94e41728d7fd02ad