### PR TITLE
Handle activation failures and centralize value normalization

### DIFF
--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -57,7 +57,24 @@ register_activation_hook(__FILE__, static function () {
 
     $iconsDir = trailingslashit($baseDir) . 'sidebar-jlg/icons/';
     if (!is_dir($iconsDir)) {
-        wp_mkdir_p($iconsDir);
+        $created = wp_mkdir_p($iconsDir);
+
+        if (!$created) {
+            $message = __('Sidebar JLG n\'a pas pu créer le dossier d\'icônes. Vérifiez les permissions du dossier uploads puis réactivez le plugin.', 'sidebar-jlg');
+
+            if (function_exists('error_log')) {
+                error_log('[Sidebar JLG] Activation failed: unable to create icons directory.');
+            }
+
+            if (!function_exists('set_transient')) {
+                return;
+            }
+
+            $expiration = defined('HOUR_IN_SECONDS') ? HOUR_IN_SECONDS : 3600;
+            set_transient('sidebar_jlg_activation_error', $message, $expiration);
+
+            return;
+        }
     }
 
     update_option('sidebar_jlg_plugin_version', SIDEBAR_JLG_VERSION);

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -4,6 +4,7 @@ namespace JLG\Sidebar\Admin;
 
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\ValueNormalizer;
 
 class SettingsSanitizer
 {
@@ -46,11 +47,11 @@ class SettingsSanitizer
 
         $sanitized['enable_sidebar'] = !empty($input['enable_sidebar']);
         $sanitized['layout_style'] = sanitize_key($input['layout_style'] ?? $existingOptions['layout_style']);
-        $sanitized['floating_vertical_margin'] = $this->sanitize_css_dimension(
+        $sanitized['floating_vertical_margin'] = ValueNormalizer::normalizeCssDimension(
             $input['floating_vertical_margin'] ?? $existingOptions['floating_vertical_margin'],
             $existingOptions['floating_vertical_margin']
         );
-        $sanitized['border_radius'] = $this->sanitize_css_dimension(
+        $sanitized['border_radius'] = ValueNormalizer::normalizeCssDimension(
             $input['border_radius'] ?? $existingOptions['border_radius'],
             $existingOptions['border_radius']
         );
@@ -58,12 +59,12 @@ class SettingsSanitizer
         $existingBorderColor = array_key_exists('border_color', $existingOptions)
             ? $existingOptions['border_color']
             : ($defaults['border_color'] ?? '');
-        $sanitized['border_color'] = $this->sanitize_color_with_existing(
+        $sanitized['border_color'] = ValueNormalizer::normalizeColorWithExisting(
             $input['border_color'] ?? null,
             $existingBorderColor
         );
         $sanitized['desktop_behavior'] = sanitize_key($input['desktop_behavior'] ?? $existingOptions['desktop_behavior']);
-        $sanitized['overlay_color'] = $this->sanitize_color_with_existing(
+        $sanitized['overlay_color'] = ValueNormalizer::normalizeColorWithExisting(
             $input['overlay_color'] ?? null,
             $existingOptions['overlay_color'] ?? ''
         );
@@ -73,7 +74,7 @@ class SettingsSanitizer
         $sanitized['overlay_opacity'] = is_numeric($input['overlay_opacity'] ?? null)
             ? max(0.0, min(1.0, (float) $input['overlay_opacity']))
             : max(0.0, min(1.0, $existingOverlayOpacity));
-        $sanitized['content_margin'] = $this->sanitize_css_dimension(
+        $sanitized['content_margin'] = ValueNormalizer::normalizeCssDimension(
             $input['content_margin'] ?? $existingOptions['content_margin'],
             $existingOptions['content_margin']
         );
@@ -87,7 +88,7 @@ class SettingsSanitizer
         $sanitized['show_close_button'] = !empty($input['show_close_button']);
         // Checkbox -> boolean conversion for the automatic closing behaviour.
         $sanitized['close_on_link_click'] = !empty($input['close_on_link_click']);
-        $sanitized['hamburger_top_position'] = $this->sanitize_css_dimension(
+        $sanitized['hamburger_top_position'] = ValueNormalizer::normalizeCssDimension(
             $input['hamburger_top_position'] ?? $existingOptions['hamburger_top_position'],
             $existingOptions['hamburger_top_position']
         );
@@ -97,7 +98,7 @@ class SettingsSanitizer
         $sanitized['header_logo_size'] = absint($input['header_logo_size'] ?? $existingOptions['header_logo_size']);
         $sanitized['header_alignment_desktop'] = sanitize_key($input['header_alignment_desktop'] ?? $existingOptions['header_alignment_desktop']);
         $sanitized['header_alignment_mobile'] = sanitize_key($input['header_alignment_mobile'] ?? $existingOptions['header_alignment_mobile']);
-        $sanitized['header_padding_top'] = $this->sanitize_css_dimension(
+        $sanitized['header_padding_top'] = ValueNormalizer::normalizeCssDimension(
             $input['header_padding_top'] ?? $existingOptions['header_padding_top'],
             $existingOptions['header_padding_top']
         );
@@ -111,27 +112,27 @@ class SettingsSanitizer
         $sanitized['style_preset'] = sanitize_key($input['style_preset'] ?? $existingOptions['style_preset']);
 
         $sanitized['bg_color_type'] = sanitize_key($input['bg_color_type'] ?? $existingOptions['bg_color_type']);
-        $sanitized['bg_color'] = $this->sanitize_color_with_existing($input['bg_color'] ?? null, $existingOptions['bg_color']);
-        $sanitized['bg_color_start'] = $this->sanitize_color_with_existing($input['bg_color_start'] ?? null, $existingOptions['bg_color_start']);
-        $sanitized['bg_color_end'] = $this->sanitize_color_with_existing($input['bg_color_end'] ?? null, $existingOptions['bg_color_end']);
+        $sanitized['bg_color'] = ValueNormalizer::normalizeColorWithExisting($input['bg_color'] ?? null, $existingOptions['bg_color']);
+        $sanitized['bg_color_start'] = ValueNormalizer::normalizeColorWithExisting($input['bg_color_start'] ?? null, $existingOptions['bg_color_start']);
+        $sanitized['bg_color_end'] = ValueNormalizer::normalizeColorWithExisting($input['bg_color_end'] ?? null, $existingOptions['bg_color_end']);
 
         $sanitized['accent_color_type'] = sanitize_key($input['accent_color_type'] ?? $existingOptions['accent_color_type']);
-        $sanitized['accent_color'] = $this->sanitize_color_with_existing($input['accent_color'] ?? null, $existingOptions['accent_color']);
-        $sanitized['accent_color_start'] = $this->sanitize_color_with_existing($input['accent_color_start'] ?? null, $existingOptions['accent_color_start']);
-        $sanitized['accent_color_end'] = $this->sanitize_color_with_existing($input['accent_color_end'] ?? null, $existingOptions['accent_color_end']);
+        $sanitized['accent_color'] = ValueNormalizer::normalizeColorWithExisting($input['accent_color'] ?? null, $existingOptions['accent_color']);
+        $sanitized['accent_color_start'] = ValueNormalizer::normalizeColorWithExisting($input['accent_color_start'] ?? null, $existingOptions['accent_color_start']);
+        $sanitized['accent_color_end'] = ValueNormalizer::normalizeColorWithExisting($input['accent_color_end'] ?? null, $existingOptions['accent_color_end']);
 
         $sanitized['font_size'] = absint($input['font_size'] ?? $existingOptions['font_size']);
         $sanitized['font_color_type'] = sanitize_key($input['font_color_type'] ?? $existingOptions['font_color_type']);
-        $sanitized['font_color'] = $this->sanitize_color_with_existing($input['font_color'] ?? null, $existingOptions['font_color']);
-        $sanitized['font_color_start'] = $this->sanitize_color_with_existing($input['font_color_start'] ?? null, $existingOptions['font_color_start']);
-        $sanitized['font_color_end'] = $this->sanitize_color_with_existing($input['font_color_end'] ?? null, $existingOptions['font_color_end']);
+        $sanitized['font_color'] = ValueNormalizer::normalizeColorWithExisting($input['font_color'] ?? null, $existingOptions['font_color']);
+        $sanitized['font_color_start'] = ValueNormalizer::normalizeColorWithExisting($input['font_color_start'] ?? null, $existingOptions['font_color_start']);
+        $sanitized['font_color_end'] = ValueNormalizer::normalizeColorWithExisting($input['font_color_end'] ?? null, $existingOptions['font_color_end']);
 
         $sanitized['font_hover_color_type'] = sanitize_key($input['font_hover_color_type'] ?? $existingOptions['font_hover_color_type']);
-        $sanitized['font_hover_color'] = $this->sanitize_color_with_existing($input['font_hover_color'] ?? null, $existingOptions['font_hover_color']);
-        $sanitized['font_hover_color_start'] = $this->sanitize_color_with_existing($input['font_hover_color_start'] ?? null, $existingOptions['font_hover_color_start']);
-        $sanitized['font_hover_color_end'] = $this->sanitize_color_with_existing($input['font_hover_color_end'] ?? null, $existingOptions['font_hover_color_end']);
+        $sanitized['font_hover_color'] = ValueNormalizer::normalizeColorWithExisting($input['font_hover_color'] ?? null, $existingOptions['font_hover_color']);
+        $sanitized['font_hover_color_start'] = ValueNormalizer::normalizeColorWithExisting($input['font_hover_color_start'] ?? null, $existingOptions['font_hover_color_start']);
+        $sanitized['font_hover_color_end'] = ValueNormalizer::normalizeColorWithExisting($input['font_hover_color_end'] ?? null, $existingOptions['font_hover_color_end']);
 
-        $sanitized['mobile_bg_color'] = $this->sanitize_color_with_existing($input['mobile_bg_color'] ?? null, $existingOptions['mobile_bg_color']);
+        $sanitized['mobile_bg_color'] = ValueNormalizer::normalizeColorWithExisting($input['mobile_bg_color'] ?? null, $existingOptions['mobile_bg_color']);
         $existingOpacity = isset($existingOptions['mobile_bg_opacity']) ? (float) $existingOptions['mobile_bg_opacity'] : 0.0;
         $sanitized['mobile_bg_opacity'] = is_numeric($input['mobile_bg_opacity'] ?? null)
             ? max(0.0, min(1.0, (float) $input['mobile_bg_opacity']))
@@ -256,198 +257,4 @@ class SettingsSanitizer
         return $sanitized;
     }
 
-    private function sanitize_css_dimension($value, $fallback): string
-    {
-        $fallback = is_string($fallback) || is_numeric($fallback) ? (string) $fallback : '';
-        $sanitizedFallback = sanitize_text_field($fallback);
-
-        $value = is_string($value) || is_numeric($value) ? (string) $value : '';
-        $value = trim($value);
-
-        if ($value === '') {
-            return $sanitizedFallback;
-        }
-
-        $value = sanitize_text_field($value);
-
-        static $cache = null;
-        if ($cache === null) {
-            $allowedUnits = ['px', 'rem', 'em', '%', 'vh', 'vw', 'vmin', 'vmax', 'ch'];
-            $unitPattern = '(?:' . implode('|', array_map(static function ($unit) {
-                return preg_quote($unit, '/');
-            }, $allowedUnits)) . ')';
-
-            $cache = [
-                'numeric_pattern'   => '/^-?(?:\d+|\d*\.\d+)(?:' . $unitPattern . ')$/i',
-                'dimension_pattern' => '/^[-+]?(?:\d+|\d*\.\d+)(?:' . $unitPattern . ')?$/i',
-            ];
-        }
-
-        $numericPattern = $cache['numeric_pattern'];
-        $dimensionPattern = $cache['dimension_pattern'];
-
-        if (preg_match($numericPattern, $value)) {
-            return $value;
-        }
-
-        if ($this->is_valid_calc_expression($value, $dimensionPattern)) {
-            return $value;
-        }
-
-        if (preg_match('/^0(?:\.0+)?$/', $value)) {
-            return '0';
-        }
-
-        return $sanitizedFallback;
-    }
-
-    private function is_valid_calc_expression(string $value, string $dimensionPattern): bool
-    {
-        if (!preg_match('/^calc\((.*)\)$/i', $value, $matches)) {
-            return false;
-        }
-
-        $expression = trim($matches[1]);
-
-        if ($expression === '') {
-            return false;
-        }
-
-        if (!preg_match('/^[0-9+\-*\/().%a-z\s]+$/i', $expression)) {
-            return false;
-        }
-
-        $expression = preg_replace('/\s+/', '', $expression);
-
-        if ($expression === '') {
-            return false;
-        }
-
-        $length = strlen($expression);
-        $tokens = [];
-        $current = '';
-
-        for ($i = 0; $i < $length; $i++) {
-            $char = $expression[$i];
-
-            if (strpos('+-*/()', $char) !== false) {
-                if ($current !== '') {
-                    $tokens[] = $current;
-                    $current = '';
-                }
-
-                $tokens[] = $char;
-                continue;
-            }
-
-            $current .= $char;
-        }
-
-        if ($current !== '') {
-            $tokens[] = $current;
-        }
-
-        $balance = 0;
-        $prevToken = '';
-
-        foreach ($tokens as $token) {
-            if ($token === '(') {
-                $balance++;
-            } elseif ($token === ')') {
-                $balance--;
-
-                if ($balance < 0) {
-                    return false;
-                }
-            }
-
-            if (in_array($token, ['+', '-', '*', '/'], true)) {
-                if ($prevToken === '' || in_array($prevToken, ['+', '-', '*', '/', '('], true)) {
-                    return false;
-                }
-            } elseif (!in_array($token, ['(', ')'], true)) {
-                if (!preg_match($dimensionPattern, $token) && !preg_match('/^\d+(?:\.\d+)?$/', $token)) {
-                    return false;
-                }
-            }
-
-            $prevToken = $token;
-        }
-
-        return $balance === 0 && !in_array($prevToken, ['+', '-', '*', '/'], true);
-    }
-
-    private function sanitize_color_with_existing($value, $existingValue): string
-    {
-        $existingValue = (is_string($existingValue) || is_numeric($existingValue))
-            ? (string) $existingValue
-            : '';
-
-        $candidate = $value;
-        if ($candidate === null) {
-            $candidate = $existingValue;
-        }
-
-        $sanitizedCandidate = $this->sanitize_rgba_color($candidate);
-        if ($sanitizedCandidate !== '') {
-            return $sanitizedCandidate;
-        }
-
-        $sanitizedExisting = $this->sanitize_rgba_color($existingValue);
-        if ($sanitizedExisting !== '') {
-            return $sanitizedExisting;
-        }
-
-        return '';
-    }
-
-    private function sanitize_rgba_color($color): string
-    {
-        if (empty($color) || is_array($color)) {
-            return '';
-        }
-
-        $color = trim((string) $color);
-
-        if (0 !== stripos($color, 'rgba')) {
-            $sanitizedHex = sanitize_hex_color($color);
-            return $sanitizedHex ? $sanitizedHex : '';
-        }
-
-        $pattern = '/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(0|1|0?\.\d+|1\.0+)\s*\)$/i';
-
-        if (!preg_match($pattern, $color, $matches)) {
-            return '';
-        }
-
-        $r = (int) $matches[1];
-        $g = (int) $matches[2];
-        $b = (int) $matches[3];
-        $aValue = (float) $matches[4];
-
-        foreach ([$r, $g, $b] as $component) {
-            if ($component < 0 || $component > 255) {
-                return '';
-            }
-        }
-
-        if ($aValue < 0 || $aValue > 1) {
-            return '';
-        }
-
-        $alpha = $matches[4];
-
-        if ('.' === substr($alpha, 0, 1)) {
-            $alpha = '0' . $alpha;
-        }
-
-        $alpha = rtrim($alpha, '0');
-        $alpha = rtrim($alpha, '.');
-
-        if ('' === $alpha) {
-            $alpha = '0';
-        }
-
-        return sprintf('rgba(%d,%d,%d,%s)', $r, $g, $b, $alpha);
-    }
 }

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -90,6 +90,14 @@ class SidebarRenderer
             $allIcons = $this->icons->getAllIcons();
             $templatePath = plugin_dir_path($this->pluginFile) . 'includes/sidebar-template.php';
 
+            if (!is_readable($templatePath)) {
+                if (function_exists('error_log')) {
+                    error_log('[Sidebar JLG] Sidebar template not found or unreadable at ' . $templatePath);
+                }
+
+                return;
+            }
+
             ob_start();
             $optionsForTemplate = $options;
             $allIconsForTemplate = $allIcons;

--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -57,6 +57,7 @@ class Plugin
         $this->maybeInvalidateCacheOnVersionChange();
 
         add_action('plugins_loaded', [$this, 'loadTextdomain']);
+        add_action('admin_notices', [$this, 'renderActivationErrorNotice']);
         add_action('update_option_sidebar_jlg_settings', [$this->cache, 'clear'], 10, 0);
 
         $this->settings->revalidateStoredOptions();
@@ -122,5 +123,24 @@ class Plugin
     public function getMenuCache(): MenuCache
     {
         return $this->cache;
+    }
+
+    public function renderActivationErrorNotice(): void
+    {
+        if (!function_exists('get_transient')) {
+            return;
+        }
+
+        $message = get_transient('sidebar_jlg_activation_error');
+
+        if ($message === false || $message === '') {
+            return;
+        }
+
+        printf('<div class="notice notice-error"><p>%s</p></div>', esc_html($message));
+
+        if (function_exists('delete_transient')) {
+            delete_transient('sidebar_jlg_activation_error');
+        }
     }
 }

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -3,6 +3,7 @@
 namespace JLG\Sidebar\Settings;
 
 use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\ValueNormalizer;
 
 class SettingsRepository
 {
@@ -89,7 +90,7 @@ class SettingsRepository
         $revalidated = $this->revalidateCustomIcons($merged);
 
         $fallbackBorderColor = $defaults['border_color'] ?? '';
-        $normalizedBorderColor = $this->normalizeColorWithExisting(
+        $normalizedBorderColor = ValueNormalizer::normalizeColorWithExisting(
             $revalidated['border_color'] ?? null,
             $fallbackBorderColor
         );
@@ -100,7 +101,7 @@ class SettingsRepository
 
         foreach (self::COLOR_OPTION_KEYS as $colorKey) {
             $defaultColor = $defaults[$colorKey] ?? '';
-            $normalizedColor = $this->normalizeColorWithExisting(
+            $normalizedColor = ValueNormalizer::normalizeColorWithExisting(
                 $revalidated[$colorKey] ?? null,
                 $defaultColor
             );
@@ -112,7 +113,7 @@ class SettingsRepository
 
         foreach (self::DIMENSION_OPTION_KEYS as $dimensionKey) {
             $defaultValue = $defaults[$dimensionKey] ?? '';
-            $normalizedValue = $this->normalizeCssDimension($revalidated[$dimensionKey] ?? null, $defaultValue);
+            $normalizedValue = ValueNormalizer::normalizeCssDimension($revalidated[$dimensionKey] ?? null, $defaultValue);
 
             if (($revalidated[$dimensionKey] ?? '') !== $normalizedValue) {
                 $revalidated[$dimensionKey] = $normalizedValue;
@@ -201,198 +202,4 @@ class SettingsRepository
         return $options;
     }
 
-    private function normalizeColorWithExisting($value, $existingValue): string
-    {
-        $existingValue = (is_string($existingValue) || is_numeric($existingValue))
-            ? (string) $existingValue
-            : '';
-
-        $candidate = $value;
-        if ($candidate === null) {
-            $candidate = $existingValue;
-        }
-
-        $sanitizedCandidate = $this->sanitizeRgbaColor($candidate);
-        if ($sanitizedCandidate !== '') {
-            return $sanitizedCandidate;
-        }
-
-        $sanitizedExisting = $this->sanitizeRgbaColor($existingValue);
-        if ($sanitizedExisting !== '') {
-            return $sanitizedExisting;
-        }
-
-        return '';
-    }
-
-    private function sanitizeRgbaColor($color): string
-    {
-        if (empty($color) || is_array($color)) {
-            return '';
-        }
-
-        $color = trim((string) $color);
-
-        if (0 !== stripos($color, 'rgba')) {
-            $sanitizedHex = sanitize_hex_color($color);
-            return $sanitizedHex ? $sanitizedHex : '';
-        }
-
-        $pattern = '/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(0|1|0?\.\d+|1\.0+)\s*\)$/i';
-
-        if (!preg_match($pattern, $color, $matches)) {
-            return '';
-        }
-
-        $r = (int) $matches[1];
-        $g = (int) $matches[2];
-        $b = (int) $matches[3];
-        $aValue = (float) $matches[4];
-
-        foreach ([$r, $g, $b] as $component) {
-            if ($component < 0 || $component > 255) {
-                return '';
-            }
-        }
-
-        if ($aValue < 0 || $aValue > 1) {
-            return '';
-        }
-
-        $alpha = $matches[4];
-
-        if ('.' === substr($alpha, 0, 1)) {
-            $alpha = '0' . $alpha;
-        }
-
-        $alpha = rtrim($alpha, '0');
-        $alpha = rtrim($alpha, '.');
-
-        if ('' === $alpha) {
-            $alpha = '0';
-        }
-
-        return sprintf('rgba(%d,%d,%d,%s)', $r, $g, $b, $alpha);
-    }
-
-    private function normalizeCssDimension($value, $fallback): string
-    {
-        $fallback = is_string($fallback) || is_numeric($fallback) ? (string) $fallback : '';
-        $sanitizedFallback = sanitize_text_field($fallback);
-
-        $value = is_string($value) || is_numeric($value) ? (string) $value : '';
-        $value = trim($value);
-
-        if ($value === '') {
-            return $sanitizedFallback;
-        }
-
-        $value = sanitize_text_field($value);
-
-        static $cache = null;
-        if ($cache === null) {
-            $allowedUnits = ['px', 'rem', 'em', '%', 'vh', 'vw', 'vmin', 'vmax', 'ch'];
-            $unitPattern = '(?:' . implode('|', array_map(static function ($unit) {
-                return preg_quote($unit, '/');
-            }, $allowedUnits)) . ')';
-
-            $cache = [
-                'numeric_pattern'   => '/^-?(?:\d+|\d*\.\d+)(?:' . $unitPattern . ')$/i',
-                'dimension_pattern' => '/^[-+]?(?:\d+|\d*\.\d+)(?:' . $unitPattern . ')?$/i',
-            ];
-        }
-
-        $numericPattern = $cache['numeric_pattern'];
-        $dimensionPattern = $cache['dimension_pattern'];
-
-        if (preg_match($numericPattern, $value)) {
-            return $value;
-        }
-
-        if ($this->isValidCalcExpression($value, $dimensionPattern)) {
-            return $value;
-        }
-
-        if (preg_match('/^0(?:\.0+)?$/', $value)) {
-            return '0';
-        }
-
-        return $sanitizedFallback;
-    }
-
-    private function isValidCalcExpression(string $value, string $dimensionPattern): bool
-    {
-        if (!preg_match('/^calc\((.*)\)$/i', $value, $matches)) {
-            return false;
-        }
-
-        $expression = trim($matches[1]);
-
-        if ($expression === '') {
-            return false;
-        }
-
-        if (!preg_match('/^[0-9+\-*\/().%a-z\s]+$/i', $expression)) {
-            return false;
-        }
-
-        $expression = preg_replace('/\s+/', '', $expression);
-
-        if ($expression === '') {
-            return false;
-        }
-
-        $length = strlen($expression);
-        $tokens = [];
-        $current = '';
-
-        for ($i = 0; $i < $length; $i++) {
-            $char = $expression[$i];
-
-            if (strpos('+-*/()', $char) !== false) {
-                if ($current !== '') {
-                    $tokens[] = $current;
-                    $current = '';
-                }
-
-                $tokens[] = $char;
-                continue;
-            }
-
-            $current .= $char;
-        }
-
-        if ($current !== '') {
-            $tokens[] = $current;
-        }
-
-        $balance = 0;
-        $prevToken = '';
-
-        foreach ($tokens as $token) {
-            if ($token === '(') {
-                $balance++;
-            } elseif ($token === ')') {
-                $balance--;
-
-                if ($balance < 0) {
-                    return false;
-                }
-            }
-
-            if (in_array($token, ['+', '-', '*', '/'], true)) {
-                if ($prevToken === '' || in_array($prevToken, ['+', '-', '*', '/', '('], true)) {
-                    return false;
-                }
-            } elseif (!in_array($token, ['(', ')'], true)) {
-                if (!preg_match($dimensionPattern, $token) && !preg_match('/^\d+(?:\.\d+)?$/', $token)) {
-                    return false;
-                }
-            }
-
-            $prevToken = $token;
-        }
-
-        return $balance === 0 && !in_array($prevToken, ['+', '-', '*', '/'], true);
-    }
 }

--- a/sidebar-jlg/src/Settings/ValueNormalizer.php
+++ b/sidebar-jlg/src/Settings/ValueNormalizer.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace JLG\Sidebar\Settings;
+
+final class ValueNormalizer
+{
+    private const ALLOWED_UNITS = ['px', 'rem', 'em', '%', 'vh', 'vw', 'vmin', 'vmax', 'ch'];
+
+    /**
+     * @var array{numeric_pattern:string,dimension_pattern:string}|null
+     */
+    private static ?array $dimensionPatterns = null;
+
+    /**
+     * @param mixed $value
+     * @param mixed $fallback
+     */
+    public static function normalizeCssDimension($value, $fallback): string
+    {
+        $fallback = is_string($fallback) || is_numeric($fallback) ? (string) $fallback : '';
+        $sanitizedFallback = sanitize_text_field($fallback);
+
+        $value = is_string($value) || is_numeric($value) ? (string) $value : '';
+        $value = trim($value);
+
+        if ($value === '') {
+            return $sanitizedFallback;
+        }
+
+        $value = sanitize_text_field($value);
+
+        $patterns = self::getDimensionPatterns();
+        $numericPattern = $patterns['numeric_pattern'];
+        $dimensionPattern = $patterns['dimension_pattern'];
+
+        if (preg_match($numericPattern, $value)) {
+            return $value;
+        }
+
+        if (self::isValidCalcExpression($value, $dimensionPattern)) {
+            return $value;
+        }
+
+        if (preg_match('/^0(?:\.0+)?$/', $value)) {
+            return '0';
+        }
+
+        return $sanitizedFallback;
+    }
+
+    /**
+     * @param mixed $value
+     * @param mixed $existingValue
+     */
+    public static function normalizeColorWithExisting($value, $existingValue): string
+    {
+        $existingValue = (is_string($existingValue) || is_numeric($existingValue))
+            ? (string) $existingValue
+            : '';
+
+        $candidate = $value;
+        if ($candidate === null) {
+            $candidate = $existingValue;
+        }
+
+        $sanitizedCandidate = self::sanitizeRgbaColor($candidate);
+        if ($sanitizedCandidate !== '') {
+            return $sanitizedCandidate;
+        }
+
+        $sanitizedExisting = self::sanitizeRgbaColor($existingValue);
+        if ($sanitizedExisting !== '') {
+            return $sanitizedExisting;
+        }
+
+        return '';
+    }
+
+    /**
+     * @param mixed $color
+     */
+    private static function sanitizeRgbaColor($color): string
+    {
+        if (empty($color) || is_array($color)) {
+            return '';
+        }
+
+        $color = trim((string) $color);
+
+        if (0 !== stripos($color, 'rgba')) {
+            $sanitizedHex = sanitize_hex_color($color);
+            return $sanitizedHex ? $sanitizedHex : '';
+        }
+
+        $pattern = '/^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(0|1|0?\.\d+|1\.0+)\s*\)$/i';
+
+        if (!preg_match($pattern, $color, $matches)) {
+            return '';
+        }
+
+        $r = (int) $matches[1];
+        $g = (int) $matches[2];
+        $b = (int) $matches[3];
+        $aValue = (float) $matches[4];
+
+        foreach ([$r, $g, $b] as $component) {
+            if ($component < 0 || $component > 255) {
+                return '';
+            }
+        }
+
+        if ($aValue < 0 || $aValue > 1) {
+            return '';
+        }
+
+        $alpha = $matches[4];
+
+        if ('.' === substr($alpha, 0, 1)) {
+            $alpha = '0' . $alpha;
+        }
+
+        $alpha = rtrim($alpha, '0');
+        $alpha = rtrim($alpha, '.');
+
+        if ('' === $alpha) {
+            $alpha = '0';
+        }
+
+        return sprintf('rgba(%d,%d,%d,%s)', $r, $g, $b, $alpha);
+    }
+
+    private static function getDimensionPatterns(): array
+    {
+        if (self::$dimensionPatterns !== null) {
+            return self::$dimensionPatterns;
+        }
+
+        $unitPattern = '(?:' . implode('|', array_map(static function ($unit) {
+            return preg_quote($unit, '/');
+        }, self::ALLOWED_UNITS)) . ')';
+
+        self::$dimensionPatterns = [
+            'numeric_pattern'   => '/^-?(?:\d+|\d*\.\d+)(?:' . $unitPattern . ')$/i',
+            'dimension_pattern' => '/^[-+]?(?:\d+|\d*\.\d+)(?:' . $unitPattern . ')?$/i',
+        ];
+
+        return self::$dimensionPatterns;
+    }
+
+    private static function isValidCalcExpression(string $value, string $dimensionPattern): bool
+    {
+        if (!preg_match('/^calc\((.*)\)$/i', $value, $matches)) {
+            return false;
+        }
+
+        $expression = trim($matches[1]);
+
+        if ($expression === '') {
+            return false;
+        }
+
+        if (!preg_match('/^[0-9+\-*\/().%a-z\s]+$/i', $expression)) {
+            return false;
+        }
+
+        $expression = preg_replace('/\s+/', '', $expression);
+
+        if ($expression === '') {
+            return false;
+        }
+
+        $length = strlen($expression);
+        $tokens = [];
+        $current = '';
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $expression[$i];
+
+            if (strpos('+-*/()', $char) !== false) {
+                if ($current !== '') {
+                    $tokens[] = $current;
+                    $current = '';
+                }
+
+                $tokens[] = $char;
+                continue;
+            }
+
+            $current .= $char;
+        }
+
+        if ($current !== '') {
+            $tokens[] = $current;
+        }
+
+        $balance = 0;
+        $prevToken = '';
+
+        foreach ($tokens as $token) {
+            if ($token === '(') {
+                $balance++;
+            } elseif ($token === ')') {
+                $balance--;
+
+                if ($balance < 0) {
+                    return false;
+                }
+            }
+
+            if (in_array($token, ['+', '-', '*', '/'], true)) {
+                if ($prevToken === '' || in_array($prevToken, ['+', '-', '*', '/', '('], true)) {
+                    return false;
+                }
+            } elseif (!in_array($token, ['(', ')'], true)) {
+                if (!preg_match($dimensionPattern, $token) && !preg_match('/^\d+(?:\.\d+)?$/', $token)) {
+                    return false;
+                }
+            }
+
+            $prevToken = $token;
+        }
+
+        return $balance === 0 && !in_array($prevToken, ['+', '-', '*', '/'], true);
+    }
+}

--- a/tests/icons_directory_creation_failure_test.php
+++ b/tests/icons_directory_creation_failure_test.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+
+$testsPassed = true;
+
+function assertTestTrue($condition, string $message): void
+{
+    global $testsPassed;
+
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+$activationCallback = null;
+
+$GLOBALS['wp_test_function_overrides']['register_activation_hook'] = static function ($file, $callback) use (&$activationCallback): void {
+    $activationCallback = $callback;
+};
+
+$uploadsBaseDir = sys_get_temp_dir() . '/sidebar_jlg_missing_' . uniqid();
+
+$GLOBALS['wp_test_function_overrides']['wp_upload_dir'] = static function () use ($uploadsBaseDir): array {
+    return [
+        'basedir' => $uploadsBaseDir,
+        'error'   => null,
+    ];
+};
+
+$GLOBALS['wp_test_function_overrides']['wp_mkdir_p'] = static function ($dir): bool {
+    echo "[INFO] wp_mkdir_p called for {$dir}\n";
+
+    return false;
+};
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+assertTestTrue(is_callable($activationCallback), 'Activation hook registered');
+
+($activationCallback)();
+
+$transient = get_transient('sidebar_jlg_activation_error');
+assertTestTrue(is_string($transient) && $transient !== '', 'Activation error notice is stored in a transient');
+
+$storedVersion = get_option('sidebar_jlg_plugin_version', null);
+assertTestTrue($storedVersion === null, 'Plugin version option is not updated when the icons directory cannot be created');
+
+if ($testsPassed) {
+    echo "Icons directory creation failure test passed.\n";
+    exit(0);
+}
+
+echo "Icons directory creation failure test failed.\n";
+exit(1);

--- a/tests/sanitize_css_dimension_test.php
+++ b/tests/sanitize_css_dimension_test.php
@@ -1,9 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use JLG\Sidebar\Admin\SettingsSanitizer;
-use JLG\Sidebar\Icons\IconLibrary;
-use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\ValueNormalizer;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -12,14 +10,6 @@ $GLOBALS['wp_test_function_overrides']['wp_check_filetype'] = static function ($
 };
 
 require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
-
-$defaults = new DefaultSettings();
-$icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
-
-$reflection = new ReflectionClass(SettingsSanitizer::class);
-$method = $reflection->getMethod('sanitize_css_dimension');
-$method->setAccessible(true);
 
 $tests = [
     'valid_px' => [
@@ -76,7 +66,7 @@ $tests = [
 
 $allPassed = true;
 foreach ($tests as $name => $test) {
-    $result = $method->invoke($sanitizer, $test['input'], $test['fallback']);
+    $result = ValueNormalizer::normalizeCssDimension($test['input'], $test['fallback']);
     if ($result === $test['expected']) {
         echo sprintf("[PASS] %s\n", $name);
         continue;

--- a/tests/sanitize_rgba_color_test.php
+++ b/tests/sanitize_rgba_color_test.php
@@ -1,9 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use JLG\Sidebar\Admin\SettingsSanitizer;
-use JLG\Sidebar\Icons\IconLibrary;
-use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\ValueNormalizer;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -12,14 +10,6 @@ $GLOBALS['wp_test_function_overrides']['wp_check_filetype'] = static function ($
 };
 
 require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
-
-$defaults = new DefaultSettings();
-$icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
-
-$reflection = new ReflectionClass(SettingsSanitizer::class);
-$method = $reflection->getMethod('sanitize_rgba_color');
-$method->setAccessible(true);
 
 $tests = [
     'valid_with_spaces' => [
@@ -90,7 +80,7 @@ $tests = [
 
 $allPassed = true;
 foreach ($tests as $name => $test) {
-    $result = $method->invoke($sanitizer, $test['input']);
+    $result = ValueNormalizer::normalizeColorWithExisting($test['input'], '');
     if ($result === $test['expected']) {
         echo sprintf("[PASS] %s\n", $name);
         continue;


### PR DESCRIPTION
## Summary
- fail the activation routine gracefully when the icons directory cannot be created, logging the issue and surfacing an admin notice via transient storage
- guard sidebar template loading against missing or unreadable files to avoid fatal errors
- consolidate CSS dimension and color normalization into a shared helper used by both the settings sanitizer and repository, updating related tests and adding coverage for the new activation error flow

## Testing
- for test in tests/*_test.php; do echo "Running $test"; php $test || exit 1; done
- php tests/render_sidebar_html_error_handling_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c4f00400832e8c9fd99bd192e85c