### PR TITLE
Ensure settings fallback merges defaults

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -27,6 +27,7 @@ class SettingsSanitizer
             }
             $existingOptions = $defaults;
         }
+        $existingOptions = wp_parse_args($existingOptions, $defaults);
         $preparedInput = is_array($input) ? $input : [];
 
         $sanitizedInput = array_merge(


### PR DESCRIPTION
## Summary
- merge persisted settings with the plugin defaults before sanitizing to guarantee all expected keys exist

## Testing
- for file in tests/*_test.php; do php $file; done

------
https://chatgpt.com/codex/tasks/task_e_68d3da93741c832e800cf62a32b79bf6