### PR TITLE
Improve settings caching and icon sanitization

### DIFF
--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -41,7 +41,7 @@ ob_start();
                     if ( ! empty( $item['icon_type'] ) && $item['icon_type'] === 'svg_url' && filter_var($item['icon'], FILTER_VALIDATE_URL) ) {
                         echo '<span class="menu-icon svg-icon"><img src="' . esc_url( $item['icon'] ) . '" alt=""></span>';
                     } elseif ( isset( $allIcons[ $item['icon'] ] ) ) {
-                        $icon_markup = $allIcons[ $item['icon'] ];
+                        $icon_markup = wp_kses_post( $allIcons[ $item['icon'] ] );
 
                         if ( strpos( $item['icon'], 'custom_' ) === 0 ) {
                             echo '<span class="menu-icon svg-icon">' . $icon_markup . '</span>';
@@ -72,7 +72,7 @@ ob_start();
                         $aria_label = $custom_label !== '' ? $custom_label : $icon_label;
 
                         echo '<a href="' . esc_url($social['url']) . '" target="_blank" rel="noopener noreferrer" aria-label="' . esc_attr($aria_label) . '">';
-                        echo $allIcons[$social['icon']];
+                        echo wp_kses_post($allIcons[$social['icon']]);
                         echo '</a>';
                     }
                 }
@@ -102,7 +102,7 @@ if ($options['social_position'] === 'footer' && !empty($options['social_icons'])
                 $aria_label = $custom_label !== '' ? $custom_label : $icon_label;
 
                 echo '<a href="' . esc_url($social['url']) . '" target="_blank" rel="noopener noreferrer" aria-label="' . esc_attr($aria_label) . '">';
-                echo $allIcons[$social['icon']];
+                echo wp_kses_post($allIcons[$social['icon']]);
                 echo '</a>';
             }
         }
@@ -202,7 +202,9 @@ $dynamic_styles .= "}";
             $close_button_markup = '<span class="close-sidebar-fallback" aria-hidden="true">&times;</span>';
 
             if (isset($allIcons['close_white']) && $allIcons['close_white'] !== '') {
-                $close_button_markup = $allIcons['close_white'];
+                $close_button_markup = wp_kses_post($allIcons['close_white']);
+            } else {
+                $close_button_markup = wp_kses_post($close_button_markup);
             }
             ?>
             <button class="close-sidebar-btn" type="button" aria-label="<?php esc_attr_e('Fermer le menu', 'sidebar-jlg'); ?>">

--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -85,11 +85,17 @@ class MenuPage
         );
 
         $options = get_option('sidebar_jlg_settings', $this->settings->getDefaultSettings());
+        if (!is_array($options)) {
+            $options = [];
+        }
+
+        $defaults = $this->settings->getDefaultSettings();
+
         wp_localize_script('sidebar-jlg-admin-js', 'sidebarJLG', [
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('jlg_ajax_nonce'),
             'reset_nonce' => wp_create_nonce('jlg_reset_nonce'),
-            'options' => wp_parse_args($options, $this->settings->getDefaultSettings()),
+            'options' => wp_parse_args($options, $defaults),
             'all_icons' => $this->icons->getAllIcons(),
         ]);
     }
@@ -99,6 +105,10 @@ class MenuPage
         $colorPicker = $this->colorPicker;
         $defaults = $this->settings->getDefaultSettings();
         $optionsFromDb = get_option('sidebar_jlg_settings');
+        if (!is_array($optionsFromDb)) {
+            $optionsFromDb = [];
+        }
+
         $options = wp_parse_args($optionsFromDb, $defaults);
         $allIcons = $this->icons->getAllIcons();
 


### PR DESCRIPTION
## Summary
- cache normalized sidebar settings per request while invalidating the cache when the stored option changes
- guard admin page option loading against corrupted values before merging with defaults
- sanitize rendered SVG icons, including the close button, with wp_kses_post for an extra security layer

## Testing
- for file in tests/*_test.php; do php "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68d41684a0c4832ea196962931a83b48