### PR TITLE
Refactor admin icons loading and consolidate settings access

### DIFF
--- a/sidebar-jlg/assets/css/admin-style.css
+++ b/sidebar-jlg/assets/css/admin-style.css
@@ -41,6 +41,10 @@ input:checked + .jlg-slider:before { transform: translateX(26px); }
 #icon-library-modal #icon-grid { flex-grow: 1; overflow-y: auto; display: grid; grid-template-columns: repeat(auto-fill, minmax(50px, 1fr)); gap: 10px; }
 #icon-library-modal #icon-grid button { padding: 10px; border: 1px solid #ddd; background: #f9f9f9; cursor: pointer; }
 #icon-library-modal #icon-grid button:hover { background: #eee; }
+#icon-library-modal #icon-grid button .icon-preview { display: block; min-height: 24px; line-height: 0; margin-bottom: 6px; }
+#icon-library-modal #icon-grid button .icon-preview svg,
+#icon-library-modal #icon-grid button .icon-preview img { width: 24px; height: 24px; display: inline-block; }
+#icon-library-modal #icon-grid button .icon-label { display: block; font-size: 11px; word-break: break-word; }
 
 /* Style pour le bouton de réinitialisation */
 .button-danger {

--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -6,6 +6,43 @@ $allIcons = $allIcons ?? [];
 
 ob_start();
 ?>
+<?php
+if (!function_exists('sidebar_jlg_render_social_icons')) {
+    function sidebar_jlg_render_social_icons(array $socialIcons, array $allIcons, string $orientation): string
+    {
+        if (empty($socialIcons)) {
+            return '';
+        }
+
+        ob_start();
+        ?>
+        <div class="social-icons <?php echo esc_attr($orientation); ?>">
+            <?php foreach ($socialIcons as $social) :
+                if (empty($social['icon']) || empty($social['url']) || !isset($allIcons[$social['icon']])) {
+                    continue;
+                }
+
+                $iconParts = explode('_', $social['icon']);
+                $iconLabel = (isset($iconParts[0]) && $iconParts[0] !== '') ? $iconParts[0] : 'unknown';
+                $customLabel = '';
+
+                if (isset($social['label']) && is_string($social['label'])) {
+                    $customLabel = trim($social['label']);
+                }
+
+                $ariaLabel = $customLabel !== '' ? $customLabel : $iconLabel;
+                ?>
+                <a href="<?php echo esc_url($social['url']); ?>" target="_blank" rel="noopener noreferrer" aria-label="<?php echo esc_attr($ariaLabel); ?>">
+                    <?php echo wp_kses_post($allIcons[$social['icon']]); ?>
+                </a>
+            <?php endforeach; ?>
+        </div>
+        <?php
+
+        return trim((string) ob_get_clean());
+    }
+}
+?>
 <nav class="sidebar-navigation" role="navigation" aria-label="<?php esc_attr_e('Navigation principale', 'sidebar-jlg'); ?>">
     <ul class="sidebar-menu">
         <?php
@@ -55,30 +92,11 @@ ob_start();
         }
         
         if ($options['social_position'] === 'in-menu' && !empty($options['social_icons']) && is_array($options['social_icons'])) {
-            echo '<li class="menu-separator" aria-hidden="true"><hr></li>';
-            echo '<li class="social-icons-wrapper">';
-            if ( ! empty( $options['social_icons'] ) && is_array( $options['social_icons'] ) ) {
-                echo '<div class="social-icons ' . esc_attr($options['social_orientation']) . '">';
-                foreach($options['social_icons'] as $social) {
-                    if ( ! empty( $social['icon'] ) && ! empty( $social['url'] ) && isset($allIcons[$social['icon']]) ) {
-                        $icon_parts = explode('_', $social['icon']);
-                        $icon_label = (isset($icon_parts[0]) && $icon_parts[0] !== '') ? $icon_parts[0] : 'unknown';
-                        $custom_label = '';
-
-                        if (isset($social['label']) && is_string($social['label'])) {
-                            $custom_label = trim($social['label']);
-                        }
-
-                        $aria_label = $custom_label !== '' ? $custom_label : $icon_label;
-
-                        echo '<a href="' . esc_url($social['url']) . '" target="_blank" rel="noopener noreferrer" aria-label="' . esc_attr($aria_label) . '">';
-                        echo wp_kses_post($allIcons[$social['icon']]);
-                        echo '</a>';
-                    }
-                }
-                echo '</div>';
+            $menuSocialIcons = sidebar_jlg_render_social_icons($options['social_icons'], $allIcons, $options['social_orientation']);
+            if ($menuSocialIcons !== '') {
+                echo '<li class="menu-separator" aria-hidden="true"><hr></li>';
+                echo '<li class="social-icons-wrapper">' . $menuSocialIcons . '</li>';
             }
-            echo '</li>';
         }
         ?>
     </ul>
@@ -86,29 +104,10 @@ ob_start();
 
 <?php
 if ($options['social_position'] === 'footer' && !empty($options['social_icons']) && is_array($options['social_icons'])) {
-    echo '<div class="sidebar-footer">';
-    if ( ! empty( $options['social_icons'] ) && is_array( $options['social_icons'] ) ) {
-        echo '<div class="social-icons ' . esc_attr($options['social_orientation']) . '">';
-        foreach($options['social_icons'] as $social) {
-            if ( ! empty( $social['icon'] ) && ! empty( $social['url'] ) && isset($allIcons[$social['icon']]) ) {
-                $icon_parts = explode('_', $social['icon']);
-                $icon_label = (isset($icon_parts[0]) && $icon_parts[0] !== '') ? $icon_parts[0] : 'unknown';
-                $custom_label = '';
-
-                if (isset($social['label']) && is_string($social['label'])) {
-                    $custom_label = trim($social['label']);
-                }
-
-                $aria_label = $custom_label !== '' ? $custom_label : $icon_label;
-
-                echo '<a href="' . esc_url($social['url']) . '" target="_blank" rel="noopener noreferrer" aria-label="' . esc_attr($aria_label) . '">';
-                echo wp_kses_post($allIcons[$social['icon']]);
-                echo '</a>';
-            }
-        }
-        echo '</div>';
+    $footerSocialIcons = sidebar_jlg_render_social_icons($options['social_icons'], $allIcons, $options['social_orientation']);
+    if ($footerSocialIcons !== '') {
+        echo '<div class="sidebar-footer">' . $footerSocialIcons . '</div>';
     }
-    echo '</div>';
 }
 
 $sidebar_content_html = ob_get_clean();

--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -84,19 +84,16 @@ class MenuPage
             true
         );
 
-        $options = get_option('sidebar_jlg_settings', $this->settings->getDefaultSettings());
-        if (!is_array($options)) {
-            $options = [];
-        }
-
         $defaults = $this->settings->getDefaultSettings();
+        $options = $this->settings->getOptionsWithRevalidation();
 
         wp_localize_script('sidebar-jlg-admin-js', 'sidebarJLG', [
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('jlg_ajax_nonce'),
             'reset_nonce' => wp_create_nonce('jlg_reset_nonce'),
             'options' => wp_parse_args($options, $defaults),
-            'all_icons' => $this->icons->getAllIcons(),
+            'icons_manifest' => $this->icons->getIconManifest(),
+            'icon_fetch_action' => 'jlg_get_icon_svg',
         ]);
     }
 
@@ -104,12 +101,7 @@ class MenuPage
     {
         $colorPicker = $this->colorPicker;
         $defaults = $this->settings->getDefaultSettings();
-        $optionsFromDb = get_option('sidebar_jlg_settings');
-        if (!is_array($optionsFromDb)) {
-            $optionsFromDb = [];
-        }
-
-        $options = wp_parse_args($optionsFromDb, $defaults);
+        $options = $this->settings->getOptionsWithRevalidation();
         $allIcons = $this->icons->getAllIcons();
 
         require plugin_dir_path($this->pluginFile) . 'includes/admin-page.php';

--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -49,7 +49,7 @@ class Plugin
             $pluginFile,
             $version
         );
-        $this->ajax = new Endpoints($this->settings, $this->cache);
+        $this->ajax = new Endpoints($this->settings, $this->cache, $this->icons);
     }
 
     public function register(): void


### PR DESCRIPTION
## Summary
- reuse the settings repository in the admin screen and expose an icon manifest instead of full SVG payloads
- stream icon SVG markup on demand through a new authenticated AJAX endpoint and update the admin UI to fetch/cache previews
- factor social icon rendering into a shared helper and harden icon library path handling for tests and runtime

## Testing
- for f in tests/*_test.php; do php "$f" || break; done

------
https://chatgpt.com/codex/tasks/task_e_68d42f258b8c832eb7bd84c5494a84bc