### PR TITLE
Optimize sidebar front-end payload and icon caching

### DIFF
--- a/sidebar-jlg/src/Cache/MenuCache.php
+++ b/sidebar-jlg/src/Cache/MenuCache.php
@@ -4,6 +4,7 @@ namespace JLG\Sidebar\Cache;
 
 class MenuCache
 {
+    private const CACHE_TTL = 86400;
     private string $optionName = 'sidebar_jlg_cached_locales';
 
     public function getLocaleForCache(): string
@@ -37,7 +38,7 @@ class MenuCache
 
     public function set(string $locale, string $html): void
     {
-        set_transient($this->getTransientKey($locale), $html);
+        set_transient($this->getTransientKey($locale), $html, self::CACHE_TTL);
         $this->rememberLocale($locale);
     }
 
@@ -59,6 +60,11 @@ class MenuCache
         if (!empty($cachedLocales)) {
             delete_option($this->optionName);
         }
+    }
+
+    public function forgetLocaleIndex(): void
+    {
+        delete_option($this->optionName);
     }
 
     public function rememberLocale(string $locale): void

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -57,7 +57,13 @@ class SidebarRenderer
             true
         );
 
-        wp_localize_script('sidebar-jlg-public-js', 'sidebarSettings', $options);
+        $localizedOptions = [
+            'animation_type' => $options['animation_type'] ?? 'slide-left',
+            'close_on_link_click' => $options['close_on_link_click'] ?? '',
+            'debug_mode' => (string) ($options['debug_mode'] ?? '0'),
+        ];
+
+        wp_localize_script('sidebar-jlg-public-js', 'sidebarSettings', $localizedOptions);
     }
 
     public function render(): void
@@ -84,6 +90,7 @@ class SidebarRenderer
             $html = $this->cache->get($currentLocale);
         } else {
             $this->cache->delete($currentLocale);
+            $this->cache->forgetLocaleIndex();
         }
 
         if (!$cacheEnabled || false === $html) {

--- a/sidebar-jlg/uninstall.php
+++ b/sidebar-jlg/uninstall.php
@@ -39,6 +39,8 @@ foreach ( $cached_locales as $locale ) {
 //    ainsi que le transient générique existant.
 delete_option( 'sidebar_jlg_cached_locales' );
 delete_transient( 'sidebar_jlg_full_html' );
+delete_option( 'sidebar_jlg_custom_icon_index' );
+delete_transient( 'sidebar_jlg_custom_icons_cache' );
 
 // Note pour l'avenir : 
 // Si le plugin devait créer des tables de base de données personnalisées ou d'autres options,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -591,15 +591,43 @@ if (!function_exists('wp_check_filetype')) {
             return $result;
         }
 
-        $extension = pathinfo((string) $file, PATHINFO_EXTENSION);
+        $extension = strtolower(pathinfo((string) $file, PATHINFO_EXTENSION));
 
         if ($extension === '') {
             return ['ext' => '', 'type' => ''];
         }
 
+        if (isset($allowed[$extension])) {
+            return ['ext' => $extension, 'type' => $allowed[$extension]];
+        }
+
+        return ['ext' => '', 'type' => ''];
+    }
+}
+
+if (!function_exists('wp_check_filetype_and_ext')) {
+    function wp_check_filetype_and_ext($file, $filename, $mimes = null)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        $checked = wp_check_filetype($filename, is_array($mimes) ? $mimes : []);
+
+        if (!isset($checked['ext'])) {
+            $checked['ext'] = '';
+        }
+
+        if (!isset($checked['type'])) {
+            $checked['type'] = '';
+        }
+
         return [
-            'ext'  => $extension,
-            'type' => $allowed[$extension] ?? 'image/' . $extension,
+            'ext' => $checked['ext'],
+            'type' => $checked['type'],
+            'proper_filename' => false,
         ];
     }
 }


### PR DESCRIPTION
## Summary
- Reduce the localized sidebar script payload to the settings the front-end actually consumes and drop cached locale metadata when caching is disabled.
- Persist sanitized custom icons in a transient keyed by file metadata, validate uploads with `wp_check_filetype_and_ext`, and reuse cached results when the library is unchanged.
- Expire sidebar HTML transients, clean up custom icon cache artifacts on uninstall, and extend the test bootstrap with a `wp_check_filetype_and_ext` stub.

## Testing
- for test in tests/*_test.php; do php $test || exit 1; done

------
https://chatgpt.com/codex/tasks/task_e_68d4360f74f8832e953f9974b61d9a3f