### PR TITLE
Harden activation and frontend rendering helpers

### DIFF
--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -1,47 +1,12 @@
 <?php
+use JLG\Sidebar\Frontend\Templating;
+
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 $options = $options ?? [];
 $allIcons = $allIcons ?? [];
 
 ob_start();
-?>
-<?php
-if (!function_exists('sidebar_jlg_render_social_icons')) {
-    function sidebar_jlg_render_social_icons(array $socialIcons, array $allIcons, string $orientation): string
-    {
-        if (empty($socialIcons)) {
-            return '';
-        }
-
-        ob_start();
-        ?>
-        <div class="social-icons <?php echo esc_attr($orientation); ?>">
-            <?php foreach ($socialIcons as $social) :
-                if (empty($social['icon']) || empty($social['url']) || !isset($allIcons[$social['icon']])) {
-                    continue;
-                }
-
-                $iconParts = explode('_', $social['icon']);
-                $iconLabel = (isset($iconParts[0]) && $iconParts[0] !== '') ? $iconParts[0] : 'unknown';
-                $customLabel = '';
-
-                if (isset($social['label']) && is_string($social['label'])) {
-                    $customLabel = trim($social['label']);
-                }
-
-                $ariaLabel = $customLabel !== '' ? $customLabel : $iconLabel;
-                ?>
-                <a href="<?php echo esc_url($social['url']); ?>" target="_blank" rel="noopener noreferrer" aria-label="<?php echo esc_attr($ariaLabel); ?>">
-                    <?php echo wp_kses_post($allIcons[$social['icon']]); ?>
-                </a>
-            <?php endforeach; ?>
-        </div>
-        <?php
-
-        return trim((string) ob_get_clean());
-    }
-}
 ?>
 <nav class="sidebar-navigation" role="navigation" aria-label="<?php esc_attr_e('Navigation principale', 'sidebar-jlg'); ?>">
     <ul class="sidebar-menu">
@@ -92,7 +57,7 @@ if (!function_exists('sidebar_jlg_render_social_icons')) {
         }
         
         if ($options['social_position'] === 'in-menu' && !empty($options['social_icons']) && is_array($options['social_icons'])) {
-            $menuSocialIcons = sidebar_jlg_render_social_icons($options['social_icons'], $allIcons, $options['social_orientation']);
+            $menuSocialIcons = Templating::renderSocialIcons($options['social_icons'], $allIcons, $options['social_orientation']);
             if ($menuSocialIcons !== '') {
                 echo '<li class="menu-separator" aria-hidden="true"><hr></li>';
                 echo '<li class="social-icons-wrapper">' . $menuSocialIcons . '</li>';
@@ -104,7 +69,7 @@ if (!function_exists('sidebar_jlg_render_social_icons')) {
 
 <?php
 if ($options['social_position'] === 'footer' && !empty($options['social_icons']) && is_array($options['social_icons'])) {
-    $footerSocialIcons = sidebar_jlg_render_social_icons($options['social_icons'], $allIcons, $options['social_orientation']);
+    $footerSocialIcons = Templating::renderSocialIcons($options['social_icons'], $allIcons, $options['social_orientation']);
     if ($footerSocialIcons !== '') {
         echo '<div class="sidebar-footer">' . $footerSocialIcons . '</div>';
     }

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -52,6 +52,18 @@ register_activation_hook(__FILE__, static function () {
             error_log(sprintf('[Sidebar JLG] Activation skipped: %s', $errorMessage));
         }
 
+        if (function_exists('set_transient')) {
+            $expiration = defined('HOUR_IN_SECONDS') ? HOUR_IN_SECONDS : 3600;
+
+            $message = __('Sidebar JLG n\'a pas pu accéder au dossier uploads. Vérifiez les permissions du dossier uploads puis réactivez le plugin.', 'sidebar-jlg');
+
+            if ($errorMessage !== '') {
+                $message .= ' ' . sprintf(__('Détails : %s', 'sidebar-jlg'), $errorMessage);
+            }
+
+            set_transient('sidebar_jlg_activation_error', $message, $expiration);
+        }
+
         return;
     }
 

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -8,6 +8,46 @@ use JLG\Sidebar\Settings\SettingsRepository;
 
 class SidebarRenderer
 {
+    private const DYNAMIC_STYLE_DEFAULTS = [
+        'width_desktop' => 280,
+        'width_tablet' => 320,
+        'bg_color_type' => 'solid',
+        'bg_color' => 'rgba(26, 29, 36, 1)',
+        'bg_color_start' => '#18181b',
+        'bg_color_end' => '#27272a',
+        'accent_color_type' => 'solid',
+        'accent_color' => 'rgba(13, 110, 253, 1)',
+        'accent_color_start' => '#60a5fa',
+        'accent_color_end' => '#c084fc',
+        'font_size' => 16,
+        'font_color' => 'rgba(224, 224, 224, 1)',
+        'font_hover_color' => 'rgba(255, 255, 255, 1)',
+        'animation_speed' => 400,
+        'header_padding_top' => '2.5rem',
+        'header_alignment_desktop' => 'flex-start',
+        'header_alignment_mobile' => 'center',
+        'header_logo_size' => 150,
+        'hamburger_top_position' => '4rem',
+        'content_margin' => '2rem',
+        'floating_vertical_margin' => '4rem',
+        'border_radius' => '12px',
+        'border_width' => 1,
+        'border_color' => 'rgba(255,255,255,0.2)',
+        'overlay_color' => 'rgba(0, 0, 0, 1)',
+        'overlay_opacity' => 0.5,
+        'mobile_bg_color' => 'rgba(26, 29, 36, 0.8)',
+        'mobile_bg_opacity' => 0.8,
+        'mobile_blur' => 10,
+        'menu_alignment_desktop' => 'flex-start',
+        'menu_alignment_mobile' => 'flex-start',
+        'search_alignment' => 'flex-start',
+        'social_icon_size' => 100,
+        'neon_blur' => 15,
+        'neon_spread' => 5,
+        'hover_effect_desktop' => 'none',
+        'hover_effect_mobile' => 'none',
+    ];
+
     private SettingsRepository $settings;
     private IconLibrary $icons;
     private MenuCache $cache;
@@ -73,79 +113,205 @@ class SidebarRenderer
 
     private function buildDynamicStyles(array $options): string
     {
-        $styles = ':root {';
-        $styles .= '--sidebar-width-desktop: ' . esc_attr($options['width_desktop'] ?? '') . 'px;';
-        $styles .= '--sidebar-width-tablet: ' . esc_attr($options['width_tablet'] ?? '') . 'px;';
+        $variables = [];
 
-        if (($options['bg_color_type'] ?? 'solid') === 'gradient') {
-            $styles .= '--sidebar-bg-image: linear-gradient(180deg, ' . esc_attr($options['bg_color_start'] ?? '') . ' 0%, ' . esc_attr($options['bg_color_end'] ?? '') . ' 100%);';
-            $styles .= '--sidebar-bg-color: ' . esc_attr($options['bg_color_start'] ?? '') . ';';
-        } else {
-            $styles .= '--sidebar-bg-image: none;';
-            $styles .= '--sidebar-bg-color: ' . esc_attr($options['bg_color'] ?? '') . ';';
-        }
+        $this->assignVariable($variables, '--sidebar-width-desktop', $this->formatPixelValue($this->resolveOption($options, 'width_desktop')));
+        $this->assignVariable($variables, '--sidebar-width-tablet', $this->formatPixelValue($this->resolveOption($options, 'width_tablet')));
 
-        if (($options['accent_color_type'] ?? 'solid') === 'gradient') {
-            $styles .= '--primary-accent-image: linear-gradient(90deg, ' . esc_attr($options['accent_color_start'] ?? '') . ' 0%, ' . esc_attr($options['accent_color_end'] ?? '') . ' 100%);';
-            $styles .= '--primary-accent-color: ' . esc_attr($options['accent_color_start'] ?? '') . ';';
-        } else {
-            $styles .= '--primary-accent-image: none;';
-            $styles .= '--primary-accent-color: ' . esc_attr($options['accent_color'] ?? '') . ';';
-        }
+        $bgType = $this->sanitizeCssString($this->resolveOption($options, 'bg_color_type')) ?? self::DYNAMIC_STYLE_DEFAULTS['bg_color_type'];
+        if ($bgType === 'gradient') {
+            $bgStart = $this->sanitizeCssString($this->resolveOption($options, 'bg_color_start'));
+            $bgEnd = $this->sanitizeCssString($this->resolveOption($options, 'bg_color_end'));
 
-        $styles .= '--sidebar-font-size: ' . esc_attr($options['font_size'] ?? '') . 'px;';
-        $styles .= '--sidebar-text-color: ' . esc_attr($options['font_color'] ?? '') . ';';
-        $styles .= '--sidebar-text-hover-color: ' . esc_attr($options['font_hover_color'] ?? '') . ';';
-        $styles .= '--transition-speed: ' . esc_attr($options['animation_speed'] ?? '') . 'ms;';
-        $styles .= '--header-padding-top: ' . esc_attr($options['header_padding_top'] ?? '') . ';';
-        $styles .= '--header-alignment-desktop: ' . esc_attr($options['header_alignment_desktop'] ?? '') . ';';
-        $styles .= '--header-alignment-mobile: ' . esc_attr($options['header_alignment_mobile'] ?? '') . ';';
-        $styles .= '--header-logo-size: ' . esc_attr($options['header_logo_size'] ?? '') . 'px;';
-        $styles .= '--hamburger-top-position: ' . esc_attr($options['hamburger_top_position'] ?? '') . ';';
-
-        $contentMarginValue = $options['content_margin'] ?? '';
-        if (is_string($contentMarginValue) || is_numeric($contentMarginValue)) {
-            $contentMarginValue = (string) $contentMarginValue;
-            $contentMarginTrimmed = trim($contentMarginValue);
-
-            if (preg_match('/^calc\((.*)\)$/i', $contentMarginTrimmed, $matches)) {
-                $contentMarginValue = $matches[1];
+            if ($bgStart !== null && $bgEnd !== null) {
+                $this->assignVariable($variables, '--sidebar-bg-image', sprintf('linear-gradient(180deg, %s 0%%, %s 100%%)', $bgStart, $bgEnd));
+                $this->assignVariable($variables, '--sidebar-bg-color', $bgStart);
             } else {
-                $contentMarginValue = $contentMarginTrimmed;
+                $solidBg = $this->sanitizeCssString($this->resolveOption($options, 'bg_color')) ?? self::DYNAMIC_STYLE_DEFAULTS['bg_color'];
+                $this->assignVariable($variables, '--sidebar-bg-image', 'none');
+                $this->assignVariable($variables, '--sidebar-bg-color', $solidBg);
             }
         } else {
-            $contentMarginValue = '';
+            $solidBg = $this->sanitizeCssString($this->resolveOption($options, 'bg_color')) ?? self::DYNAMIC_STYLE_DEFAULTS['bg_color'];
+            $this->assignVariable($variables, '--sidebar-bg-image', 'none');
+            $this->assignVariable($variables, '--sidebar-bg-color', $solidBg);
         }
 
-        $styles .= '--content-margin: calc(var(--sidebar-width-desktop) + ' . esc_attr($contentMarginValue) . ');';
-        $styles .= '--floating-vertical-margin: ' . esc_attr($options['floating_vertical_margin'] ?? '') . ';';
-        $styles .= '--border-radius: ' . esc_attr($options['border_radius'] ?? '') . ';';
-        $styles .= '--border-width: ' . esc_attr($options['border_width'] ?? '') . 'px;';
-        $styles .= '--border-color: ' . esc_attr($options['border_color'] ?? '') . ';';
-        $styles .= '--overlay-color: ' . esc_attr($options['overlay_color'] ?? '') . ';';
-        $styles .= '--overlay-opacity: ' . esc_attr($options['overlay_opacity'] ?? '') . ';';
-        $styles .= '--mobile-bg-color: ' . esc_attr($options['mobile_bg_color'] ?? '') . ';';
-        $styles .= '--mobile-bg-opacity: ' . esc_attr($options['mobile_bg_opacity'] ?? '') . ';';
-        $styles .= '--mobile-blur: ' . esc_attr($options['mobile_blur'] ?? '') . 'px;';
-        $styles .= '--menu-alignment-desktop: ' . esc_attr($options['menu_alignment_desktop'] ?? '') . ';';
-        $styles .= '--menu-alignment-mobile: ' . esc_attr($options['menu_alignment_mobile'] ?? '') . ';';
-        $styles .= '--search-alignment: ' . esc_attr($options['search_alignment'] ?? '') . ';';
+        $accentType = $this->sanitizeCssString($this->resolveOption($options, 'accent_color_type')) ?? self::DYNAMIC_STYLE_DEFAULTS['accent_color_type'];
+        if ($accentType === 'gradient') {
+            $accentStart = $this->sanitizeCssString($this->resolveOption($options, 'accent_color_start'));
+            $accentEnd = $this->sanitizeCssString($this->resolveOption($options, 'accent_color_end'));
 
-        $rawSocialIconSize = $options['social_icon_size'] ?? 100;
+            if ($accentStart !== null && $accentEnd !== null) {
+                $this->assignVariable($variables, '--primary-accent-image', sprintf('linear-gradient(90deg, %s 0%%, %s 100%%)', $accentStart, $accentEnd));
+                $this->assignVariable($variables, '--primary-accent-color', $accentStart);
+            } else {
+                $solidAccent = $this->sanitizeCssString($this->resolveOption($options, 'accent_color')) ?? self::DYNAMIC_STYLE_DEFAULTS['accent_color'];
+                $this->assignVariable($variables, '--primary-accent-image', 'none');
+                $this->assignVariable($variables, '--primary-accent-color', $solidAccent);
+            }
+        } else {
+            $solidAccent = $this->sanitizeCssString($this->resolveOption($options, 'accent_color')) ?? self::DYNAMIC_STYLE_DEFAULTS['accent_color'];
+            $this->assignVariable($variables, '--primary-accent-image', 'none');
+            $this->assignVariable($variables, '--primary-accent-color', $solidAccent);
+        }
+
+        $this->assignVariable($variables, '--sidebar-font-size', $this->formatPixelValue($this->resolveOption($options, 'font_size')));
+        $this->assignVariable($variables, '--sidebar-text-color', $this->sanitizeCssString($this->resolveOption($options, 'font_color')));
+        $this->assignVariable($variables, '--sidebar-text-hover-color', $this->sanitizeCssString($this->resolveOption($options, 'font_hover_color')));
+        $this->assignVariable($variables, '--transition-speed', $this->formatMillisecondsValue($this->resolveOption($options, 'animation_speed')));
+        $this->assignVariable($variables, '--header-padding-top', $this->sanitizeCssString($this->resolveOption($options, 'header_padding_top')));
+        $this->assignVariable($variables, '--header-alignment-desktop', $this->sanitizeCssString($this->resolveOption($options, 'header_alignment_desktop')));
+        $this->assignVariable($variables, '--header-alignment-mobile', $this->sanitizeCssString($this->resolveOption($options, 'header_alignment_mobile')));
+        $this->assignVariable($variables, '--header-logo-size', $this->formatPixelValue($this->resolveOption($options, 'header_logo_size')));
+        $this->assignVariable($variables, '--hamburger-top-position', $this->sanitizeCssString($this->resolveOption($options, 'hamburger_top_position')));
+
+        $contentMargin = $this->resolveContentMargin($options);
+        if ($contentMargin !== null) {
+            $this->assignVariable($variables, '--content-margin', $contentMargin);
+        }
+
+        $this->assignVariable($variables, '--floating-vertical-margin', $this->sanitizeCssString($this->resolveOption($options, 'floating_vertical_margin')));
+        $this->assignVariable($variables, '--border-radius', $this->sanitizeCssString($this->resolveOption($options, 'border_radius')));
+        $this->assignVariable($variables, '--border-width', $this->formatPixelValue($this->resolveOption($options, 'border_width')));
+        $this->assignVariable($variables, '--border-color', $this->sanitizeCssString($this->resolveOption($options, 'border_color')));
+        $this->assignVariable($variables, '--overlay-color', $this->sanitizeCssString($this->resolveOption($options, 'overlay_color')));
+        $this->assignVariable($variables, '--overlay-opacity', $this->formatOpacityValue($this->resolveOption($options, 'overlay_opacity')));
+        $this->assignVariable($variables, '--mobile-bg-color', $this->sanitizeCssString($this->resolveOption($options, 'mobile_bg_color')));
+        $this->assignVariable($variables, '--mobile-bg-opacity', $this->formatOpacityValue($this->resolveOption($options, 'mobile_bg_opacity')));
+        $this->assignVariable($variables, '--mobile-blur', $this->formatPixelValue($this->resolveOption($options, 'mobile_blur')));
+        $this->assignVariable($variables, '--menu-alignment-desktop', $this->sanitizeCssString($this->resolveOption($options, 'menu_alignment_desktop')));
+        $this->assignVariable($variables, '--menu-alignment-mobile', $this->sanitizeCssString($this->resolveOption($options, 'menu_alignment_mobile')));
+        $this->assignVariable($variables, '--search-alignment', $this->sanitizeCssString($this->resolveOption($options, 'search_alignment')));
+
+        $rawSocialIconSize = $this->resolveOption($options, 'social_icon_size');
         if (!is_numeric($rawSocialIconSize)) {
-            $rawSocialIconSize = 100;
+            $rawSocialIconSize = self::DYNAMIC_STYLE_DEFAULTS['social_icon_size'];
         }
         $socialIconSizeFactor = ((float) $rawSocialIconSize) / 100;
-        $styles .= '--social-icon-size-factor: ' . esc_attr($socialIconSizeFactor) . ';';
+        $this->assignVariable($variables, '--social-icon-size-factor', $this->normalizeNumericValue($socialIconSizeFactor));
 
-        if (($options['hover_effect_desktop'] ?? '') === 'neon' || ($options['hover_effect_mobile'] ?? '') === 'neon') {
-            $styles .= '--neon-blur: ' . esc_attr($options['neon_blur'] ?? '') . 'px;';
-            $styles .= '--neon-spread: ' . esc_attr($options['neon_spread'] ?? '') . 'px;';
+        $hoverEffectDesktop = $this->sanitizeCssString($this->resolveOption($options, 'hover_effect_desktop')) ?? self::DYNAMIC_STYLE_DEFAULTS['hover_effect_desktop'];
+        $hoverEffectMobile = $this->sanitizeCssString($this->resolveOption($options, 'hover_effect_mobile')) ?? self::DYNAMIC_STYLE_DEFAULTS['hover_effect_mobile'];
+        if ($hoverEffectDesktop === 'neon' || $hoverEffectMobile === 'neon') {
+            $this->assignVariable($variables, '--neon-blur', $this->formatPixelValue($this->resolveOption($options, 'neon_blur')));
+            $this->assignVariable($variables, '--neon-spread', $this->formatPixelValue($this->resolveOption($options, 'neon_spread')));
         }
 
+        if ($variables === []) {
+            return '';
+        }
+
+        $styles = ':root {';
+        foreach ($variables as $name => $value) {
+            $styles .= $name . ': ' . esc_attr($value) . ';';
+        }
         $styles .= '}';
 
         return $styles;
+    }
+
+    private function assignVariable(array &$variables, string $name, ?string $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        $variables[$name] = $value;
+    }
+
+    private function resolveOption(array $options, string $key)
+    {
+        $value = $options[$key] ?? null;
+
+        if (is_string($value)) {
+            $value = trim($value);
+            if ($value === '') {
+                $value = null;
+            }
+        }
+
+        if ($value === null && array_key_exists($key, self::DYNAMIC_STYLE_DEFAULTS)) {
+            $value = self::DYNAMIC_STYLE_DEFAULTS[$key];
+        }
+
+        return $value;
+    }
+
+    private function sanitizeCssString($value): ?string
+    {
+        if (is_string($value) || is_numeric($value)) {
+            $string = trim((string) $value);
+
+            return $string === '' ? null : $string;
+        }
+
+        return null;
+    }
+
+    private function formatPixelValue($value): ?string
+    {
+        $normalized = $this->normalizeNumericValue($value);
+
+        return $normalized === null ? null : $normalized . 'px';
+    }
+
+    private function formatMillisecondsValue($value): ?string
+    {
+        $normalized = $this->normalizeNumericValue($value);
+
+        return $normalized === null ? null : $normalized . 'ms';
+    }
+
+    private function formatOpacityValue($value): ?string
+    {
+        return $this->normalizeNumericValue($value);
+    }
+
+    private function normalizeNumericValue($value): ?string
+    {
+        if (is_string($value)) {
+            $value = trim($value);
+            if ($value === '') {
+                return null;
+            }
+        }
+
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        $floatValue = (float) $value;
+        if (abs($floatValue - (int) $floatValue) < 0.0001) {
+            return (string) (int) round($floatValue);
+        }
+
+        return rtrim(rtrim(sprintf('%.4f', $floatValue), '0'), '.');
+    }
+
+    private function resolveContentMargin(array $options): ?string
+    {
+        $rawValue = $this->resolveOption($options, 'content_margin');
+        if ($rawValue === null) {
+            return null;
+        }
+
+        $stringValue = is_string($rawValue) ? $rawValue : (string) $rawValue;
+        $stringValue = trim($stringValue);
+
+        if ($stringValue === '') {
+            return null;
+        }
+
+        if (preg_match('/^calc\((.*)\)$/i', $stringValue, $matches)) {
+            $stringValue = trim($matches[1]);
+        }
+
+        if ($stringValue === '') {
+            return null;
+        }
+
+        return 'calc(var(--sidebar-width-desktop) + ' . $stringValue . ')';
     }
 
     public function render(): void

--- a/sidebar-jlg/src/Frontend/Templating.php
+++ b/sidebar-jlg/src/Frontend/Templating.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace JLG\Sidebar\Frontend;
+
+class Templating
+{
+    public static function renderSocialIcons(array $socialIcons, array $allIcons, string $orientation): string
+    {
+        if ($socialIcons === []) {
+            return '';
+        }
+
+        ob_start();
+        ?>
+        <div class="social-icons <?php echo esc_attr($orientation); ?>">
+            <?php foreach ($socialIcons as $social) :
+                if (empty($social['icon']) || empty($social['url']) || !isset($allIcons[$social['icon']])) {
+                    continue;
+                }
+
+                $iconParts = explode('_', $social['icon']);
+                $iconLabel = (isset($iconParts[0]) && $iconParts[0] !== '') ? $iconParts[0] : 'unknown';
+                $customLabel = '';
+
+                if (isset($social['label']) && is_string($social['label'])) {
+                    $customLabel = trim($social['label']);
+                }
+
+                $ariaLabel = $customLabel !== '' ? $customLabel : $iconLabel;
+                ?>
+                <a href="<?php echo esc_url($social['url']); ?>" target="_blank" rel="noopener noreferrer" aria-label="<?php echo esc_attr($ariaLabel); ?>">
+                    <?php echo wp_kses_post($allIcons[$social['icon']]); ?>
+                </a>
+            <?php endforeach; ?>
+        </div>
+        <?php
+
+        return trim((string) ob_get_clean());
+    }
+}

--- a/tests/upload_dir_failure_regression_test.php
+++ b/tests/upload_dir_failure_regression_test.php
@@ -53,6 +53,10 @@ try {
 
 assertTrue($activationException === null, 'Activation callback completes without throwing');
 
+$transientMessage = get_transient('sidebar_jlg_activation_error');
+assertTrue(is_string($transientMessage) && $transientMessage !== '', 'Activation failure message is stored in a transient');
+assertTrue(strpos((string) $transientMessage, 'Uploads directory is unavailable') !== false, 'Transient message includes upload error details');
+
 $iconLibrary = new IconLibrary(__FILE__);
 $allIcons = $iconLibrary->getAllIcons();
 


### PR DESCRIPTION
## Summary
- report upload directory failures during activation through the existing admin transient so the notice is displayed
- move the social icon renderer into a dedicated namespaced helper and update the template to call it
- refactor the dynamic style builder to ignore empty values, apply defaults, and expose helpers for safer CSS variables

## Testing
- for file in tests/*_test.php; do php "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68d44c0c8fac832e846c7b8ec05c292c