### PR TITLE
Harden AJAX endpoints and cache handling

### DIFF
--- a/sidebar-jlg/src/Cache/MenuCache.php
+++ b/sidebar-jlg/src/Cache/MenuCache.php
@@ -33,7 +33,23 @@ class MenuCache
 
     public function get(string $locale)
     {
-        return get_transient($this->getTransientKey($locale));
+        $value = get_transient($this->getTransientKey($locale));
+
+        if ($value === false) {
+            return false;
+        }
+
+        if (!is_string($value)) {
+            $this->delete($locale);
+
+            if (function_exists('error_log')) {
+                error_log('[Sidebar JLG] Invalid sidebar cache payload cleared for locale ' . $this->normalizeLocale($locale));
+            }
+
+            return false;
+        }
+
+        return $value;
     }
 
     public function set(string $locale, string $html): void


### PR DESCRIPTION
## Summary
- strip all HTML from post and category labels before serializing AJAX responses
- enforce an upper limit on custom SVG icon requests and log excessive usage attempts
- validate cached sidebar payloads and automatically flush corrupted entries

## Testing
- php -l src/Ajax/Endpoints.php
- php -l src/Cache/MenuCache.php

------
https://chatgpt.com/codex/tasks/task_e_68d537f18e00832eb8af9727de7657ea