### PR TITLE
Sanitize icon library SVG markup centrally

### DIFF
--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -43,7 +43,7 @@ ob_start();
                     if ( ! empty( $item['icon_type'] ) && $item['icon_type'] === 'svg_url' && filter_var($item['icon'], FILTER_VALIDATE_URL) ) {
                         echo '<span class="menu-icon svg-icon"><img src="' . esc_url( $item['icon'] ) . '" alt=""></span>';
                     } elseif ( isset( $allIcons[ $item['icon'] ] ) ) {
-                        $icon_markup = wp_kses_post( $allIcons[ $item['icon'] ] );
+                        $icon_markup = (string) $allIcons[ $item['icon'] ];
 
                         if ( strpos( $item['icon'], 'custom_' ) === 0 ) {
                             echo '<span class="menu-icon svg-icon">' . $icon_markup . '</span>';
@@ -100,7 +100,7 @@ $sidebar_content_html = ob_get_clean();
             $close_button_markup = '<span class="close-sidebar-fallback" aria-hidden="true">&times;</span>';
 
             if (isset($allIcons['close_white']) && $allIcons['close_white'] !== '') {
-                $close_button_markup = wp_kses_post($allIcons['close_white']);
+                $close_button_markup = (string) $allIcons['close_white'];
             } else {
                 $close_button_markup = wp_kses_post($close_button_markup);
             }

--- a/sidebar-jlg/src/Frontend/Templating.php
+++ b/sidebar-jlg/src/Frontend/Templating.php
@@ -30,7 +30,7 @@ class Templating
                 '<a href="%1$s" target="_blank" rel="noopener noreferrer" aria-label="%2$s">%3$s</a>',
                 esc_url($social['url']),
                 esc_attr($ariaLabel),
-                wp_kses_post($allIcons[$social['icon']])
+                (string) $allIcons[$social['icon']]
             );
         }
 


### PR DESCRIPTION
## Summary
- add a public helper to sanitize and validate inline SVG markup with the same rules used for custom icons
- reuse the helper when loading both standard and custom icons so stored markup is always safe to render
- render previously sanitized SVG strings directly in templates that consume the icon library

## Testing
- php -l sidebar-jlg/src/Icons/IconLibrary.php
- php -l sidebar-jlg/includes/sidebar-template.php
- php -l sidebar-jlg/src/Frontend/Templating.php

------
https://chatgpt.com/codex/tasks/task_e_68d5c03d110c832e974837ab94d168cf