### PR TITLE
Enforce allow-listed options in sidebar sanitizer

### DIFF
--- a/tests/sanitize_effects_enumerated_settings_test.php
+++ b/tests/sanitize_effects_enumerated_settings_test.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Admin\SettingsSanitizer;
+use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\DefaultSettings;
+
+require __DIR__ . '/bootstrap.php';
+
+$GLOBALS['wp_test_function_overrides']['wp_check_filetype'] = static function ($file, $allowed = []) {
+    return ['ext' => '', 'type' => ''];
+};
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$defaults = new DefaultSettings();
+$icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
+$sanitizer = new SettingsSanitizer($defaults, $icons);
+
+$reflection = new ReflectionClass(SettingsSanitizer::class);
+$effectsMethod = $reflection->getMethod('sanitize_effects_settings');
+$effectsMethod->setAccessible(true);
+
+$testsPassed = true;
+
+function assertSame($expected, $actual, string $message): void {
+    global $testsPassed;
+
+    if ($expected !== $actual) {
+        $testsPassed = false;
+        echo "Assertion failed: {$message}. Expected `" . var_export($expected, true) . "`, got `" . var_export($actual, true) . "`.\n";
+    }
+}
+
+$existing_effects = array_merge($defaults->all(), [
+    'hover_effect_desktop' => 'neon',
+    'hover_effect_mobile'  => 'tile-slide',
+    'animation_type'       => 'fade',
+]);
+
+$input_invalid_effects = [
+    'hover_effect_desktop' => 'super-glow',
+    'hover_effect_mobile'  => 'spiral',
+    'animation_type'       => 'spin',
+];
+
+$result_effects = $effectsMethod->invoke($sanitizer, $input_invalid_effects, $existing_effects);
+
+assertSame('neon', $result_effects['hover_effect_desktop'] ?? null, 'Invalid desktop hover effect falls back to existing value');
+assertSame('tile-slide', $result_effects['hover_effect_mobile'] ?? null, 'Invalid mobile hover effect falls back to existing value');
+assertSame('fade', $result_effects['animation_type'] ?? null, 'Invalid animation type falls back to existing value');
+
+$existing_effects_invalid = array_merge($defaults->all(), [
+    'hover_effect_mobile' => 'spiral',
+    'animation_type'      => 'warp',
+]);
+
+$result_effects_default = $effectsMethod->invoke($sanitizer, $input_invalid_effects, $existing_effects_invalid);
+
+assertSame('none', $result_effects_default['hover_effect_mobile'] ?? null, 'Invalid mobile hover effect with invalid existing falls back to default');
+assertSame('slide-left', $result_effects_default['animation_type'] ?? null, 'Invalid animation type with invalid existing falls back to default');
+
+$socialMethod = $reflection->getMethod('sanitize_social_settings');
+$socialMethod->setAccessible(true);
+
+$existing_social = array_merge($defaults->all(), [
+    'social_orientation' => 'vertical',
+    'social_position'    => 'in-menu',
+]);
+
+$input_invalid_social = [
+    'social_orientation' => 'diagonal',
+    'social_position'    => 'header',
+];
+
+$result_social = $socialMethod->invoke($sanitizer, $input_invalid_social, $existing_social);
+
+assertSame('vertical', $result_social['social_orientation'] ?? null, 'Invalid social orientation falls back to existing value');
+assertSame('in-menu', $result_social['social_position'] ?? null, 'Invalid social position falls back to existing value');
+
+$existing_social_invalid = array_merge($defaults->all(), [
+    'social_orientation' => 'angled',
+    'social_position'    => 'header',
+]);
+
+$result_social_default = $socialMethod->invoke($sanitizer, $input_invalid_social, $existing_social_invalid);
+
+assertSame('horizontal', $result_social_default['social_orientation'] ?? null, 'Invalid social orientation with invalid existing falls back to default');
+assertSame('footer', $result_social_default['social_position'] ?? null, 'Invalid social position with invalid existing falls back to default');
+
+if (!$testsPassed) {
+    exit(1);
+}
+
+echo "All tests passed.\n";

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -103,6 +103,48 @@ $result_min = $method->invoke($sanitizer, $input_min, $existing_options);
 
 assertSame(0.0, $result_min['overlay_opacity'] ?? null, 'Overlay opacity is floored at 0.0');
 
+$existing_enums = array_merge($defaults->all(), [
+    'layout_style'           => 'floating',
+    'desktop_behavior'       => 'push',
+    'search_method'          => 'hook',
+    'search_alignment'       => 'flex-end',
+    'header_logo_type'       => 'image',
+    'header_alignment_desktop' => 'center',
+    'header_alignment_mobile'  => 'flex-start',
+]);
+
+$input_invalid_enums = [
+    'layout_style'           => 'diagonal',
+    'desktop_behavior'       => 'teleport',
+    'search_method'          => 'quantum',
+    'search_alignment'       => 'space-between',
+    'header_logo_type'       => 'emoji',
+    'header_alignment_desktop' => 'space-around',
+    'header_alignment_mobile'  => 'stretch',
+];
+
+$result_invalid_enums = $method->invoke($sanitizer, $input_invalid_enums, $existing_enums);
+
+assertSame('floating', $result_invalid_enums['layout_style'] ?? null, 'Invalid layout style falls back to existing value');
+assertSame('push', $result_invalid_enums['desktop_behavior'] ?? null, 'Invalid desktop behavior falls back to default');
+assertSame('hook', $result_invalid_enums['search_method'] ?? null, 'Invalid search method falls back to existing value');
+assertSame('flex-end', $result_invalid_enums['search_alignment'] ?? null, 'Invalid search alignment falls back to existing value');
+assertSame('image', $result_invalid_enums['header_logo_type'] ?? null, 'Invalid header logo type falls back to existing value');
+assertSame('center', $result_invalid_enums['header_alignment_desktop'] ?? null, 'Invalid desktop header alignment falls back to existing value');
+assertSame('flex-start', $result_invalid_enums['header_alignment_mobile'] ?? null, 'Invalid mobile header alignment falls back to existing value');
+
+$existing_invalid_alignment = array_merge($defaults->all(), [
+    'header_alignment_desktop' => 'diagonal',
+]);
+
+$input_invalid_alignment = [
+    'header_alignment_desktop' => 'curved',
+];
+
+$result_alignment_default = $method->invoke($sanitizer, $input_invalid_alignment, $existing_invalid_alignment);
+
+assertSame('flex-start', $result_alignment_default['header_alignment_desktop'] ?? null, 'Invalid alignment with invalid existing value falls back to default');
+
 if (!$testsPassed) {
     exit(1);
 }


### PR DESCRIPTION
## Summary
- gate every enumerated option in the settings sanitizer behind explicit allow lists and safe fallbacks
- reuse the same choice validation across the style, effects, menu, and social sanitizers to keep invalid values out
- cover invalid radio/select submissions with unit tests for general, effects, and social settings

## Testing
- php tests/sanitize_general_settings_test.php
- php tests/sanitize_effects_enumerated_settings_test.php
- php tests/sanitize_style_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d65d5919d8832e86f1f4b389f35358