### PR TITLE
Normalize numeric settings during option revalidation

### DIFF
--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -15,6 +15,23 @@ class SettingsRepository
         'header_padding_top',
     ];
 
+    private const OPACITY_OPTION_KEYS = [
+        'overlay_opacity',
+        'mobile_bg_opacity',
+    ];
+
+    private const ABSINT_OPTION_KEYS = [
+        'border_width',
+        'width_desktop',
+        'width_tablet',
+        'header_logo_size',
+        'font_size',
+        'mobile_blur',
+        'animation_speed',
+        'neon_blur',
+        'neon_spread',
+    ];
+
     private const COLOR_OPTION_KEYS = [
         'bg_color',
         'bg_color_start',
@@ -133,6 +150,54 @@ class SettingsRepository
 
             if (($revalidated[$dimensionKey] ?? '') !== $normalizedValue) {
                 $revalidated[$dimensionKey] = $normalizedValue;
+            }
+        }
+
+        foreach (self::OPACITY_OPTION_KEYS as $opacityKey) {
+            $defaultOpacity = isset($defaults[$opacityKey]) && is_numeric($defaults[$opacityKey])
+                ? max(0.0, min(1.0, (float) $defaults[$opacityKey]))
+                : 0.0;
+            $currentOpacity = $revalidated[$opacityKey] ?? $defaultOpacity;
+            $shouldUpdate = false;
+
+            if (!is_numeric($currentOpacity)) {
+                $normalizedOpacity = $defaultOpacity;
+                $shouldUpdate = true;
+            } else {
+                $normalizedOpacity = (float) $currentOpacity;
+
+                if ($normalizedOpacity < 0.0) {
+                    $normalizedOpacity = 0.0;
+                    $shouldUpdate = true;
+                } elseif ($normalizedOpacity > 1.0) {
+                    $normalizedOpacity = 1.0;
+                    $shouldUpdate = true;
+                }
+            }
+
+            if ($shouldUpdate) {
+                $revalidated[$opacityKey] = $normalizedOpacity;
+            }
+        }
+
+        foreach (self::ABSINT_OPTION_KEYS as $intKey) {
+            $defaultValue = isset($defaults[$intKey]) ? absint($defaults[$intKey]) : 0;
+            $currentValue = $revalidated[$intKey] ?? $defaultValue;
+            $shouldUpdate = false;
+
+            if (!is_scalar($currentValue)) {
+                $normalizedValue = $defaultValue;
+                $shouldUpdate = true;
+            } else {
+                $normalizedValue = absint($currentValue);
+
+                if ((string) $normalizedValue !== (string) $currentValue) {
+                    $shouldUpdate = true;
+                }
+            }
+
+            if ($shouldUpdate) {
+                $revalidated[$intKey] = $normalizedValue;
             }
         }
 

--- a/tests/revalidate_opacity_options_test.php
+++ b/tests/revalidate_opacity_options_test.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+use function JLG\Sidebar\plugin;
+
+require __DIR__ . '/bootstrap.php';
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$plugin = plugin();
+$repository = $plugin->getSettingsRepository();
+
+$defaults = $repository->getDefaultSettings();
+
+$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
+    'overlay_opacity' => 5.2,
+    'mobile_bg_opacity' => 'not-a-number',
+    'mobile_blur' => '-15',
+    'animation_speed' => '200ms',
+];
+
+$repository->revalidateStoredOptions();
+
+$storedAfterRevalidation = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+
+$testsPassed = true;
+
+function assertSame($expected, $actual, string $message): void
+{
+    if ($expected === $actual) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    global $testsPassed;
+    $testsPassed = false;
+    echo "[FAIL] {$message}. Expected `" . var_export($expected, true) . "`, got `" . var_export($actual, true) . "`.\n";
+}
+
+assertSame(1.0, $storedAfterRevalidation['overlay_opacity'] ?? null, 'Overlay opacity is clamped to 1.0');
+assertSame(
+    $defaults['mobile_bg_opacity'],
+    $storedAfterRevalidation['mobile_bg_opacity'] ?? null,
+    'Mobile background opacity falls back to default when invalid'
+);
+assertSame(15, $storedAfterRevalidation['mobile_blur'] ?? null, 'Mobile blur uses absolute integer value');
+assertSame(200, $storedAfterRevalidation['animation_speed'] ?? null, 'Animation speed is normalized using absint logic');
+
+if (!$testsPassed) {
+    exit(1);
+}
+
+echo "All tests passed.\n";


### PR DESCRIPTION
## Summary
- clamp opacity options and absint-based numeric settings when revalidating stored options
- add regression coverage to ensure corrupted opacity and blur settings are corrected

## Testing
- php tests/revalidate_opacity_options_test.php
- php tests/revalidate_color_options_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d65d595af4832e938a631ee1b381a8