### PR TITLE
Normalize numeric options during settings revalidation

### DIFF
--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -30,6 +30,7 @@ class SettingsRepository
         'animation_speed',
         'neon_blur',
         'neon_spread',
+        'social_icon_size',
     ];
 
     private const COLOR_OPTION_KEYS = [
@@ -172,6 +173,8 @@ class SettingsRepository
                 } elseif ($normalizedOpacity > 1.0) {
                     $normalizedOpacity = 1.0;
                     $shouldUpdate = true;
+                } elseif (!is_float($currentOpacity)) {
+                    $shouldUpdate = true;
                 }
             }
 
@@ -191,7 +194,7 @@ class SettingsRepository
             } else {
                 $normalizedValue = absint($currentValue);
 
-                if ((string) $normalizedValue !== (string) $currentValue) {
+                if ($normalizedValue !== (int) $currentValue || !is_int($currentValue)) {
                     $shouldUpdate = true;
                 }
             }

--- a/tests/revalidate_opacity_options_test.php
+++ b/tests/revalidate_opacity_options_test.php
@@ -17,6 +17,7 @@ $GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
     'mobile_bg_opacity' => 'not-a-number',
     'mobile_blur' => '-15',
     'animation_speed' => '200ms',
+    'social_icon_size' => '90%',
 ];
 
 $repository->revalidateStoredOptions();
@@ -46,6 +47,7 @@ assertSame(
 );
 assertSame(15, $storedAfterRevalidation['mobile_blur'] ?? null, 'Mobile blur uses absolute integer value');
 assertSame(200, $storedAfterRevalidation['animation_speed'] ?? null, 'Animation speed is normalized using absint logic');
+assertSame(90, $storedAfterRevalidation['social_icon_size'] ?? null, 'Social icon size is normalized using absint logic');
 
 if (!$testsPassed) {
     exit(1);


### PR DESCRIPTION
## Summary
- clamp stored opacity and integer options during settings revalidation to mirror the sanitizer logic, including social icon size
- extend the opacity revalidation regression test to cover numeric normalization cases

## Testing
- php tests/revalidate_opacity_options_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d6616bdc00832e88e12a18e812999d