### PR TITLE
Add allow lists for enumerated sidebar settings

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -20,10 +20,25 @@ class SettingsSanitizer
         'search_method' => ['default', 'shortcode', 'hook'],
         'search_alignment' => ['flex-start', 'center', 'flex-end'],
         'header_logo_type' => ['text', 'image'],
-        'header_alignment' => ['flex-start', 'center', 'flex-end'],
+        'header_alignment_desktop' => ['flex-start', 'center', 'flex-end'],
+        'header_alignment_mobile' => ['flex-start', 'center', 'flex-end'],
         'style_preset' => ['custom', 'moderne_dark'],
-        'color_type' => ['solid', 'gradient'],
-        'hover_effect' => [
+        'bg_color_type' => ['solid', 'gradient'],
+        'accent_color_type' => ['solid', 'gradient'],
+        'font_color_type' => ['solid', 'gradient'],
+        'font_hover_color_type' => ['solid', 'gradient'],
+        'hover_effect_desktop' => [
+            'none',
+            'tile-slide',
+            'underline-center',
+            'pill-center',
+            'spotlight',
+            'glossy-tilt',
+            'neon',
+            'glow',
+            'pulse',
+        ],
+        'hover_effect_mobile' => [
             'none',
             'tile-slide',
             'underline-center',
@@ -35,7 +50,8 @@ class SettingsSanitizer
             'pulse',
         ],
         'animation_type' => ['slide-left', 'fade', 'scale'],
-        'menu_alignment' => ['flex-start', 'center', 'flex-end'],
+        'menu_alignment_desktop' => ['flex-start', 'center', 'flex-end'],
+        'menu_alignment_mobile' => ['flex-start', 'center', 'flex-end'],
         'social_orientation' => ['horizontal', 'vertical'],
         'social_position' => ['footer', 'in-menu'],
     ];
@@ -153,13 +169,13 @@ class SettingsSanitizer
         $sanitized['header_logo_size'] = absint($input['header_logo_size'] ?? $existingOptions['header_logo_size']);
         $sanitized['header_alignment_desktop'] = $this->sanitizeChoice(
             $input['header_alignment_desktop'] ?? null,
-            $this->allowedChoices['header_alignment'],
+            $this->allowedChoices['header_alignment_desktop'],
             $existingOptions['header_alignment_desktop'] ?? ($defaults['header_alignment_desktop'] ?? ''),
             $defaults['header_alignment_desktop'] ?? ''
         );
         $sanitized['header_alignment_mobile'] = $this->sanitizeChoice(
             $input['header_alignment_mobile'] ?? null,
-            $this->allowedChoices['header_alignment'],
+            $this->allowedChoices['header_alignment_mobile'],
             $existingOptions['header_alignment_mobile'] ?? ($defaults['header_alignment_mobile'] ?? ''),
             $defaults['header_alignment_mobile'] ?? ''
         );
@@ -185,7 +201,7 @@ class SettingsSanitizer
 
         $sanitized['bg_color_type'] = $this->sanitizeChoice(
             $input['bg_color_type'] ?? null,
-            $this->allowedChoices['color_type'],
+            $this->allowedChoices['bg_color_type'],
             $existingOptions['bg_color_type'] ?? ($defaults['bg_color_type'] ?? ''),
             $defaults['bg_color_type'] ?? ''
         );
@@ -195,7 +211,7 @@ class SettingsSanitizer
 
         $sanitized['accent_color_type'] = $this->sanitizeChoice(
             $input['accent_color_type'] ?? null,
-            $this->allowedChoices['color_type'],
+            $this->allowedChoices['accent_color_type'],
             $existingOptions['accent_color_type'] ?? ($defaults['accent_color_type'] ?? ''),
             $defaults['accent_color_type'] ?? ''
         );
@@ -206,7 +222,7 @@ class SettingsSanitizer
         $sanitized['font_size'] = absint($input['font_size'] ?? $existingOptions['font_size']);
         $sanitized['font_color_type'] = $this->sanitizeChoice(
             $input['font_color_type'] ?? null,
-            $this->allowedChoices['color_type'],
+            $this->allowedChoices['font_color_type'],
             $existingOptions['font_color_type'] ?? ($defaults['font_color_type'] ?? ''),
             $defaults['font_color_type'] ?? ''
         );
@@ -216,7 +232,7 @@ class SettingsSanitizer
 
         $sanitized['font_hover_color_type'] = $this->sanitizeChoice(
             $input['font_hover_color_type'] ?? null,
-            $this->allowedChoices['color_type'],
+            $this->allowedChoices['font_hover_color_type'],
             $existingOptions['font_hover_color_type'] ?? ($defaults['font_hover_color_type'] ?? ''),
             $defaults['font_hover_color_type'] ?? ''
         );
@@ -241,13 +257,13 @@ class SettingsSanitizer
 
         $sanitized['hover_effect_desktop'] = $this->sanitizeChoice(
             $input['hover_effect_desktop'] ?? null,
-            $this->allowedChoices['hover_effect'],
+            $this->allowedChoices['hover_effect_desktop'],
             $existingOptions['hover_effect_desktop'] ?? ($defaults['hover_effect_desktop'] ?? ''),
             $defaults['hover_effect_desktop'] ?? ''
         );
         $sanitized['hover_effect_mobile'] = $this->sanitizeChoice(
             $input['hover_effect_mobile'] ?? null,
-            $this->allowedChoices['hover_effect'],
+            $this->allowedChoices['hover_effect_mobile'],
             $existingOptions['hover_effect_mobile'] ?? ($defaults['hover_effect_mobile'] ?? ''),
             $defaults['hover_effect_mobile'] ?? ''
         );
@@ -272,13 +288,13 @@ class SettingsSanitizer
 
         $sanitized['menu_alignment_desktop'] = $this->sanitizeChoice(
             $input['menu_alignment_desktop'] ?? null,
-            $this->allowedChoices['menu_alignment'],
+            $this->allowedChoices['menu_alignment_desktop'],
             $existingOptions['menu_alignment_desktop'] ?? ($defaults['menu_alignment_desktop'] ?? ''),
             $defaults['menu_alignment_desktop'] ?? ''
         );
         $sanitized['menu_alignment_mobile'] = $this->sanitizeChoice(
             $input['menu_alignment_mobile'] ?? null,
-            $this->allowedChoices['menu_alignment'],
+            $this->allowedChoices['menu_alignment_mobile'],
             $existingOptions['menu_alignment_mobile'] ?? ($defaults['menu_alignment_mobile'] ?? ''),
             $defaults['menu_alignment_mobile'] ?? ''
         );

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -20,6 +20,14 @@ $sanitizer = new SettingsSanitizer($defaults, $icons);
 $reflection = new ReflectionClass(SettingsSanitizer::class);
 $method = $reflection->getMethod('sanitize_general_settings');
 $method->setAccessible(true);
+$styleMethod = $reflection->getMethod('sanitize_style_settings');
+$styleMethod->setAccessible(true);
+$effectsMethod = $reflection->getMethod('sanitize_effects_settings');
+$effectsMethod->setAccessible(true);
+$menuMethod = $reflection->getMethod('sanitize_menu_settings');
+$menuMethod->setAccessible(true);
+$socialMethod = $reflection->getMethod('sanitize_social_settings');
+$socialMethod->setAccessible(true);
 
 $existing_options = array_merge($defaults->all(), [
     'overlay_color'   => 'rgba(10, 20, 30, 0.8)',
@@ -144,6 +152,123 @@ $input_invalid_alignment = [
 $result_alignment_default = $method->invoke($sanitizer, $input_invalid_alignment, $existing_invalid_alignment);
 
 assertSame('flex-start', $result_alignment_default['header_alignment_desktop'] ?? null, 'Invalid alignment with invalid existing value falls back to default');
+
+$existing_style_enums = array_merge($defaults->all(), [
+    'style_preset' => 'moderne_dark',
+    'bg_color_type' => 'gradient',
+    'accent_color_type' => 'gradient',
+]);
+
+$input_invalid_style_enums = [
+    'style_preset' => 'retro',
+    'bg_color_type' => 'pattern',
+    'accent_color_type' => 'sparkle',
+];
+
+$result_style_invalid = $styleMethod->invoke($sanitizer, $input_invalid_style_enums, $existing_style_enums);
+
+assertSame('moderne_dark', $result_style_invalid['style_preset'] ?? null, 'Invalid style preset falls back to existing value');
+assertSame('gradient', $result_style_invalid['bg_color_type'] ?? null, 'Invalid background color type falls back to existing value');
+assertSame('gradient', $result_style_invalid['accent_color_type'] ?? null, 'Invalid accent color type falls back to existing value');
+
+$existing_style_defaults = array_merge($defaults->all(), [
+    'font_color_type' => 'pattern',
+    'font_hover_color_type' => 'sparkle',
+]);
+
+$input_invalid_font_types = [
+    'font_color_type' => 'dots',
+    'font_hover_color_type' => 'stripes',
+];
+
+$result_style_default = $styleMethod->invoke($sanitizer, $input_invalid_font_types, $existing_style_defaults);
+
+assertSame('solid', $result_style_default['font_color_type'] ?? null, 'Invalid font color type with invalid existing value falls back to default');
+assertSame('solid', $result_style_default['font_hover_color_type'] ?? null, 'Invalid font hover color type with invalid existing value falls back to default');
+
+$existing_effects_enums = array_merge($defaults->all(), [
+    'hover_effect_desktop' => 'glow',
+    'hover_effect_mobile' => 'neon',
+    'animation_type' => 'fade',
+]);
+
+$input_invalid_effects = [
+    'hover_effect_desktop' => 'spin',
+    'hover_effect_mobile' => 'bounce',
+    'animation_type' => 'teleport',
+];
+
+$result_effects_invalid = $effectsMethod->invoke($sanitizer, $input_invalid_effects, $existing_effects_enums);
+
+assertSame('glow', $result_effects_invalid['hover_effect_desktop'] ?? null, 'Invalid desktop hover effect falls back to existing value');
+assertSame('neon', $result_effects_invalid['hover_effect_mobile'] ?? null, 'Invalid mobile hover effect falls back to existing value');
+assertSame('fade', $result_effects_invalid['animation_type'] ?? null, 'Invalid animation type falls back to existing value');
+
+$existing_effects_defaults = array_merge($defaults->all(), [
+    'hover_effect_mobile' => 'orbit',
+]);
+
+$input_invalid_mobile_effect = [
+    'hover_effect_mobile' => 'ripple',
+];
+
+$result_effects_default = $effectsMethod->invoke($sanitizer, $input_invalid_mobile_effect, $existing_effects_defaults);
+
+assertSame('none', $result_effects_default['hover_effect_mobile'] ?? null, 'Invalid mobile hover effect with invalid existing value falls back to default');
+
+$existing_menu_enums = array_merge($defaults->all(), [
+    'menu_alignment_desktop' => 'center',
+    'menu_alignment_mobile' => 'flex-end',
+]);
+
+$input_invalid_menu_alignments = [
+    'menu_alignment_desktop' => 'space-between',
+    'menu_alignment_mobile' => 'space-around',
+];
+
+$result_menu_invalid = $menuMethod->invoke($sanitizer, $input_invalid_menu_alignments, $existing_menu_enums);
+
+assertSame('center', $result_menu_invalid['menu_alignment_desktop'] ?? null, 'Invalid desktop menu alignment falls back to existing value');
+assertSame('flex-end', $result_menu_invalid['menu_alignment_mobile'] ?? null, 'Invalid mobile menu alignment falls back to existing value');
+
+$existing_menu_defaults = array_merge($defaults->all(), [
+    'menu_alignment_mobile' => 'stretch',
+]);
+
+$input_invalid_menu_mobile = [
+    'menu_alignment_mobile' => 'baseline',
+];
+
+$result_menu_default = $menuMethod->invoke($sanitizer, $input_invalid_menu_mobile, $existing_menu_defaults);
+
+assertSame('flex-start', $result_menu_default['menu_alignment_mobile'] ?? null, 'Invalid mobile menu alignment with invalid existing value falls back to default');
+
+$existing_social_enums = array_merge($defaults->all(), [
+    'social_orientation' => 'vertical',
+    'social_position' => 'in-menu',
+]);
+
+$input_invalid_social = [
+    'social_orientation' => 'diagonal',
+    'social_position' => 'header',
+];
+
+$result_social_invalid = $socialMethod->invoke($sanitizer, $input_invalid_social, $existing_social_enums);
+
+assertSame('vertical', $result_social_invalid['social_orientation'] ?? null, 'Invalid social orientation falls back to existing value');
+assertSame('in-menu', $result_social_invalid['social_position'] ?? null, 'Invalid social position falls back to existing value');
+
+$existing_social_defaults = array_merge($defaults->all(), [
+    'social_position' => 'sidebar',
+]);
+
+$input_invalid_social_default = [
+    'social_position' => 'toolbar',
+];
+
+$result_social_default = $socialMethod->invoke($sanitizer, $input_invalid_social_default, $existing_social_defaults);
+
+assertSame('footer', $result_social_default['social_position'] ?? null, 'Invalid social position with invalid existing value falls back to default');
 
 if (!$testsPassed) {
     exit(1);


### PR DESCRIPTION
## Summary
- add explicit allow lists for enumerated sidebar settings and apply them across sanitization routines
- ensure invalid enumerated inputs fall back to the stored or default value
- expand sanitizer tests to cover invalid style, effects, menu, and social options

## Testing
- php tests/sanitize_general_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d6616bc98c832ea76a5713cd8da96d