### PR TITLE
Add guard clauses for closing sidebar via Escape

### DIFF
--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -32,6 +32,9 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function closeSidebar() {
+        if (!document.body.classList.contains('sidebar-open')) {
+            return;
+        }
         document.body.classList.remove('sidebar-open');
         hamburgerBtn.classList.remove('is-active');
         hamburgerBtn.setAttribute('aria-expanded', 'false');
@@ -85,7 +88,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') {
+        if (e.key === 'Escape' && document.body.classList.contains('sidebar-open')) {
             closeSidebar();
         }
     });


### PR DESCRIPTION
## Summary
- avoid closing logic when the sidebar is already closed
- only respond to the Escape key when the sidebar is open

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66f9bec28832e97070c8a4d6fb3e1