### PR TITLE
Normalize enumerated settings during revalidation

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -4,6 +4,7 @@ namespace JLG\Sidebar\Admin;
 
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\OptionChoices;
 use JLG\Sidebar\Settings\ValueNormalizer;
 
 class SettingsSanitizer
@@ -14,52 +15,13 @@ class SettingsSanitizer
     /**
      * @var array<string, string[]>
      */
-    private array $allowedChoices = [
-        'layout_style' => ['full', 'floating'],
-        'desktop_behavior' => ['push', 'overlay'],
-        'search_method' => ['default', 'shortcode', 'hook'],
-        'search_alignment' => ['flex-start', 'center', 'flex-end'],
-        'header_logo_type' => ['text', 'image'],
-        'header_alignment_desktop' => ['flex-start', 'center', 'flex-end'],
-        'header_alignment_mobile' => ['flex-start', 'center', 'flex-end'],
-        'style_preset' => ['custom', 'moderne_dark'],
-        'bg_color_type' => ['solid', 'gradient'],
-        'accent_color_type' => ['solid', 'gradient'],
-        'font_color_type' => ['solid', 'gradient'],
-        'font_hover_color_type' => ['solid', 'gradient'],
-        'hover_effect_desktop' => [
-            'none',
-            'tile-slide',
-            'underline-center',
-            'pill-center',
-            'spotlight',
-            'glossy-tilt',
-            'neon',
-            'glow',
-            'pulse',
-        ],
-        'hover_effect_mobile' => [
-            'none',
-            'tile-slide',
-            'underline-center',
-            'pill-center',
-            'spotlight',
-            'glossy-tilt',
-            'neon',
-            'glow',
-            'pulse',
-        ],
-        'animation_type' => ['slide-left', 'fade', 'scale'],
-        'menu_alignment_desktop' => ['flex-start', 'center', 'flex-end'],
-        'menu_alignment_mobile' => ['flex-start', 'center', 'flex-end'],
-        'social_orientation' => ['horizontal', 'vertical'],
-        'social_position' => ['footer', 'in-menu'],
-    ];
+    private array $allowedChoices;
 
     public function __construct(DefaultSettings $defaults, IconLibrary $icons)
     {
         $this->defaults = $defaults;
         $this->icons = $icons;
+        $this->allowedChoices = OptionChoices::getAll();
     }
 
     public function sanitize_settings($input): array
@@ -409,42 +371,7 @@ class SettingsSanitizer
 
     private function sanitizeChoice($rawValue, array $allowed, $existingValue, $defaultValue): string
     {
-        $allowed = array_values(array_unique(array_map('strval', $allowed)));
-
-        $choice = $this->normalizeChoice($rawValue, $allowed);
-        if ($choice !== null) {
-            return $choice;
-        }
-
-        $existingChoice = $this->normalizeChoice($existingValue, $allowed);
-        if ($existingChoice !== null) {
-            return $existingChoice;
-        }
-
-        $defaultChoice = $this->normalizeChoice($defaultValue, $allowed);
-        if ($defaultChoice !== null) {
-            return $defaultChoice;
-        }
-
-        return $allowed[0] ?? '';
-    }
-
-    private function normalizeChoice($value, array $allowed): ?string
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        if (!is_scalar($value)) {
-            return null;
-        }
-
-        $sanitized = sanitize_key((string) $value);
-        if ($sanitized === '') {
-            return null;
-        }
-
-        return in_array($sanitized, $allowed, true) ? $sanitized : null;
+        return OptionChoices::resolveChoice($rawValue, $allowed, $existingValue, $defaultValue);
     }
 
 }

--- a/sidebar-jlg/src/Settings/OptionChoices.php
+++ b/sidebar-jlg/src/Settings/OptionChoices.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace JLG\Sidebar\Settings;
+
+final class OptionChoices
+{
+    /**
+     * @var array<string, string[]>
+     */
+    public const ALLOWED_CHOICES = [
+        'layout_style' => ['full', 'floating'],
+        'desktop_behavior' => ['push', 'overlay'],
+        'search_method' => ['default', 'shortcode', 'hook'],
+        'search_alignment' => ['flex-start', 'center', 'flex-end'],
+        'header_logo_type' => ['text', 'image'],
+        'header_alignment_desktop' => ['flex-start', 'center', 'flex-end'],
+        'header_alignment_mobile' => ['flex-start', 'center', 'flex-end'],
+        'style_preset' => ['custom', 'moderne_dark'],
+        'bg_color_type' => ['solid', 'gradient'],
+        'accent_color_type' => ['solid', 'gradient'],
+        'font_color_type' => ['solid', 'gradient'],
+        'font_hover_color_type' => ['solid', 'gradient'],
+        'hover_effect_desktop' => [
+            'none',
+            'tile-slide',
+            'underline-center',
+            'pill-center',
+            'spotlight',
+            'glossy-tilt',
+            'neon',
+            'glow',
+            'pulse',
+        ],
+        'hover_effect_mobile' => [
+            'none',
+            'tile-slide',
+            'underline-center',
+            'pill-center',
+            'spotlight',
+            'glossy-tilt',
+            'neon',
+            'glow',
+            'pulse',
+        ],
+        'animation_type' => ['slide-left', 'fade', 'scale'],
+        'menu_alignment_desktop' => ['flex-start', 'center', 'flex-end'],
+        'menu_alignment_mobile' => ['flex-start', 'center', 'flex-end'],
+        'social_orientation' => ['horizontal', 'vertical'],
+        'social_position' => ['footer', 'in-menu'],
+    ];
+
+    /**
+     * @return array<string, string[]>
+     */
+    public static function getAll(): array
+    {
+        return self::ALLOWED_CHOICES;
+    }
+
+    /**
+     * @param mixed $rawValue
+     * @param mixed $existingValue
+     * @param mixed $defaultValue
+     *
+     * @return string
+     */
+    public static function resolveChoice($rawValue, array $allowed, $existingValue, $defaultValue): string
+    {
+        $allowed = array_values(array_unique(array_map('strval', $allowed)));
+
+        $choice = self::normalizeChoice($rawValue, $allowed);
+        if ($choice !== null) {
+            return $choice;
+        }
+
+        $existingChoice = self::normalizeChoice($existingValue, $allowed);
+        if ($existingChoice !== null) {
+            return $existingChoice;
+        }
+
+        $defaultChoice = self::normalizeChoice($defaultValue, $allowed);
+        if ($defaultChoice !== null) {
+            return $defaultChoice;
+        }
+
+        return $allowed[0] ?? '';
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function normalizeChoice($value, array $allowed): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $sanitized = sanitize_key((string) $value);
+        if ($sanitized === '') {
+            return null;
+        }
+
+        return in_array($sanitized, $allowed, true) ? $sanitized : null;
+    }
+}

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -204,6 +204,22 @@ class SettingsRepository
             }
         }
 
+        foreach (OptionChoices::getAll() as $choiceKey => $allowedValues) {
+            $currentValue = $revalidated[$choiceKey] ?? null;
+            $defaultValue = $defaults[$choiceKey] ?? null;
+
+            $normalizedChoice = OptionChoices::resolveChoice(
+                $currentValue,
+                $allowedValues,
+                $defaultValue,
+                $defaultValue
+            );
+
+            if (($revalidated[$choiceKey] ?? null) !== $normalizedChoice) {
+                $revalidated[$choiceKey] = $normalizedChoice;
+            }
+        }
+
         if ($revalidated !== $merged) {
             update_option('sidebar_jlg_settings', $revalidated);
             $this->invalidateCache();

--- a/tests/revalidate_enumerated_options_test.php
+++ b/tests/revalidate_enumerated_options_test.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+use function JLG\Sidebar\plugin;
+
+require __DIR__ . '/bootstrap.php';
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$plugin = plugin();
+$repository = $plugin->getSettingsRepository();
+$renderer = $plugin->getSidebarRenderer();
+
+$defaults = $repository->getDefaultSettings();
+
+$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
+    'desktop_behavior' => 'invalid-behavior',
+];
+
+$repository->revalidateStoredOptions();
+
+$storedAfter = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+
+$testsPassed = true;
+
+function assertSame($expected, $actual, string $message): void
+{
+    if ($expected === $actual) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    global $testsPassed;
+    $testsPassed = false;
+    echo "[FAIL] {$message}. Expected `" . var_export($expected, true) . "`, got `" . var_export($actual, true) . "`.\n";
+}
+
+function assertContains($needle, array $haystack, string $message): void
+{
+    if (in_array($needle, $haystack, true)) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    global $testsPassed;
+    $testsPassed = false;
+    echo "[FAIL] {$message}. Needle `" . var_export($needle, true) . "` not found in `" . var_export($haystack, true) . "`.\n";
+}
+
+assertSame(
+    $defaults['desktop_behavior'],
+    $storedAfter['desktop_behavior'] ?? null,
+    'Desktop behavior falls back to default when stored value is invalid'
+);
+
+$bodyClasses = $renderer->addBodyClasses([]);
+assertContains('jlg-sidebar-push', $bodyClasses, 'Sidebar body classes include push modifier by default');
+
+if (!$testsPassed) {
+    exit(1);
+}
+
+echo "All tests passed.\n";


### PR DESCRIPTION
## Summary
- extract the enumerated option allow-lists into a shared helper so the sanitizer and repository stay in sync
- ensure `SettingsRepository::revalidateStoredOptions()` normalizes enumerated settings with the shared helper
- add a regression test covering recovery from an invalid `desktop_behavior` value and the resulting body classes

## Testing
- php tests/revalidate_enumerated_options_test.php
- php tests/sanitize_general_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d69b1e0cdc832eba336139b793a3e2