### PR TITLE
Clean up plugin version during uninstall

### DIFF
--- a/sidebar-jlg/uninstall.php
+++ b/sidebar-jlg/uninstall.php
@@ -17,6 +17,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // 1. Supprimer l'option principale du plugin de la table wp_options.
 // C'est ici que tous les réglages de la sidebar sont stockés.
 delete_option( 'sidebar_jlg_settings' );
+delete_option( 'sidebar_jlg_plugin_version' );
 
 // 2. Supprimer tous les transients de cache générés pour les locales mémorisées.
 $cached_locales = get_option( 'sidebar_jlg_cached_locales', [] );

--- a/tests/uninstall_version_cleanup_test.php
+++ b/tests/uninstall_version_cleanup_test.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+function assertSame($expected, $actual, string $message): void
+{
+    assertTrue($expected === $actual, $message);
+}
+
+update_option('sidebar_jlg_plugin_version', '4.1.0');
+assertSame('4.1.0', get_option('sidebar_jlg_plugin_version'), 'Plugin version option is seeded before uninstall');
+
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    define('WP_UNINSTALL_PLUGIN', true);
+}
+
+require __DIR__ . '/../sidebar-jlg/uninstall.php';
+
+$deletedValue = get_option('sidebar_jlg_plugin_version', null);
+assertSame(null, $deletedValue, 'Plugin version option is removed during uninstall');
+
+if ($testsPassed) {
+    echo "Uninstall version cleanup test passed.\n";
+    exit(0);
+}
+
+echo "Uninstall version cleanup test failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- delete the stored plugin version when uninstalling the sidebar extension
- add a regression test ensuring the uninstall script purges the version option

## Testing
- php tests/uninstall_version_cleanup_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d6ac3447bc832ea427510b53e0167a