### PR TITLE
Handle empty numeric inputs during settings sanitization

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -68,7 +68,12 @@ class SettingsSanitizer
             $input['border_radius'] ?? $existingOptions['border_radius'],
             $existingOptions['border_radius']
         );
-        $sanitized['border_width'] = absint($input['border_width'] ?? $existingOptions['border_width']);
+        $sanitized['border_width'] = $this->sanitizeIntegerOption(
+            $input,
+            'border_width',
+            $existingOptions,
+            $defaults
+        );
         $existingBorderColor = array_key_exists('border_color', $existingOptions)
             ? $existingOptions['border_color']
             : ($defaults['border_color'] ?? '');
@@ -96,8 +101,18 @@ class SettingsSanitizer
             $input['content_margin'] ?? $existingOptions['content_margin'],
             $existingOptions['content_margin']
         );
-        $sanitized['width_desktop'] = absint($input['width_desktop'] ?? $existingOptions['width_desktop']);
-        $sanitized['width_tablet'] = absint($input['width_tablet'] ?? $existingOptions['width_tablet']);
+        $sanitized['width_desktop'] = $this->sanitizeIntegerOption(
+            $input,
+            'width_desktop',
+            $existingOptions,
+            $defaults
+        );
+        $sanitized['width_tablet'] = $this->sanitizeIntegerOption(
+            $input,
+            'width_tablet',
+            $existingOptions,
+            $defaults
+        );
         $sanitized['enable_search'] = !empty($input['enable_search']);
         $sanitized['search_method'] = $this->sanitizeChoice(
             $input['search_method'] ?? null,
@@ -128,7 +143,12 @@ class SettingsSanitizer
             $defaults['header_logo_type'] ?? ''
         );
         $sanitized['header_logo_image'] = esc_url_raw($input['header_logo_image'] ?? $existingOptions['header_logo_image']);
-        $sanitized['header_logo_size'] = absint($input['header_logo_size'] ?? $existingOptions['header_logo_size']);
+        $sanitized['header_logo_size'] = $this->sanitizeIntegerOption(
+            $input,
+            'header_logo_size',
+            $existingOptions,
+            $defaults
+        );
         $sanitized['header_alignment_desktop'] = $this->sanitizeChoice(
             $input['header_alignment_desktop'] ?? null,
             $this->allowedChoices['header_alignment_desktop'],
@@ -181,7 +201,12 @@ class SettingsSanitizer
         $sanitized['accent_color_start'] = ValueNormalizer::normalizeColorWithExisting($input['accent_color_start'] ?? null, $existingOptions['accent_color_start']);
         $sanitized['accent_color_end'] = ValueNormalizer::normalizeColorWithExisting($input['accent_color_end'] ?? null, $existingOptions['accent_color_end']);
 
-        $sanitized['font_size'] = absint($input['font_size'] ?? $existingOptions['font_size']);
+        $sanitized['font_size'] = $this->sanitizeIntegerOption(
+            $input,
+            'font_size',
+            $existingOptions,
+            $defaults
+        );
         $sanitized['font_color_type'] = $this->sanitizeChoice(
             $input['font_color_type'] ?? null,
             $this->allowedChoices['font_color_type'],
@@ -207,7 +232,12 @@ class SettingsSanitizer
         $sanitized['mobile_bg_opacity'] = is_numeric($input['mobile_bg_opacity'] ?? null)
             ? max(0.0, min(1.0, (float) $input['mobile_bg_opacity']))
             : max(0.0, min(1.0, $existingOpacity));
-        $sanitized['mobile_blur'] = absint($input['mobile_blur'] ?? $existingOptions['mobile_blur']);
+        $sanitized['mobile_blur'] = $this->sanitizeIntegerOption(
+            $input,
+            'mobile_blur',
+            $existingOptions,
+            $defaults
+        );
 
         return $sanitized;
     }
@@ -229,15 +259,30 @@ class SettingsSanitizer
             $existingOptions['hover_effect_mobile'] ?? ($defaults['hover_effect_mobile'] ?? ''),
             $defaults['hover_effect_mobile'] ?? ''
         );
-        $sanitized['animation_speed'] = absint($input['animation_speed'] ?? $existingOptions['animation_speed']);
+        $sanitized['animation_speed'] = $this->sanitizeIntegerOption(
+            $input,
+            'animation_speed',
+            $existingOptions,
+            $defaults
+        );
         $sanitized['animation_type'] = $this->sanitizeChoice(
             $input['animation_type'] ?? null,
             $this->allowedChoices['animation_type'],
             $existingOptions['animation_type'] ?? ($defaults['animation_type'] ?? ''),
             $defaults['animation_type'] ?? ''
         );
-        $sanitized['neon_blur'] = absint($input['neon_blur'] ?? $existingOptions['neon_blur']);
-        $sanitized['neon_spread'] = absint($input['neon_spread'] ?? $existingOptions['neon_spread']);
+        $sanitized['neon_blur'] = $this->sanitizeIntegerOption(
+            $input,
+            'neon_blur',
+            $existingOptions,
+            $defaults
+        );
+        $sanitized['neon_spread'] = $this->sanitizeIntegerOption(
+            $input,
+            'neon_spread',
+            $existingOptions,
+            $defaults
+        );
 
         return $sanitized;
     }
@@ -364,9 +409,44 @@ class SettingsSanitizer
             $existingOptions['social_position'] ?? ($defaults['social_position'] ?? ''),
             $defaults['social_position'] ?? ''
         );
-        $sanitized['social_icon_size'] = absint($input['social_icon_size'] ?? $existingOptions['social_icon_size']);
+        $sanitized['social_icon_size'] = $this->sanitizeIntegerOption(
+            $input,
+            'social_icon_size',
+            $existingOptions,
+            $defaults
+        );
 
         return $sanitized;
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     * @param array<string, mixed> $existingOptions
+     * @param array<string, mixed> $defaults
+     */
+    private function sanitizeIntegerOption(array $input, string $key, array $existingOptions, array $defaults): int
+    {
+        $existing = $existingOptions[$key] ?? ($defaults[$key] ?? 0);
+
+        if (array_key_exists($key, $input)) {
+            $raw = $input[$key];
+
+            if (!is_scalar($raw)) {
+                return absint($existing);
+            }
+
+            if (is_string($raw)) {
+                $raw = trim($raw);
+            }
+
+            if ($raw === '' || !is_numeric($raw)) {
+                return absint($existing);
+            }
+
+            return absint($raw);
+        }
+
+        return absint($existing);
     }
 
     private function sanitizeChoice($rawValue, array $allowed, $existingValue, $defaultValue): string

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -103,6 +103,27 @@ $result_close_zero = $method->invoke($sanitizer, $input_close_on_click_zero, $ex
 
 assertSame(false, $result_close_zero['close_on_link_click'] ?? null, 'Close-on-click option treats "0" as disabled');
 
+$existing_numeric_general = array_merge($defaults->all(), [
+    'border_width'   => 4,
+    'width_desktop'  => 360,
+    'width_tablet'   => 280,
+    'header_logo_size' => 96,
+]);
+
+$input_empty_numeric_general = [
+    'border_width'   => '',
+    'width_desktop'  => '   ',
+    'width_tablet'   => 'abc',
+    'header_logo_size' => false,
+];
+
+$result_numeric_general = $method->invoke($sanitizer, $input_empty_numeric_general, $existing_numeric_general);
+
+assertSame(4, $result_numeric_general['border_width'] ?? null, 'Empty border width keeps existing value');
+assertSame(360, $result_numeric_general['width_desktop'] ?? null, 'Empty desktop width keeps existing value');
+assertSame(280, $result_numeric_general['width_tablet'] ?? null, 'Non-numeric tablet width keeps existing value');
+assertSame(96, $result_numeric_general['header_logo_size'] ?? null, 'Non-numeric header logo size keeps existing value');
+
 $input_min = [
     'overlay_opacity' => -0.3,
 ];
@@ -186,6 +207,21 @@ $result_style_default = $styleMethod->invoke($sanitizer, $input_invalid_font_typ
 assertSame('solid', $result_style_default['font_color_type'] ?? null, 'Invalid font color type with invalid existing value falls back to default');
 assertSame('solid', $result_style_default['font_hover_color_type'] ?? null, 'Invalid font hover color type with invalid existing value falls back to default');
 
+$existing_style_numeric = array_merge($defaults->all(), [
+    'font_size' => 22,
+    'mobile_blur' => 7,
+]);
+
+$input_style_numeric = [
+    'font_size' => '',
+    'mobile_blur' => 'blur',
+];
+
+$result_style_numeric = $styleMethod->invoke($sanitizer, $input_style_numeric, $existing_style_numeric);
+
+assertSame(22, $result_style_numeric['font_size'] ?? null, 'Empty font size keeps existing value');
+assertSame(7, $result_style_numeric['mobile_blur'] ?? null, 'Non-numeric mobile blur keeps existing value');
+
 $existing_effects_enums = array_merge($defaults->all(), [
     'hover_effect_desktop' => 'glow',
     'hover_effect_mobile' => 'neon',
@@ -215,6 +251,24 @@ $input_invalid_mobile_effect = [
 $result_effects_default = $effectsMethod->invoke($sanitizer, $input_invalid_mobile_effect, $existing_effects_defaults);
 
 assertSame('none', $result_effects_default['hover_effect_mobile'] ?? null, 'Invalid mobile hover effect with invalid existing value falls back to default');
+
+$existing_effects_numeric = array_merge($defaults->all(), [
+    'animation_speed' => 450,
+    'neon_blur' => 14,
+    'neon_spread' => 6,
+]);
+
+$input_effects_numeric = [
+    'animation_speed' => '',
+    'neon_blur' => 'blurrier',
+    'neon_spread' => [],
+];
+
+$result_effects_numeric = $effectsMethod->invoke($sanitizer, $input_effects_numeric, $existing_effects_numeric);
+
+assertSame(450, $result_effects_numeric['animation_speed'] ?? null, 'Empty animation speed keeps existing value');
+assertSame(14, $result_effects_numeric['neon_blur'] ?? null, 'Non-numeric neon blur keeps existing value');
+assertSame(6, $result_effects_numeric['neon_spread'] ?? null, 'Invalid neon spread keeps existing value');
 
 $existing_menu_enums = array_merge($defaults->all(), [
     'menu_alignment_desktop' => 'center',
@@ -269,6 +323,18 @@ $input_invalid_social_default = [
 $result_social_default = $socialMethod->invoke($sanitizer, $input_invalid_social_default, $existing_social_defaults);
 
 assertSame('footer', $result_social_default['social_position'] ?? null, 'Invalid social position with invalid existing value falls back to default');
+
+$existing_social_numeric = array_merge($defaults->all(), [
+    'social_icon_size' => 42,
+]);
+
+$input_social_numeric = [
+    'social_icon_size' => '',
+];
+
+$result_social_numeric = $socialMethod->invoke($sanitizer, $input_social_numeric, $existing_social_numeric);
+
+assertSame(42, $result_social_numeric['social_icon_size'] ?? null, 'Empty social icon size keeps existing value');
 
 if (!$testsPassed) {
     exit(1);


### PR DESCRIPTION
## Summary
- ensure numeric sidebar settings reuse existing or default values when provided inputs are empty or invalid
- expand sanitization test coverage to confirm general, style, effects, and social settings retain previous numeric values

## Testing
- php tests/sanitize_general_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d8074f6e3c832eb1afc53cfdc1790c