### PR TITLE
Sanitize external SVG menu icons

### DIFF
--- a/sidebar-jlg/src/Icons/IconLibrary.php
+++ b/sidebar-jlg/src/Icons/IconLibrary.php
@@ -376,7 +376,7 @@ class IconLibrary
         return $customIcons;
     }
 
-    private function recordRejectedCustomIcon(string $file, string $reasonKey, array $context = []): void
+    public function recordRejectedCustomIcon(string $file, string $reasonKey, array $context = []): void
     {
         $this->storeRejectedCustomIcon($file, $reasonKey, $context, true);
     }
@@ -551,6 +551,8 @@ class IconLibrary
                 return __('sanitized SVG differed from the original markup', 'sidebar-jlg');
             case 'empty_icon_key':
                 return __('filename produced an empty identifier', 'sidebar-jlg');
+            case 'external_svg_url':
+                return __('external SVG URLs are not allowed', 'sidebar-jlg');
             case 'unknown':
                 return __('was rejected', 'sidebar-jlg');
         }

--- a/tests/external_svg_icon_rejection_test.php
+++ b/tests/external_svg_icon_rejection_test.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Admin\SettingsSanitizer;
+use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\DefaultSettings;
+
+require __DIR__ . '/bootstrap.php';
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$defaults = new DefaultSettings();
+$icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
+$sanitizer = new SettingsSanitizer($defaults, $icons);
+
+$input = [
+    'menu_items' => [
+        [
+            'label' => 'External Icon',
+            'type' => 'custom',
+            'value' => 'https://example.com/page',
+            'icon_type' => 'svg_url',
+            'icon' => 'https://cdn.example.org/icons/icon.svg',
+        ],
+    ],
+];
+
+$sanitized = $sanitizer->sanitize_settings($input);
+$menuItems = $sanitized['menu_items'] ?? [];
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+function assertSame($expected, $actual, string $message): void
+{
+    $condition = $expected === $actual;
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $expectedExport = var_export($expected, true);
+    $actualExport = var_export($actual, true);
+    assertTrue(false, "{$message} - expected {$expectedExport} got {$actualExport}");
+}
+
+assertSame(1, count($menuItems), 'Menu item preserved after sanitization');
+$menuItem = $menuItems[0];
+
+assertSame('svg_inline', $menuItem['icon_type'], 'External SVG URL falls back to inline icon type');
+assertSame('', $menuItem['icon'], 'External SVG URL value cleared during sanitization');
+
+$rejections = $icons->consumeRejectedCustomIcons();
+assertTrue(!empty($rejections), 'Rejection recorded for external SVG URL');
+if (!empty($rejections)) {
+    $message = (string) $rejections[0];
+    assertTrue(strpos($message, 'external SVG URLs are not allowed') !== false, 'Rejection message references external SVG restriction');
+}
+
+$options = $sanitized;
+$options['social_icons'] = [];
+$allIcons = [];
+
+ob_start();
+require __DIR__ . '/../sidebar-jlg/includes/sidebar-template.php';
+$html = ob_get_clean();
+
+assertTrue(strpos($html, '<img') === false, 'No <img> tag rendered for rejected external SVG icon');
+
+if ($testsPassed) {
+    echo "External SVG icon rejection tests passed.\n";
+    exit(0);
+}
+
+echo "External SVG icon rejection tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- validate svg_url menu icons against the uploads/sidebar-jlg directory and fall back to inline icons when blocked
- expose the icon rejection logger and add a reason for external svg urls so the rejection is surfaced to admins
- add coverage proving external svg urls are sanitized away and never render an <img> tag in the sidebar template

## Testing
- php tests/external_svg_icon_rejection_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d91e0b6d2c832e8b45c4ba1784b6d5