### PR TITLE
Validate SVG icon URLs and add tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "devDependencies": {
         "jest": "^29.7.0",
-        "jest-environment-jsdom": "^29.7.0"
+        "jest-environment-jsdom": "^29.7.0",
+        "jquery": "^3.7.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3163,6 +3164,13 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "jquery": "^3.7.1"
   }
 }

--- a/sidebar-jlg/assets/js/__tests__/admin-script.test.js
+++ b/sidebar-jlg/assets/js/__tests__/admin-script.test.js
@@ -1,0 +1,40 @@
+describe('renderSvgUrlPreview', () => {
+  let renderSvgUrlPreview;
+  let $;
+
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '';
+
+    $ = require('jquery');
+    $.fn.ready = function() { return this; };
+    global.jQuery = $;
+    global.$ = $;
+
+    ({ renderSvgUrlPreview } = require('../admin-script.js'));
+  });
+
+  afterEach(() => {
+    delete global.jQuery;
+    delete global.$;
+    document.body.innerHTML = '';
+  });
+
+  it('escapes attributes when icon URL contains quotes', () => {
+    document.body.innerHTML = `
+      <span class="icon-preview"></span>
+    `;
+
+    const $preview = $('.icon-preview');
+    const iconValue = 'https://example.com/icon.svg" onload="alert(1)';
+
+    const didRender = renderSvgUrlPreview(iconValue, $preview);
+
+    expect(didRender).toBe(true);
+    const img = document.querySelector('.icon-preview img');
+    expect(img).not.toBeNull();
+    expect(img.getAttribute('src')).toBe('https://example.com/icon.svg%22%20onload=%22alert(1)');
+    expect(img.getAttribute('alt')).toBe('preview');
+    expect(img.getAttribute('onload')).toBeNull();
+  });
+});

--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -1,3 +1,38 @@
+function renderSvgUrlPreview(iconValue, $preview) {
+    if (!$preview || typeof $preview.empty !== 'function' || typeof $preview.append !== 'function') {
+        return false;
+    }
+
+    if (!iconValue) {
+        $preview.empty();
+        return false;
+    }
+
+    let url;
+    try {
+        url = new URL(iconValue, window.location.origin);
+    } catch (error) {
+        $preview.empty();
+        return false;
+    }
+
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+        $preview.empty();
+        return false;
+    }
+
+    const img = document.createElement('img');
+    img.src = url.href;
+    img.alt = 'preview';
+    $preview.empty().append(img);
+
+    return true;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.renderSvgUrlPreview = renderSvgUrlPreview;
+}
+
 jQuery(document).ready(function($) {
     const options = sidebarJLG.options || {};
     const ajaxUrl = sidebarJLG.ajax_url || '';
@@ -327,7 +362,7 @@ jQuery(document).ready(function($) {
 
         const iconType = $(input).closest('.menu-item-box').find('.menu-item-icon-type').val();
         if (iconType === 'svg_url') {
-            $preview.html(iconValue.startsWith('http') ? `<img src="${iconValue}" alt="preview">` : '');
+            renderSvgUrlPreview(iconValue, $preview);
             return;
         }
 
@@ -1127,6 +1162,16 @@ jQuery(document).ready(function($) {
     });
 
     // --- Bouton de debug (si mode debug activé) ---
+    if (typeof window !== 'undefined') {
+        window.SidebarJLGAdmin = window.SidebarJLGAdmin || {};
+        window.SidebarJLGAdmin.updateIconPreview = updateIconPreview;
+        window.SidebarJLGAdmin.renderSvgUrlPreview = renderSvgUrlPreview;
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports.updateIconPreview = updateIconPreview;
+    }
+
     if (debugMode) {
         const debugButton = $('<button type="button" class="button" style="margin-left: 20px;">🐛 Debug Info</button>');
         debugButton.on('click', function(e) {


### PR DESCRIPTION
## Summary
- validate external SVG icon URLs before rendering admin previews and render them via DOM APIs
- expose the SVG preview helper for reuse and make it available to tests
- add a Jest test to guard against quote injection in icon preview HTML and add jquery as a dev dependency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d920fd65a4832e81fdeff8e501c902