### PR TITLE
Restrict custom SVG previews to uploads directory

### DIFF
--- a/sidebar-jlg/assets/css/admin-style.css
+++ b/sidebar-jlg/assets/css/admin-style.css
@@ -21,6 +21,24 @@ input:checked + .jlg-slider:before { transform: translateX(26px); }
 .menu-item-content p { margin-top: 0; }
 .menu-item-content .widefat { width: 100%; }
 .icon-preview svg, .icon-preview img { width: 20px; height: 20px; vertical-align: middle; margin-left: 10px; }
+.icon-preview-status {
+    display: block;
+    margin-top: 6px;
+    font-size: 12px;
+    color: #3c434a;
+}
+.icon-preview-status.is-error {
+    color: #d63638;
+}
+.icon-input-invalid {
+    border-color: #d63638 !important;
+    box-shadow: 0 0 0 1px #d63638;
+}
+.icon-url-hint {
+    margin-top: 6px;
+    font-size: 12px;
+    color: #646970;
+}
 .menu-item-placeholder { border: 2px dashed #ccc; background-color: #f0f0f0; height: 50px; margin-bottom: 10px; }
 .menu-item-search-container { margin-top: 8px; gap: 8px; align-items: center; display: flex; }
 .menu-item-search-container input[type="search"] { flex: 1; min-width: 0; }

--- a/sidebar-jlg/assets/js/__tests__/admin-script.test.js
+++ b/sidebar-jlg/assets/js/__tests__/admin-script.test.js
@@ -11,12 +11,33 @@ describe('renderSvgUrlPreview', () => {
     global.jQuery = $;
     global.$ = $;
 
+    global.sidebarJLG = {
+      svg_url_restrictions: {
+        host: 'example.com',
+        allowed_path: '/wp-content/uploads/sidebar-jlg/'
+      },
+      options: {},
+      ajax_url: '',
+      nonce: '',
+      reset_nonce: '',
+      icons_manifest: [],
+      icon_fetch_action: ''
+    };
+
+    if (typeof window !== 'undefined') {
+      window.sidebarJLG = global.sidebarJLG;
+    }
+
     ({ renderSvgUrlPreview } = require('../admin-script.js'));
   });
 
   afterEach(() => {
     delete global.jQuery;
     delete global.$;
+    delete global.sidebarJLG;
+    if (typeof window !== 'undefined' && window.sidebarJLG) {
+      delete window.sidebarJLG;
+    }
     document.body.innerHTML = '';
   });
 
@@ -26,15 +47,33 @@ describe('renderSvgUrlPreview', () => {
     `;
 
     const $preview = $('.icon-preview');
-    const iconValue = 'https://example.com/icon.svg" onload="alert(1)';
+    const iconValue = 'https://example.com/wp-content/uploads/sidebar-jlg/icon.svg" onload="alert(1)';
 
     const didRender = renderSvgUrlPreview(iconValue, $preview);
 
     expect(didRender).toBe(true);
     const img = document.querySelector('.icon-preview img');
     expect(img).not.toBeNull();
-    expect(img.getAttribute('src')).toBe('https://example.com/icon.svg%22%20onload=%22alert(1)');
+    expect(img.getAttribute('src')).toBe('https://example.com/wp-content/uploads/sidebar-jlg/icon.svg%22%20onload=%22alert(1)');
     expect(img.getAttribute('alt')).toBe('preview');
     expect(img.getAttribute('onload')).toBeNull();
+  });
+
+  it('rejects URLs outside of the allowed upload directory', () => {
+    document.body.innerHTML = `
+      <input type="text" class="icon-input" />
+      <span class="icon-preview"></span>
+      <span class="icon-preview-status"></span>
+    `;
+
+    const $preview = $('.icon-preview');
+    const iconValue = 'https://example.com/wp-content/uploads/other-folder/icon.svg';
+
+    const didRender = renderSvgUrlPreview(iconValue, $preview);
+
+    expect(didRender).toBe(false);
+    expect(document.querySelector('.icon-preview img')).toBeNull();
+    expect($('.icon-input').hasClass('icon-input-invalid')).toBe(true);
+    expect($('.icon-preview-status').text()).toMatch(/ne sera pas enregistrée/i);
   });
 });

--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -94,6 +94,7 @@ class MenuPage
             'options' => wp_parse_args($options, $defaults),
             'icons_manifest' => $this->icons->getIconManifest(),
             'icon_fetch_action' => 'jlg_get_icon_svg',
+            'svg_url_restrictions' => $this->sanitizer->getSvgUrlRestrictions(),
         ]);
     }
 

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -48,6 +48,14 @@ class SettingsSanitizer
         return array_merge($existingOptions, $sanitizedInput);
     }
 
+    /**
+     * @return array{host: string|null, allowed_path: string}
+     */
+    public function getSvgUrlRestrictions(): array
+    {
+        return $this->getSvgUrlValidationContext();
+    }
+
     private function sanitize_general_settings(array $input, array $existingOptions): array
     {
         $sanitized = [];


### PR DESCRIPTION
## Summary
- expose the SVG upload restrictions to the admin JavaScript bundle
- validate preview URLs client-side and display warnings when they fall outside the allowed uploads path
- style the warning state and adjust unit tests to cover the new behaviour

## Testing
- npx jest --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68da5738dbfc832eb1e659485bbb602e