### PR TITLE
Whitelist settings sanitizer output keys

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -32,9 +32,11 @@ class SettingsSanitizer
             if (function_exists('error_log')) {
                 error_log('Sidebar JLG settings option was not an array. Resetting to defaults.');
             }
-            $existingOptions = $defaults;
+            $existingOptions = [];
         }
-        $existingOptions = wp_parse_args($existingOptions, $defaults);
+        $allowedKeys = array_fill_keys(array_keys($defaults), true);
+        $existingOptions = array_intersect_key($existingOptions, $allowedKeys);
+        $existingOptions = array_merge($defaults, $existingOptions);
         $preparedInput = is_array($input) ? $input : [];
 
         $sanitizedInput = array_merge(
@@ -45,7 +47,9 @@ class SettingsSanitizer
             $this->sanitize_social_settings($preparedInput, $existingOptions) ?: []
         );
 
-        return array_merge($existingOptions, $sanitizedInput);
+        $sanitizedInput = array_intersect_key($sanitizedInput, $allowedKeys);
+
+        return array_merge($defaults, $sanitizedInput);
     }
 
     /**

--- a/tests/sanitize_settings_corrupted_option_test.php
+++ b/tests/sanitize_settings_corrupted_option_test.php
@@ -13,10 +13,13 @@ $defaults = new DefaultSettings();
 $icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
 $sanitizer = new SettingsSanitizer($defaults, $icons);
 
-$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = 'totally-invalid-settings';
+$storedOptions = $defaults->all();
+$storedOptions['unexpected'] = 'should disappear';
+$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = $storedOptions;
 
 $input = [
     'enable_sidebar' => '1',
+    'unexpected_input' => 'also removed',
 ];
 
 $testsPassed = true;
@@ -57,6 +60,8 @@ assertSame(true, $sanitized['enable_sidebar'] ?? null, 'Enable sidebar flag keep
 assertSame($defaultSettings['layout_style'], $sanitized['layout_style'] ?? null, 'Layout style falls back to default when missing from input');
 assertSame($normalizedOverlayDefault, $sanitized['overlay_color'] ?? null, 'Overlay color falls back to default when missing from input');
 assertSame($defaultSettings['social_position'], $sanitized['social_position'] ?? null, 'Social position falls back to default when missing from input');
+assertTrue(!array_key_exists('unexpected', $sanitized), 'Unexpected stored keys are stripped after sanitization');
+assertTrue(!array_key_exists('unexpected_input', $sanitized), 'Unexpected input keys are stripped after sanitization');
 
 if (!$testsPassed) {
     exit(1);


### PR DESCRIPTION
## Summary
- filter existing settings with the default whitelist before sanitizing
- merge sanitized values onto defaults so only approved keys are returned
- extend the corrupted settings test to confirm unexpected keys are stripped

## Testing
- php tests/sanitize_settings_corrupted_option_test.php

------
https://chatgpt.com/codex/tasks/task_e_68dad6b04d98832e89b7a3d13faaf883