### PR TITLE
Strip color suffixes from social icon labels

### DIFF
--- a/sidebar-jlg/src/Frontend/Templating.php
+++ b/sidebar-jlg/src/Frontend/Templating.php
@@ -4,6 +4,8 @@ namespace JLG\Sidebar\Frontend;
 
 class Templating
 {
+    private const ICON_COLOR_SUFFIXES = ['white', 'black'];
+
     public static function renderSocialIcons(array $socialIcons, array $allIcons, string $orientation): string
     {
         if ($socialIcons === []) {
@@ -60,6 +62,16 @@ class Templating
         }
 
         $readable = trim($readable);
+
+        if ($readable !== '' && self::ICON_COLOR_SUFFIXES !== []) {
+            $suffixPattern = sprintf(
+                '/\b(?:%s)\s*$/u',
+                implode('|', array_map(static fn (string $suffix): string => preg_quote($suffix, '/'), self::ICON_COLOR_SUFFIXES))
+            );
+
+            $readable = (string) preg_replace($suffixPattern, '', $readable);
+            $readable = trim($readable);
+        }
 
         if ($readable === '') {
             return __('Lien social', 'sidebar-jlg');

--- a/tests/render_social_icons_markup_test.php
+++ b/tests/render_social_icons_markup_test.php
@@ -34,7 +34,7 @@ $resultWithStandardIcon = Templating::renderSocialIcons([
     ],
 ], $allIcons, 'horizontal');
 
-$expectedStandardMarkup = '<div class="social-icons horizontal"><a href="https://example.com/facebook" target="_blank" rel="noopener noreferrer" aria-label="Facebook White"><svg class="facebook"></svg></a></div>';
+$expectedStandardMarkup = '<div class="social-icons horizontal"><a href="https://example.com/facebook" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><svg class="facebook"></svg></a></div>';
 assertSame($expectedStandardMarkup, $resultWithStandardIcon, 'renders markup for valid social icon with humanized label');
 
 $resultWithCustomLabel = Templating::renderSocialIcons([

--- a/tests/social_icon_label_persistence_test.php
+++ b/tests/social_icon_label_persistence_test.php
@@ -103,7 +103,7 @@ $html = ob_get_clean();
 unset($GLOBALS['wp_test_function_overrides']['esc_attr']);
 
 assertContains('aria-label="Label &quot;Test &amp; Co&quot;"', $html, 'Custom label is escaped in aria-label attribute');
-assertContains('aria-label="x"', $html, 'Empty label falls back to icon name in aria-label');
+assertContains('aria-label="X"', $html, 'Empty label falls back to icon name in aria-label');
 
 if (!$testsPassed) {
     exit(1);


### PR DESCRIPTION
## Summary
- remove trailing color suffixes when humanizing social icon keys so aria-labels drop white/black endings
- keep existing custom icon handling intact and adjust tests for the new labels

## Testing
- php tests/render_social_icons_markup_test.php
- php tests/social_icon_label_persistence_test.php

------
https://chatgpt.com/codex/tasks/task_e_68dbf7524740832ebb4bb1b453104863