### PR TITLE
Handle missing icon fallback for social links

### DIFF
--- a/sidebar-jlg/src/Frontend/Templating.php
+++ b/sidebar-jlg/src/Frontend/Templating.php
@@ -15,7 +15,7 @@ class Templating
         $iconsMarkup = [];
 
         foreach ($socialIcons as $social) {
-            if (empty($social['icon']) || empty($social['url']) || !isset($allIcons[$social['icon']])) {
+            if (empty($social['url'])) {
                 continue;
             }
 
@@ -25,14 +25,34 @@ class Templating
                 $customLabel = trim($social['label']);
             }
 
-            $defaultLabel = self::humanizeIconKey((string) $social['icon']);
+            $iconKey = isset($social['icon']) ? (string) $social['icon'] : '';
+            $iconMarkup = $iconKey !== '' && isset($allIcons[$iconKey]) ? (string) $allIcons[$iconKey] : null;
+
+            $defaultLabel = self::humanizeIconKey($iconKey);
             $ariaLabel = $customLabel !== '' ? $customLabel : $defaultLabel;
 
+            $href = esc_url($social['url']);
+
+            if ($href === '') {
+                continue;
+            }
+
+            $linkClasses = [];
+
+            if ($iconMarkup === null) {
+                $linkClasses[] = 'no-icon';
+            }
+
+            $classAttribute = $linkClasses === [] ? '' : sprintf(' class="%s"', esc_attr(implode(' ', $linkClasses)));
+
+            $content = $iconMarkup ?? sprintf('<span class="no-icon-label">%s</span>', esc_html($ariaLabel));
+
             $iconsMarkup[] = sprintf(
-                '<a href="%1$s" target="_blank" rel="noopener noreferrer" aria-label="%2$s">%3$s</a>',
-                esc_url($social['url']),
+                '<a href="%1$s"%2$s target="_blank" rel="noopener noreferrer" aria-label="%3$s">%4$s</a>',
+                $href,
+                $classAttribute,
                 esc_attr($ariaLabel),
-                (string) $allIcons[$social['icon']]
+                $content
             );
         }
 

--- a/tests/render_social_icons_markup_test.php
+++ b/tests/render_social_icons_markup_test.php
@@ -59,7 +59,7 @@ $resultWithCustomFallback = Templating::renderSocialIcons([
 $expectedCustomFallbackMarkup = '<div class="social-icons vertical"><a href="https://example.com/custom" target="_blank" rel="noopener noreferrer" aria-label="My Brand"><svg class="custom"></svg></a></div>';
 assertSame($expectedCustomFallbackMarkup, $resultWithCustomFallback, 'falls back to humanized label for custom icon');
 
-$resultWithoutRenderableIcons = Templating::renderSocialIcons([
+$resultWithMissingIconMarkup = Templating::renderSocialIcons([
     [
         'icon'  => 'unknown_icon',
         'url'   => 'https://example.com/unknown',
@@ -67,6 +67,7 @@ $resultWithoutRenderableIcons = Templating::renderSocialIcons([
     ],
 ], $allIcons, 'horizontal');
 
-assertSame('', $resultWithoutRenderableIcons, 'returns empty string when no valid icons are rendered');
+$expectedMissingIconMarkup = '<div class="social-icons horizontal"><a href="https://example.com/unknown" class="no-icon" target="_blank" rel="noopener noreferrer" aria-label="Unknown Icon"><span class="no-icon-label">Unknown Icon</span></a></div>';
+assertSame($expectedMissingIconMarkup, $resultWithMissingIconMarkup, 'renders textual fallback when icon markup is missing');
 
 exit($testsPassed ? 0 : 1);


### PR DESCRIPTION
## Summary
- update the social icons renderer to keep valid links even when icon markup is unavailable by outputting a textual fallback
- flag fallback links with a no-icon class and label span for custom styling
- cover the new behaviour with an updated render_social_icons_markup_test scenario

## Testing
- php tests/render_social_icons_markup_test.php

------
https://chatgpt.com/codex/tasks/task_e_68dbfb976898832ea08e25a3217a12f2