### PR TITLE
Guard search block option sync behind capability checks

### DIFF
--- a/tests/search_block_option_sync_permissions_test.php
+++ b/tests/search_block_option_sync_permissions_test.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Frontend\Blocks\SearchBlock;
+use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
+
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../sidebar-jlg/autoload.php';
+
+$GLOBALS['test_current_user_can'] = false;
+$GLOBALS['test_is_admin'] = false;
+
+if (!function_exists('current_user_can')) {
+    function current_user_can($capability): bool
+    {
+        return !empty($GLOBALS['test_current_user_can']);
+    }
+}
+
+if (!function_exists('is_admin')) {
+    function is_admin(): bool
+    {
+        return !empty($GLOBALS['test_is_admin']);
+    }
+}
+
+$testsPassed = true;
+
+function assertSameValue($expected, $actual, string $message): void
+{
+    global $testsPassed;
+
+    if ($expected === $actual) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+    echo 'Expected: ' . var_export($expected, true) . "\n";
+    echo 'Actual: ' . var_export($actual, true) . "\n";
+}
+
+$pluginFile = __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+$defaults = new DefaultSettings();
+$iconLibrary = new IconLibrary($pluginFile);
+
+$createBlock = static function () use ($defaults, $iconLibrary, $pluginFile): SearchBlock {
+    $settings = new SettingsRepository($defaults, $iconLibrary);
+
+    return new SearchBlock($settings, $pluginFile, 'test-version');
+};
+
+$initialOptions = [
+    'enable_search' => false,
+    'search_method' => 'default',
+    'search_alignment' => 'flex-start',
+    'search_shortcode' => '',
+];
+
+$attributes = [
+    'enable_search' => true,
+    'search_method' => 'shortcode',
+    'search_alignment' => 'center',
+    'search_shortcode' => '[example] ',
+];
+
+// Scenario 1: visitor or unauthorized user should not trigger option synchronization.
+$GLOBALS['test_current_user_can'] = false;
+$GLOBALS['test_is_admin'] = false;
+update_option('sidebar_jlg_settings', $initialOptions);
+
+$unauthorizedBlock = $createBlock();
+$unauthorizedBlock->render($attributes);
+
+$storedAfterUnauthorized = get_option('sidebar_jlg_settings');
+assertSameValue($initialOptions, $storedAfterUnauthorized, 'Options remain unchanged for unauthorized users.');
+
+// Scenario 2: admin context with proper capability should synchronize options.
+$GLOBALS['test_current_user_can'] = true;
+$GLOBALS['test_is_admin'] = true;
+update_option('sidebar_jlg_settings', $initialOptions);
+
+$authorizedBlock = $createBlock();
+$authorizedBlock->render($attributes);
+
+$expectedOptions = $initialOptions;
+$expectedOptions['enable_search'] = true;
+$expectedOptions['search_method'] = 'shortcode';
+$expectedOptions['search_alignment'] = 'center';
+$expectedOptions['search_shortcode'] = '[example]';
+
+$storedAfterAuthorized = get_option('sidebar_jlg_settings');
+assertSameValue($expectedOptions, $storedAfterAuthorized, 'Options are synchronized for authorized users in admin context.');
+
+if ($testsPassed) {
+    echo "Search block option synchronization permission tests passed.\n";
+    exit(0);
+}
+
+echo "Search block option synchronization permission tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- ensure the search block skips option synchronization outside of admin contexts without manage_options
- add a capability gate inside the synchronization routine itself
- cover authorized and unauthorized render scenarios with a new test

## Testing
- php tests/search_block_option_sync_permissions_test.php

------
https://chatgpt.com/codex/tasks/task_e_68dc225f7ec8832e8b2be77463e795ef