### PR TITLE
Allow ARIA attributes in sanitized SVG icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Après activation, un menu "Sidebar JLG" apparait dans l'administration. Vous po
 - Seuls les fichiers au format `.svg` sont chargés par le plugin. Chaque fichier est contrôlé avec `wp_check_filetype()` avant d'être ajouté à la bibliothèque.
 - Le contenu SVG est validé via `wp_kses`. Les fichiers dont le contenu est altéré par le nettoyage ou qui contiennent des éléments non autorisés sont ignorés pour éviter toute contamination.
 - Un contrôle supplémentaire inspecte les attributs `href`/`xlink:href` des balises `<use>` afin de s'assurer qu'ils pointent uniquement vers un identifiant local ou vers un média de la bibliothèque (`wp-content/uploads`). Les validations spécifiques sont centralisées dans `Sidebar\JLG\Icons\IconLibrary::validateSanitizedSvg()` pour simplifier l'ajout de nouvelles règles de sécurité.
+- Les attributs ARIA usuels (`aria-label`, `aria-describedby`, etc.) sont désormais préservés lors de la validation afin de faciliter l'accessibilité des icônes.
 
 ## Désinstallation
 

--- a/sidebar-jlg/src/Icons/IconLibrary.php
+++ b/sidebar-jlg/src/Icons/IconLibrary.php
@@ -662,6 +662,8 @@ class IconLibrary
             'transform' => true,
             'data-name' => true,
             'focusable' => true,
+            'aria-label' => true,
+            'aria-describedby' => true,
         ];
 
         $allowed = [

--- a/tests/sanitize_svg_markup_helper_test.php
+++ b/tests/sanitize_svg_markup_helper_test.php
@@ -81,6 +81,18 @@ if (is_array($safeResult)) {
     assertNotContains('<script', $safeResult['svg'], 'sanitizeSvgMarkup keeps safe markup unchanged');
 }
 
+$svgWithAria = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" aria-label="Icone decorative" aria-describedby="group-desc"><g id="group-desc" aria-label="Description du groupe"><circle cx="5" cy="5" r="4" aria-label="Point central" /></g></svg>';
+$failure = null;
+$ariaResult = $iconLibrary->sanitizeSvgMarkup($svgWithAria, null, $failure);
+
+assertTrue(is_array($ariaResult), 'sanitizeSvgMarkup accepts SVG markup with common ARIA attributes');
+assertSame(null, $failure, 'sanitizeSvgMarkup leaves failure context empty for SVG markup using ARIA attributes');
+
+if (is_array($ariaResult)) {
+    assertTrue(strpos($ariaResult['svg'], 'aria-label="Icone decorative"') !== false, 'sanitizeSvgMarkup preserves aria-label attributes');
+    assertTrue(strpos($ariaResult['svg'], 'aria-describedby="group-desc"') !== false, 'sanitizeSvgMarkup preserves aria-describedby attributes');
+}
+
 $svgWithScript = '<svg xmlns="http://www.w3.org/2000/svg"><title>Unsafe</title><script>alert(1)</script><circle cx="0" cy="0" r="1" /></svg>';
 $failure = null;
 $rejectedResult = $iconLibrary->sanitizeSvgMarkup($svgWithScript, null, $failure);


### PR DESCRIPTION
## Summary
- allow `aria-label` and `aria-describedby` on all allowed SVG elements
- cover SVG sanitization helper with a test case that keeps ARIA attributes intact
- document ARIA attribute support for custom icons in the README

## Testing
- php tests/sanitize_svg_markup_helper_test.php

------
https://chatgpt.com/codex/tasks/task_e_68dc3531268c832ea898faa6c1ea7d16