### PR TITLE
Localize menu item templates and admin script strings

### DIFF
--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -1,17 +1,30 @@
+function getSidebarGlobalData() {
+    if (typeof window !== 'undefined' && window.sidebarJLG && typeof window.sidebarJLG === 'object') {
+        return window.sidebarJLG;
+    }
+
+    if (typeof sidebarJLG !== 'undefined' && typeof sidebarJLG === 'object') {
+        return sidebarJLG;
+    }
+
+    return null;
+}
+
+function getI18nString(key, fallback = '') {
+    const globalData = getSidebarGlobalData();
+    if (globalData && globalData.i18n && typeof globalData.i18n[key] === 'string') {
+        return globalData.i18n[key];
+    }
+
+    return fallback;
+}
+
 function getSvgUrlRestrictions(overrides) {
     if (overrides && typeof overrides === 'object') {
         return overrides;
     }
 
-    let globalData = null;
-
-    if (typeof window !== 'undefined' && window.sidebarJLG && typeof window.sidebarJLG === 'object') {
-        globalData = window.sidebarJLG;
-    }
-
-    if (!globalData && typeof sidebarJLG !== 'undefined' && typeof sidebarJLG === 'object') {
-        globalData = sidebarJLG;
-    }
+    const globalData = getSidebarGlobalData();
 
     if (globalData && typeof globalData.svg_url_restrictions === 'object' && globalData.svg_url_restrictions !== null) {
         return globalData.svg_url_restrictions;
@@ -73,10 +86,18 @@ function buildOutOfScopeMessage(restrictions) {
     const description = getRestrictionDescription(restrictions);
 
     if (description) {
-        return `Cette URL ne sera pas enregistrée. Utilisez une adresse dans ${description}.`;
+        const template = getI18nString(
+            'svgUrlOutOfScopeWithDescription',
+            'Cette URL ne sera pas enregistrée. Utilisez une adresse dans %s.'
+        );
+
+        return template.replace('%s', description);
     }
 
-    return 'Cette URL ne sera pas enregistrée car elle est en dehors de la zone autorisée.';
+    return getI18nString(
+        'svgUrlOutOfScope',
+        'Cette URL ne sera pas enregistrée car elle est en dehors de la zone autorisée.'
+    );
 }
 
 function joinMessages(...messages) {
@@ -168,14 +189,14 @@ function renderSvgUrlPreview(iconValue, $preview, restrictionsOverride) {
         url = new URL(iconValue, window.location.origin);
     } catch (error) {
         clearPreview();
-        setStatus(joinMessages('URL invalide.', outOfScopeMessage), true);
+        setStatus(joinMessages(getI18nString('invalidUrl', 'URL invalide.'), outOfScopeMessage), true);
         setInputValidity(false);
         return false;
     }
 
     if (url.protocol !== 'https:' && url.protocol !== 'http:') {
         clearPreview();
-        setStatus(joinMessages('Seuls les liens HTTP(S) sont autorisés.', outOfScopeMessage), true);
+        setStatus(joinMessages(getI18nString('httpOnly', 'Seuls les liens HTTP(S) sont autorisés.'), outOfScopeMessage), true);
         setInputValidity(false);
         return false;
     }
@@ -189,7 +210,7 @@ function renderSvgUrlPreview(iconValue, $preview, restrictionsOverride) {
 
     const img = document.createElement('img');
     img.src = url.href;
-    img.alt = 'preview';
+    img.alt = getI18nString('iconPreviewAlt', 'preview');
 
     clearPreview();
     setStatus('', false);
@@ -1186,7 +1207,7 @@ jQuery(document).ready(function($) {
         dataKey: 'menu_items',
         addButtonId: 'add-menu-item', 
         deleteButtonClass: 'delete-menu-item',
-        newTitle: 'Nouvel élément',
+        newTitle: getI18nString('menuItemDefaultTitle', 'Nouvel élément'),
         newItem: (index) => ({ 
             index, 
             label: '', 
@@ -1261,7 +1282,7 @@ jQuery(document).ready(function($) {
         dataKey: 'social_icons',
         addButtonId: 'add-social-icon',
         deleteButtonClass: 'delete-social-icon',
-        newTitle: 'Nouvelle icône',
+        newTitle: getI18nString('socialIconDefaultTitle', 'Nouvelle icône'),
         newItem: (index) => ({
             index,
             label: '',
@@ -1275,7 +1296,7 @@ jQuery(document).ready(function($) {
             const $preview = $itemBox.find('.icon-preview');
             $preview.html(standardIcons[itemData.icon] || '');
 
-            const defaultTitle = 'Nouvelle icône';
+            const defaultTitle = getI18nString('socialIconDefaultTitle', 'Nouvelle icône');
             const iconKey = typeof itemData.icon === 'string' ? itemData.icon : '';
             const fallbackTitle = iconKey ? iconKey.split('_')[0] : defaultTitle;
             $itemBox.data('fallbackTitle', (fallbackTitle || defaultTitle).trim());

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -407,17 +407,17 @@
     <div class="menu-item-box">
         <div class="menu-item-header">
             <span class="menu-item-handle">::</span>
-            <span class="menu-item-title item-title">{{ data.label || 'Nouvel élément' }}</span>
-            <button type="button" class="button-link delete-menu-item">Supprimer</button>
+            <span class="menu-item-title item-title">{{ data.label || ( window.sidebarJLG && window.sidebarJLG.i18n && window.sidebarJLG.i18n.menuItemDefaultTitle ? window.sidebarJLG.i18n.menuItemDefaultTitle : '<?php echo esc_js( __( 'Nouvel élément', 'sidebar-jlg' ) ); ?>' ) }}</span>
+            <button type="button" class="button-link delete-menu-item"><?php echo esc_html__( 'Supprimer', 'sidebar-jlg' ); ?></button>
         </div>
         <div class="menu-item-content">
-            <p><label>Label</label><input type="text" class="widefat item-label" name="sidebar_jlg_settings[menu_items][{{ data.index }}][label]" value="{{ data.label }}"></p>
-            <p><label>Type de lien</label>
+            <p><label><?php echo esc_html__( 'Label', 'sidebar-jlg' ); ?></label><input type="text" class="widefat item-label" name="sidebar_jlg_settings[menu_items][{{ data.index }}][label]" value="{{ data.label }}"></p>
+            <p><label><?php echo esc_html__( 'Type de lien', 'sidebar-jlg' ); ?></label>
                 <select class="widefat menu-item-type" name="sidebar_jlg_settings[menu_items][{{ data.index }}][type]">
-                    <option value="custom" <# if (data.type === 'custom') { #>selected<# } #>>Lien personnalisé</option>
-                    <option value="post" <# if (data.type === 'post') { #>selected<# } #>>Article</option>
-                    <option value="page" <# if (data.type === 'page') { #>selected<# } #>>Page</option>
-                    <option value="category" <# if (data.type === 'category') { #>selected<# } #>>Catégorie</option>
+                    <option value="custom" <# if (data.type === 'custom') { #>selected<# } #>><?php echo esc_html__( 'Lien personnalisé', 'sidebar-jlg' ); ?></option>
+                    <option value="post" <# if (data.type === 'post') { #>selected<# } #>><?php echo esc_html__( 'Article', 'sidebar-jlg' ); ?></option>
+                    <option value="page" <# if (data.type === 'page') { #>selected<# } #>><?php echo esc_html__( 'Page', 'sidebar-jlg' ); ?></option>
+                    <option value="category" <# if (data.type === 'category') { #>selected<# } #>><?php echo esc_html__( 'Catégorie', 'sidebar-jlg' ); ?></option>
                 </select>
             </p>
             <div class="menu-item-value-wrapper">
@@ -427,10 +427,10 @@
                     <div class="menu-item-search-status" aria-live="polite"></div>
                 </div>
             </div>
-            <p><label>Icône</label>
+            <p><label><?php echo esc_html__( 'Icône', 'sidebar-jlg' ); ?></label>
                 <select class="widefat menu-item-icon-type" name="sidebar_jlg_settings[menu_items][{{ data.index }}][icon_type]">
-                    <option value="svg_inline" <# if (data.icon_type === 'svg_inline') { #>selected<# } #>>Icône de la bibliothèque</option>
-                    <option value="svg_url" <# if (data.icon_type === 'svg_url') { #>selected<# } #>>SVG personnalisé (URL)</option>
+                    <option value="svg_inline" <# if (data.icon_type === 'svg_inline') { #>selected<# } #>><?php echo esc_html__( 'Icône de la bibliothèque', 'sidebar-jlg' ); ?></option>
+                    <option value="svg_url" <# if (data.icon_type === 'svg_url') { #>selected<# } #>><?php echo esc_html__( 'SVG personnalisé (URL)', 'sidebar-jlg' ); ?></option>
                 </select>
             </p>
             <div class="menu-item-icon-wrapper"></div>
@@ -441,15 +441,15 @@
     <div class="menu-item-box">
         <div class="menu-item-header">
             <span class="menu-item-handle">::</span>
-            <span class="menu-item-title item-title">{{ data.label || data.icon || 'Nouvelle icône' }}</span>
-            <button type="button" class="button-link delete-social-icon">Supprimer</button>
+            <span class="menu-item-title item-title">{{ data.label || data.icon || ( window.sidebarJLG && window.sidebarJLG.i18n && window.sidebarJLG.i18n.socialIconDefaultTitle ? window.sidebarJLG.i18n.socialIconDefaultTitle : '<?php echo esc_js( __( 'Nouvelle icône', 'sidebar-jlg' ) ); ?>' ) }}</span>
+            <button type="button" class="button-link delete-social-icon"><?php echo esc_html__( 'Supprimer', 'sidebar-jlg' ); ?></button>
         </div>
         <div class="menu-item-content">
-            <p><label>Label</label><input type="text" class="widefat item-label" name="sidebar_jlg_settings[social_icons][{{ data.index }}][label]" value="{{ data.label || '' }}"></p>
-            <p><label>URL</label><input type="text" class="widefat social-url" name="sidebar_jlg_settings[social_icons][{{ data.index }}][url]" value="{{ data.url }}" placeholder="https://..."></p>
-            <p><label>Icône</label>
+            <p><label><?php echo esc_html__( 'Label', 'sidebar-jlg' ); ?></label><input type="text" class="widefat item-label" name="sidebar_jlg_settings[social_icons][{{ data.index }}][label]" value="{{ data.label || '' }}"></p>
+            <p><label><?php echo esc_html__( 'URL', 'sidebar-jlg' ); ?></label><input type="text" class="widefat social-url" name="sidebar_jlg_settings[social_icons][{{ data.index }}][url]" value="{{ data.url }}" placeholder="<?php echo esc_attr__( 'https://…', 'sidebar-jlg' ); ?>"></p>
+            <p><label><?php echo esc_html__( 'Icône', 'sidebar-jlg' ); ?></label>
                 <select class="widefat social-icon-select" name="sidebar_jlg_settings[social_icons][{{ data.index }}][icon]"></select>
-                 <span class="icon-preview"></span>
+             <span class="icon-preview"></span>
             </p>
         </div>
     </div>

--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -95,6 +95,15 @@ class MenuPage
             'icons_manifest' => $this->icons->getIconManifest(),
             'icon_fetch_action' => 'jlg_get_icon_svg',
             'svg_url_restrictions' => $this->sanitizer->getSvgUrlRestrictions(),
+            'i18n' => [
+                'menuItemDefaultTitle' => __('Nouvel élément', 'sidebar-jlg'),
+                'socialIconDefaultTitle' => __('Nouvelle icône', 'sidebar-jlg'),
+                'svgUrlOutOfScopeWithDescription' => __('Cette URL ne sera pas enregistrée. Utilisez une adresse dans %s.', 'sidebar-jlg'),
+                'svgUrlOutOfScope' => __('Cette URL ne sera pas enregistrée car elle est en dehors de la zone autorisée.', 'sidebar-jlg'),
+                'invalidUrl' => __('URL invalide.', 'sidebar-jlg'),
+                'httpOnly' => __('Seuls les liens HTTP(S) sont autorisés.', 'sidebar-jlg'),
+                'iconPreviewAlt' => __('Aperçu', 'sidebar-jlg'),
+            ],
         ]);
     }
 


### PR DESCRIPTION
## Summary
- localize the admin menu item and social icon templates using translation helpers or localized fallbacks
- expose the required i18n strings via `wp_localize_script` for use in JavaScript
- update the admin script to consume the localized strings for validation and default labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc35345978832e9908966d7a880a9b