### PR TITLE
Harden SVG URL sanitization

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -458,7 +458,17 @@ class SettingsSanitizer
             return false;
         }
 
-        $path = wp_normalize_path((string) $parts['path']);
+        $rawPath = (string) $parts['path'];
+        $decodedPath = rawurldecode($rawPath);
+        if ($decodedPath === '') {
+            return false;
+        }
+
+        if (preg_match('#(^|[\\/])\.\.(?=[\\/]|$)#', $decodedPath)) {
+            return false;
+        }
+
+        $path = wp_normalize_path($decodedPath);
         if ($path === '') {
             return false;
         }

--- a/tests/svg_url_path_traversal_rejection_test.php
+++ b/tests/svg_url_path_traversal_rejection_test.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Admin\SettingsSanitizer;
+use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\DefaultSettings;
+
+require __DIR__ . '/bootstrap.php';
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$defaults = new DefaultSettings();
+$icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
+$sanitizer = new SettingsSanitizer($defaults, $icons);
+
+$input = [
+    'menu_items' => [
+        [
+            'label' => 'Traversal Icon',
+            'type' => 'custom',
+            'value' => 'https://example.com/page',
+            'icon_type' => 'svg_url',
+            'icon' => 'http://example.com/uploads/sidebar-jlg/../evil.svg',
+        ],
+    ],
+];
+
+$sanitized = $sanitizer->sanitize_settings($input);
+$menuItems = $sanitized['menu_items'] ?? [];
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+function assertSame($expected, $actual, string $message): void
+{
+    $condition = $expected === $actual;
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $expectedExport = var_export($expected, true);
+    $actualExport = var_export($actual, true);
+    assertTrue(false, "{$message} - expected {$expectedExport} got {$actualExport}");
+}
+
+assertSame(1, count($menuItems), 'Menu item preserved after sanitization');
+$menuItem = $menuItems[0];
+
+assertSame('svg_inline', $menuItem['icon_type'], 'Traversal SVG URL falls back to inline icon type');
+assertSame('', $menuItem['icon'], 'Traversal SVG URL value cleared during sanitization');
+
+$rejections = $icons->consumeRejectedCustomIcons();
+assertTrue(!empty($rejections), 'Rejection recorded for traversal SVG URL');
+
+$options = $sanitized;
+$options['social_icons'] = [];
+$allIcons = [];
+
+ob_start();
+require __DIR__ . '/../sidebar-jlg/includes/sidebar-template.php';
+$html = ob_get_clean();
+
+assertTrue(strpos($html, '<img') === false, 'No <img> tag rendered for rejected traversal SVG icon');
+
+if ($testsPassed) {
+    echo "SVG URL traversal rejection tests passed.\n";
+    exit(0);
+}
+
+echo "SVG URL traversal rejection tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- tighten SVG URL validation by decoding paths, rejecting traversal patterns, and ensuring URLs stay within the allowed uploads directory
- fall back to inline icons for rejected SVG URLs while still recording the rejection for administrator notices
- add a regression test covering traversal attempts in custom SVG menu icons

## Testing
- php tests/svg_url_path_traversal_rejection_test.php

------
https://chatgpt.com/codex/tasks/task_e_68dc43afb024832ebecaa2a8735907a1