### PR TITLE
Add configurable hamburger icon color

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Après activation, un menu "Sidebar JLG" apparait dans l'administration. Vous po
 
 - Activer ou désactiver la sidebar.
 - Choisir le style : couleurs, typographie, effets d'animation, marges…
+- Ajuster la position et la couleur du bouton hamburger pour garantir le contraste.
 - Renseigner les dimensions en utilisant des unités classiques (`px`, `rem`, `vh`, etc.) ou des expressions `calc()` composées d'opérateurs arithmétiques autorisés.
 - Ajouter des éléments de menu (pages, articles, catégories, liens personnalisés) et des icônes sociales.
 - Activer une recherche intégrée et personnaliser son affichage.

--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -202,7 +202,7 @@ body { transition: padding-left var(--transition-speed, 0.4s) ease; }
 .icon-1, .icon-2, .icon-3 {
     position: absolute; left: 0;
     width: 32px; height: 3px;
-    background-color: #fff;
+    background-color: var(--hamburger-color, #fff);
     transition: all 400ms cubic-bezier(.84,.06,.52,1.8);
 }
 .icon-1 { top: 0; }

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -95,6 +95,7 @@
                     <th scope="row"><?php esc_html_e( 'Bouton Hamburger (Mobile)', 'sidebar-jlg' ); ?></th>
                     <td>
                         <p><label><?php esc_html_e( 'Position verticale', 'sidebar-jlg' ); ?></label> <input type="text" name="sidebar_jlg_settings[hamburger_top_position]" value="<?php echo esc_attr( $options['hamburger_top_position'] ); ?>" class="small-text"/> <em class="description"><?php esc_html_e( 'Unités CSS (ex: 4rem, 15px).', 'sidebar-jlg' ); ?></em></p>
+                        <p><label><?php esc_html_e( 'Couleur des barres', 'sidebar-jlg' ); ?></label> <input type="text" name="sidebar_jlg_settings[hamburger_color]" value="<?php echo esc_attr( $options['hamburger_color'] ); ?>" class="color-picker-rgba"/> <em class="description"><?php esc_html_e( 'Utilisez une couleur contrastée pour les barres du bouton.', 'sidebar-jlg' ); ?></em></p>
                         <p><label><input type="checkbox" name="sidebar_jlg_settings[show_close_button]" value="1" <?php checked( $options['show_close_button'], 1 ); ?> /> <?php esc_html_e( 'Afficher le bouton de fermeture (X) dans la sidebar.', 'sidebar-jlg' ); ?></label></p>
                     </td>
                 </tr>

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -147,6 +147,10 @@ class SettingsSanitizer
             $input['hamburger_top_position'] ?? $existingOptions['hamburger_top_position'],
             $existingOptions['hamburger_top_position']
         );
+        $sanitized['hamburger_color'] = ValueNormalizer::normalizeColorWithExisting(
+            $input['hamburger_color'] ?? null,
+            $existingOptions['hamburger_color'] ?? ''
+        );
         $sanitized['app_name'] = sanitize_text_field($input['app_name'] ?? $existingOptions['app_name']);
         $sanitized['header_logo_type'] = $this->sanitizeChoice(
             $input['header_logo_type'] ?? null,

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -28,6 +28,7 @@ class SidebarRenderer
         'header_alignment_mobile' => 'center',
         'header_logo_size' => 150,
         'hamburger_top_position' => '4rem',
+        'hamburger_color' => 'rgba(255, 255, 255, 1)',
         'content_margin' => '2rem',
         'floating_vertical_margin' => '4rem',
         'border_radius' => '12px',
@@ -165,6 +166,7 @@ class SidebarRenderer
         $this->assignVariable($variables, '--header-alignment-mobile', $this->sanitizeCssString($this->resolveOption($options, 'header_alignment_mobile')));
         $this->assignVariable($variables, '--header-logo-size', $this->formatPixelValue($this->resolveOption($options, 'header_logo_size')));
         $this->assignVariable($variables, '--hamburger-top-position', $this->sanitizeCssString($this->resolveOption($options, 'hamburger_top_position')));
+        $this->assignVariable($variables, '--hamburger-color', $this->sanitizeCssString($this->resolveOption($options, 'hamburger_color')));
 
         $contentMargin = $this->resolveContentMargin($options);
         if ($contentMargin !== null) {

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -32,6 +32,7 @@ class DefaultSettings
             // Automatically close the sidebar after clicking menu or social links.
             'close_on_link_click' => false,
             'hamburger_top_position' => '4rem',
+            'hamburger_color'      => 'rgba(255, 255, 255, 1)',
             'header_logo_type'  => 'text',
             'header_logo_image' => '',
             'header_logo_size'  => 150,

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -48,6 +48,7 @@ class SettingsRepository
         'font_hover_color_end',
         'overlay_color',
         'mobile_bg_color',
+        'hamburger_color',
     ];
 
     private DefaultSettings $defaults;


### PR DESCRIPTION
## Summary
- expose a configurable hamburger icon color and use the CSS variable in public styles
- propagate the new option through defaults, sanitization, and repository so it can be saved
- add the color picker to the admin page and update the README documentation

## Testing
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68dc5c6d88f4832ea74aba233c71ecdf