### PR TITLE
Lock body scroll when sidebar opens

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -2,6 +2,11 @@
 
 /* --- Base --- */
 body { transition: padding-left var(--transition-speed, 0.4s) ease; }
+body.sidebar-open {
+    overflow: hidden;
+    touch-action: none;
+    padding-right: var(--sidebar-scrollbar-compensation, 0);
+}
 @media (min-width: 993px) {
     body.jlg-sidebar-active.jlg-sidebar-push {
         padding-left: var(--sidebar-width-desktop) !important;


### PR DESCRIPTION
## Summary
- add a scroll lock style on the body when the sidebar is open, including compensation for scrollbar removal
- compute and maintain scrollbar compensation in JavaScript, and close the mobile sidebar when resizing to desktop widths
- keep the hover effect responsive updates while ensuring resize also refreshes scroll lock state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc5c6a3ed8832e9788a3b8b477a972