### PR TITLE
Align hamburger icon colors with sidebar text

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -207,7 +207,7 @@ body.sidebar-open {
 .icon-1, .icon-2, .icon-3 {
     position: absolute; left: 0;
     width: 32px; height: 3px;
-    background-color: var(--hamburger-color, #fff);
+    background-color: var(--hamburger-color, var(--sidebar-text-color, #fff));
     transition: all 400ms cubic-bezier(.84,.06,.52,1.8);
 }
 .icon-1 { top: 0; }

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -166,7 +166,13 @@ class SidebarRenderer
         $this->assignVariable($variables, '--header-alignment-mobile', $this->sanitizeCssString($this->resolveOption($options, 'header_alignment_mobile')));
         $this->assignVariable($variables, '--header-logo-size', $this->formatPixelValue($this->resolveOption($options, 'header_logo_size')));
         $this->assignVariable($variables, '--hamburger-top-position', $this->sanitizeCssString($this->resolveOption($options, 'hamburger_top_position')));
-        $this->assignVariable($variables, '--hamburger-color', $this->sanitizeCssString($this->resolveOption($options, 'hamburger_color')));
+
+        $hamburgerColor = $this->sanitizeCssString($options['hamburger_color'] ?? null);
+        if ($hamburgerColor === null) {
+            $hamburgerColor = $this->sanitizeCssString($this->resolveOption($options, 'font_color'));
+        }
+
+        $this->assignVariable($variables, '--hamburger-color', $hamburgerColor);
 
         $contentMargin = $this->resolveContentMargin($options);
         if ($contentMargin !== null) {


### PR DESCRIPTION
## Summary
- use the sidebar text color as the default fallback for hamburger icon bars
- ensure the hamburger icon color variable is derived from the user-selected color or text color

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcf6b4e8d4832e8a6bf090b5a90d49