### PR TITLE
Update hamburger button labels dynamically

### DIFF
--- a/sidebar-jlg/assets/js/__tests__/public-script.test.js
+++ b/sidebar-jlg/assets/js/__tests__/public-script.test.js
@@ -29,7 +29,13 @@ describe('public-script.js', () => {
 
     document.body.innerHTML = `
       <div id="sidebar-overlay"></div>
-      <button id="hamburger-btn" aria-expanded="false">Menu</button>
+      <button
+        id="hamburger-btn"
+        aria-expanded="false"
+        aria-label="Ouvrir"
+        data-open-label="Ouvrir"
+        data-close-label="Fermer"
+      >Menu</button>
       <aside id="pro-sidebar" data-hover-desktop="glow" data-hover-mobile="underline">
         <button class="close-sidebar-btn">Fermer</button>
         <nav class="sidebar-menu">
@@ -66,6 +72,7 @@ describe('public-script.js', () => {
     expect(document.body.classList.contains('sidebar-open')).toBe(true);
     expect(hamburgerBtn.classList.contains('is-active')).toBe(true);
     expect(hamburgerBtn.getAttribute('aria-expanded')).toBe('true');
+    expect(hamburgerBtn.getAttribute('aria-label')).toBe('Fermer');
     expect(overlay.classList.contains('is-visible')).toBe(true);
     expect(document.activeElement).toBe(focusableContent[0]);
 
@@ -74,6 +81,7 @@ describe('public-script.js', () => {
     expect(document.body.classList.contains('sidebar-open')).toBe(false);
     expect(hamburgerBtn.classList.contains('is-active')).toBe(false);
     expect(hamburgerBtn.getAttribute('aria-expanded')).toBe('false');
+    expect(hamburgerBtn.getAttribute('aria-label')).toBe('Ouvrir');
     expect(document.activeElement).toBe(hamburgerBtn);
   });
 

--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const hamburgerBtn = document.getElementById('hamburger-btn');
     const closeBtn = sidebar ? sidebar.querySelector('.close-sidebar-btn') : null;
     const overlay = document.getElementById('sidebar-overlay');
+    const openLabel = hamburgerBtn ? (hamburgerBtn.getAttribute('data-open-label') || hamburgerBtn.getAttribute('aria-label') || '') : '';
+    const closeLabel = hamburgerBtn ? (hamburgerBtn.getAttribute('data-close-label') || openLabel) : '';
 
     if (!sidebar || !hamburgerBtn) {
         if (typeof sidebarSettings !== 'undefined' && sidebarSettings.debug_mode == '1') {
@@ -49,6 +51,9 @@ document.addEventListener('DOMContentLoaded', function() {
         document.body.classList.add('sidebar-open');
         hamburgerBtn.classList.add('is-active');
         hamburgerBtn.setAttribute('aria-expanded', 'true');
+        if (closeLabel) {
+            hamburgerBtn.setAttribute('aria-label', closeLabel);
+        }
         if (overlay) overlay.classList.add('is-visible');
         setTimeout(() => {
             if (firstFocusableElement) firstFocusableElement.focus();
@@ -65,6 +70,9 @@ document.addEventListener('DOMContentLoaded', function() {
         document.body.classList.remove('sidebar-open');
         hamburgerBtn.classList.remove('is-active');
         hamburgerBtn.setAttribute('aria-expanded', 'false');
+        if (openLabel) {
+            hamburgerBtn.setAttribute('aria-label', openLabel);
+        }
         if (overlay) overlay.classList.remove('is-visible');
         clearScrollLockCompensation();
         if (returnFocus) {

--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -79,13 +79,19 @@ $sidebar_content_html = ob_get_clean();
 ?>
 <div class="sidebar-overlay" id="sidebar-overlay"></div>
 
+<?php
+    $hamburger_open_label  = esc_attr__( 'Ouvrir le menu', 'sidebar-jlg' );
+    $hamburger_close_label = esc_attr__( 'Fermer le menu', 'sidebar-jlg' );
+?>
 <button
     class="hamburger-menu"
     id="hamburger-btn"
     type="button"
-    aria-label="<?php esc_attr_e('Ouvrir le menu', 'sidebar-jlg'); ?>"
+    aria-label="<?php echo esc_attr( $hamburger_open_label ); ?>"
     aria-controls="pro-sidebar"
-    aria-expanded="false">
+    aria-expanded="false"
+    data-open-label="<?php echo esc_attr( $hamburger_open_label ); ?>"
+    data-close-label="<?php echo esc_attr( $hamburger_close_label ); ?>">
     <div class="hamburger-icon">
         <div class="icon-1"></div>
         <div class="icon-2"></div>


### PR DESCRIPTION
## Summary
- expose the hamburger button open/close labels via data attributes in the template
- update the public script to swap the aria-label when opening or closing the sidebar
- extend the public script tests to confirm the label tracks the sidebar state

## Testing
- npm test -- public-script

------
https://chatgpt.com/codex/tasks/task_e_68dd0ea023c0832ea7c8c77b78a6398d