### PR TITLE
Add reduced motion support to sidebar animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Après activation, un menu "Sidebar JLG" apparait dans l'administration. Vous po
 - Activer ou désactiver la sidebar.
 - Choisir le style : couleurs, typographie, effets d'animation, marges…
 - Ajuster la position et la couleur du bouton hamburger pour garantir le contraste.
+- Désactiver les animations front-end lorsque le système annonce "réduire les mouvements" (`prefers-reduced-motion`).
 - Renseigner les dimensions en utilisant des unités classiques (`px`, `rem`, `vh`, etc.) ou des expressions `calc()` composées d'opérateurs arithmétiques autorisés.
 - Ajouter des éléments de menu (pages, articles, catégories, liens personnalisés) et des icônes sociales.
 - Activer une recherche intégrée et personnaliser son affichage.

--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -2,6 +2,77 @@
 
 /* --- Base --- */
 body { transition: padding-left var(--transition-speed, 0.4s) ease; }
+
+@media (prefers-reduced-motion: reduce) {
+    body,
+    .pro-sidebar,
+    .sidebar-overlay,
+    .sidebar-menu a,
+    .sidebar-menu a::before,
+    .social-icons a,
+    .social-icons a svg,
+    .hamburger-menu .icon-1,
+    .hamburger-menu .icon-2,
+    .hamburger-menu .icon-3 {
+        transition: none !important;
+        animation: none !important;
+    }
+
+    .pro-sidebar.animation-scale,
+    body.sidebar-open .pro-sidebar.animation-scale,
+    .pro-sidebar.animation-slide-left,
+    body.sidebar-open .pro-sidebar.animation-slide-left,
+    .pro-sidebar.animation-fade,
+    body.sidebar-open .pro-sidebar.animation-fade,
+    .pro-sidebar[data-hover-desktop="glossy-tilt"] .sidebar-menu a,
+    .pro-sidebar[data-hover-mobile="glossy-tilt"] .sidebar-menu a {
+        transform: none !important;
+        opacity: 1 !important;
+    }
+
+    .sidebar-menu a,
+    .sidebar-menu a::before,
+    .social-icons a,
+    .social-icons a svg,
+    .pro-sidebar[data-hover-desktop="neon"] .sidebar-menu a:hover,
+    .pro-sidebar[data-hover-mobile="neon"] .sidebar-menu a:hover,
+    .pro-sidebar[data-hover-desktop="glow"] .sidebar-menu a:hover,
+    .pro-sidebar[data-hover-mobile="glow"] .sidebar-menu a:hover,
+    .pro-sidebar[data-hover-desktop="spotlight"] .sidebar-menu a,
+    .pro-sidebar[data-hover-mobile="spotlight"] .sidebar-menu a,
+    .pro-sidebar[data-hover-desktop="tile-slide"] .sidebar-menu a::before,
+    .pro-sidebar[data-hover-mobile="tile-slide"] .sidebar-menu a::before,
+    .pro-sidebar[data-hover-desktop="underline-center"] .sidebar-menu a::before,
+    .pro-sidebar[data-hover-mobile="underline-center"] .sidebar-menu a::before,
+    .pro-sidebar[data-hover-desktop="pill-center"] .sidebar-menu a::before,
+    .pro-sidebar[data-hover-mobile="pill-center"] .sidebar-menu a::before,
+    .social-icons a:hover svg {
+        transform: none !important;
+    }
+
+    .pro-sidebar[data-hover-desktop="pulse"] .sidebar-menu a:hover,
+    .pro-sidebar[data-hover-mobile="pulse"] .sidebar-menu a:hover,
+    .social-icons a,
+    .social-icons a:hover,
+    .sidebar-menu a:hover,
+    .sidebar-menu .menu-icon svg,
+    .close-sidebar-btn svg {
+        animation: none !important;
+        transform: none !important;
+    }
+
+    .hamburger-menu.is-active .icon-1,
+    .hamburger-menu.is-active .icon-3 {
+        top: 0;
+    }
+
+    .hamburger-menu.is-active .icon-1,
+    .hamburger-menu.is-active .icon-2,
+    .hamburger-menu.is-active .icon-3 {
+        transform: none !important;
+        opacity: 1 !important;
+    }
+}
 body.sidebar-open {
     overflow: hidden;
     touch-action: none;

--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -11,6 +11,18 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
+    const prefersReducedMotion = typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-reduced-motion: reduce)')
+        : null;
+
+    function getDelay(defaultDelay) {
+        if (!prefersReducedMotion) {
+            return defaultDelay;
+        }
+
+        return prefersReducedMotion.matches ? 0 : defaultDelay;
+    }
+
     // Appliquer la classe d'animation
     const animationType = (typeof sidebarSettings !== 'undefined' && sidebarSettings.animation_type) ? sidebarSettings.animation_type : 'slide-left';
     sidebar.classList.add(`animation-${animationType}`);
@@ -52,7 +64,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (overlay) overlay.classList.add('is-visible');
         setTimeout(() => {
             if (firstFocusableElement) firstFocusableElement.focus();
-        }, 100);
+        }, getDelay(100));
         document.addEventListener('keydown', trapFocus);
     }
 
@@ -111,7 +123,7 @@ document.addEventListener('DOMContentLoaded', function() {
         selectors.forEach((selector) => {
             sidebar.querySelectorAll(selector).forEach((element) => {
                 element.addEventListener('click', () => {
-                    setTimeout(closeSidebar, 50);
+                    setTimeout(closeSidebar, getDelay(50));
                 });
             });
         });


### PR DESCRIPTION
## Summary
- disable sidebar transitions and decorative transforms when the user prefers reduced motion
- update front-end script delays so focus and closing react immediately under reduced motion
- document the option so site integrators know it respects prefers-reduced-motion

## Testing
- npm run test:js

------
https://chatgpt.com/codex/tasks/task_e_68dd0ea47434832ea18354e387307657