### PR TITLE
Improve sidebar touch interactions on mobile

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -3,9 +3,15 @@
 /* --- Base --- */
 body { transition: padding-left var(--transition-speed, 0.4s) ease; }
 body.sidebar-open {
-    overflow: hidden;
-    touch-action: none;
+    touch-action: pan-y;
     padding-right: var(--sidebar-scrollbar-compensation, 0);
+}
+body.sidebar-scroll-lock {
+    overflow: hidden;
+}
+.sidebar-overlay,
+body.sidebar-open .pro-sidebar {
+    touch-action: pan-y;
 }
 body.jlg-sidebar-active.jlg-sidebar-horizontal-bar { padding-left: 0 !important; }
 @media (min-width: 993px) {

--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -86,6 +86,7 @@ document.addEventListener('DOMContentLoaded', function() {
         sidebar.focus({ preventScroll: true });
     }
     const DESKTOP_BREAKPOINT = 993;
+    const SCROLL_LOCK_CLASS = 'sidebar-scroll-lock';
 
     function getScrollbarWidth() {
         const scrollProbe = document.createElement('div');
@@ -110,8 +111,21 @@ document.addEventListener('DOMContentLoaded', function() {
         document.body.style.removeProperty('--sidebar-scrollbar-compensation');
     }
 
+    function applyScrollLock() {
+        if (window.innerWidth < DESKTOP_BREAKPOINT) {
+            document.body.classList.add(SCROLL_LOCK_CLASS);
+        } else {
+            document.body.classList.remove(SCROLL_LOCK_CLASS);
+        }
+    }
+
+    function releaseScrollLock() {
+        document.body.classList.remove(SCROLL_LOCK_CLASS);
+    }
+
     function openSidebar() {
         applyScrollLockCompensation();
+        applyScrollLock();
         document.body.classList.add('sidebar-open');
         hamburgerBtn.classList.add('is-active');
         hamburgerBtn.setAttribute('aria-expanded', 'true');
@@ -132,6 +146,7 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
         document.body.classList.remove('sidebar-open');
+        releaseScrollLock();
         hamburgerBtn.classList.remove('is-active');
         hamburgerBtn.setAttribute('aria-expanded', 'false');
         if (openLabel) {
@@ -248,6 +263,7 @@ document.addEventListener('DOMContentLoaded', function() {
             closeSidebar({ returnFocus: false });
         } else {
             applyScrollLockCompensation();
+            applyScrollLock();
         }
     }
 


### PR DESCRIPTION
## Summary
- relax the body touch handling to allow pinch zoom while moving overflow locking to a dedicated class
- toggle the new scroll-lock class from the sidebar script and re-apply it on mobile resize

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dd691ebcbc832eb6ccd4fd46ed7ed1