### PR TITLE
Honor reduced motion preference in sidebar interactions

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -14,6 +14,55 @@ body.sidebar-open .pro-sidebar {
     touch-action: pan-y;
 }
 body.jlg-sidebar-active.jlg-sidebar-horizontal-bar { padding-left: 0 !important; }
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-delay: 0 !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        animation-name: none !important;
+        animation-play-state: paused !important;
+        transition-delay: 0 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+
+    body,
+    .sidebar-overlay,
+    .pro-sidebar {
+        transition: none !important;
+    }
+
+    .pro-sidebar {
+        -webkit-backdrop-filter: none !important;
+        backdrop-filter: none !important;
+    }
+}
+
+html.jlg-prefers-reduced-motion *,
+html.jlg-prefers-reduced-motion *::before,
+html.jlg-prefers-reduced-motion *::after {
+    animation-delay: 0 !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    animation-name: none !important;
+    animation-play-state: paused !important;
+    transition-delay: 0 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+}
+
+html.jlg-prefers-reduced-motion body,
+html.jlg-prefers-reduced-motion .sidebar-overlay,
+html.jlg-prefers-reduced-motion .pro-sidebar {
+    transition: none !important;
+}
+
+html.jlg-prefers-reduced-motion .pro-sidebar {
+    -webkit-backdrop-filter: none !important;
+    backdrop-filter: none !important;
+}
 @media (min-width: 993px) {
     body.jlg-sidebar-active.jlg-sidebar-horizontal-bar.jlg-horizontal-position-top {
         padding-top: var(--horizontal-bar-height, 4rem) !important;

--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -21,8 +21,11 @@ document.addEventListener('DOMContentLoaded', function() {
     // Appliquer la classe d'animation
     const animationType = (typeof sidebarSettings !== 'undefined' && sidebarSettings.animation_type) ? sidebarSettings.animation_type : 'slide-left';
     const animationClass = `animation-${animationType}`;
+    const REDUCED_MOTION_CLASS = 'jlg-prefers-reduced-motion';
 
     function applyAnimationPreference() {
+        document.documentElement.classList.toggle(REDUCED_MOTION_CLASS, isReducedMotion);
+
         if (isReducedMotion) {
             sidebar.classList.remove(animationClass);
         } else if (!sidebar.classList.contains(animationClass)) {


### PR DESCRIPTION
## Summary
- add reduced-motion style fallbacks to disable transitions, animations, and blur effects
- update the public script to flag reduced-motion sessions and avoid applying animated classes

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dd7ed6c820832e8404044626f869b1