### PR TITLE
Highlight active sidebar menu items

### DIFF
--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -1,4 +1,5 @@
 <?php
+use JLG\Sidebar\Frontend\SidebarRenderer;
 use JLG\Sidebar\Frontend\Templating;
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -20,6 +21,8 @@ if ($layoutStyle === 'horizontal-bar') {
     $menuClasses[] = 'is-horizontal';
 }
 $menuClassAttr = implode(' ', array_map('sanitize_html_class', $menuClasses));
+
+$currentRequestContext = SidebarRenderer::getCurrentRequestContext();
 
 ob_start();
 ?>
@@ -52,9 +55,30 @@ ob_start();
                 if ($is_valid_url) {
                     $url = $raw_url;
                 }
+
+                $is_current_item = false;
+                if (is_array($item)) {
+                    if (($item['type'] ?? '') === 'custom' && !$is_valid_url) {
+                        $is_current_item = false;
+                    } else {
+                        $is_current_item = SidebarRenderer::isMenuItemCurrent($item, $currentRequestContext);
+                    }
+                }
+
+                $itemClasses = [];
+                if ($is_current_item) {
+                    $itemClasses[] = 'current-menu-item';
+                }
+
+                $liClassAttribute = '';
+                if (!empty($itemClasses)) {
+                    $liClassAttribute = ' class="' . esc_attr(implode(' ', array_map('sanitize_html_class', $itemClasses))) . '"';
+                }
+
+                $ariaCurrentAttribute = $is_current_item ? ' aria-current="page"' : '';
                 ?>
-                <li>
-                    <a href="<?php echo esc_url($url); ?>">
+                <li<?php echo $liClassAttribute; ?>>
+                    <a href="<?php echo esc_url($url); ?>"<?php echo $ariaCurrentAttribute; ?>>
                         <?php if (!empty($item['icon'])) : ?>
                             <?php if (!empty($item['icon_type']) && $item['icon_type'] === 'svg_url' && filter_var($item['icon'], FILTER_VALIDATE_URL)) : ?>
                                 <span class="menu-icon svg-icon"><img src="<?php echo esc_url($item['icon']); ?>" alt=""></span>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -574,6 +574,19 @@ if (!function_exists('esc_attr_e')) {
     }
 }
 
+if (!function_exists('esc_attr__')) {
+    function esc_attr__($text, $domain = 'default')
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        return esc_attr(__($text, $domain));
+    }
+}
+
 if (!function_exists('esc_url_raw')) {
     function esc_url_raw($value)
     {
@@ -709,6 +722,25 @@ if (!function_exists('sanitize_key')) {
         $key = strtolower((string) $key);
 
         return preg_replace('/[^a-z0-9_\-]/', '', $key);
+    }
+}
+
+if (!function_exists('sanitize_html_class')) {
+    function sanitize_html_class($class, $fallback = '')
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return (string) $result;
+        }
+
+        $sanitized = preg_replace('/[^A-Za-z0-9_-]/', '', (string) $class);
+
+        if ($sanitized === '' && $fallback !== '') {
+            $sanitized = preg_replace('/[^A-Za-z0-9_-]/', '', (string) $fallback);
+        }
+
+        return (string) $sanitized;
     }
 }
 

--- a/tests/render_sidebar_active_state_test.php
+++ b/tests/render_sidebar_active_state_test.php
@@ -1,0 +1,155 @@
+<?php
+declare(strict_types=1);
+
+use function JLG\Sidebar\plugin;
+
+require __DIR__ . '/bootstrap.php';
+
+if (!function_exists('get_queried_object')) {
+    function get_queried_object()
+    {
+        return $GLOBALS['test_queried_object'] ?? null;
+    }
+}
+
+if (!function_exists('get_queried_object_id')) {
+    function get_queried_object_id()
+    {
+        $object = get_queried_object();
+        if (is_object($object)) {
+            if (isset($object->ID)) {
+                return (int) $object->ID;
+            }
+
+            if (isset($object->term_id)) {
+                return (int) $object->term_id;
+            }
+        }
+
+        return 0;
+    }
+}
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$plugin = plugin();
+$settingsRepository = $plugin->getSettingsRepository();
+$renderer = $plugin->getSidebarRenderer();
+$menuCache = $plugin->getMenuCache();
+
+$baseSettings = $settingsRepository->getDefaultSettings();
+$baseSettings['social_icons'] = [];
+$baseSettings['menu_items'] = [];
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+function assertContains(string $needle, string $haystack, string $message): void
+{
+    assertTrue(strpos($haystack, $needle) !== false, $message);
+}
+
+function runSidebarScenario(array $menuItem, callable $configureContext): array
+{
+    global $renderer, $menuCache, $baseSettings;
+
+    $settings = $baseSettings;
+    $settings['menu_items'] = [$menuItem];
+
+    update_option('sidebar_jlg_settings', $settings);
+
+    $GLOBALS['test_queried_object'] = null;
+    $_SERVER['HTTP_HOST'] = 'example.com';
+    $_SERVER['REQUEST_URI'] = '/';
+    unset($_SERVER['HTTPS']);
+
+    $configureContext();
+
+    $menuCache->clear();
+    $GLOBALS['wp_test_transients'] = [];
+
+    ob_start();
+    $renderer->render();
+    $html = (string) ob_get_clean();
+
+    return ['html' => $html, 'settings' => $settings];
+}
+
+$pageScenario = runSidebarScenario([
+    'label' => 'Sample Page',
+    'type'  => 'page',
+    'value' => 42,
+], function (): void {
+    $GLOBALS['test_queried_object'] = (object) [
+        'ID'        => 42,
+        'post_type' => 'page',
+    ];
+});
+
+assertContains('current-menu-item', $pageScenario['html'], 'Page item marked as current on matching page');
+assertContains('aria-current="page"', $pageScenario['html'], 'Page item includes aria-current attribute');
+assertTrue($renderer->is_sidebar_output_dynamic($pageScenario['settings']), 'Page scenario disables cached sidebar output');
+
+$postScenario = runSidebarScenario([
+    'label' => 'Sample Post',
+    'type'  => 'post',
+    'value' => 75,
+], function (): void {
+    $GLOBALS['test_queried_object'] = (object) [
+        'ID'        => 75,
+        'post_type' => 'post',
+    ];
+});
+
+assertContains('current-menu-item', $postScenario['html'], 'Post item marked as current on matching post');
+assertContains('aria-current="page"', $postScenario['html'], 'Post item includes aria-current attribute');
+assertTrue($renderer->is_sidebar_output_dynamic($postScenario['settings']), 'Post scenario disables cached sidebar output');
+
+$categoryScenario = runSidebarScenario([
+    'label' => 'Sample Category',
+    'type'  => 'category',
+    'value' => 9,
+], function (): void {
+    $GLOBALS['test_queried_object'] = (object) [
+        'term_id'  => 9,
+        'taxonomy' => 'category',
+    ];
+});
+
+assertContains('current-menu-item', $categoryScenario['html'], 'Category item marked as current on matching archive');
+assertContains('aria-current="page"', $categoryScenario['html'], 'Category item includes aria-current attribute');
+assertTrue($renderer->is_sidebar_output_dynamic($categoryScenario['settings']), 'Category scenario disables cached sidebar output');
+
+$customScenario = runSidebarScenario([
+    'label' => 'Custom Link',
+    'type'  => 'custom',
+    'value' => 'http://example.com/custom-link',
+], function (): void {
+    $_SERVER['HTTP_HOST'] = 'example.com';
+    $_SERVER['REQUEST_URI'] = '/custom-link/';
+    $GLOBALS['test_queried_object'] = null;
+});
+
+assertContains('current-menu-item', $customScenario['html'], 'Custom URL item marked as current when URLs match');
+assertContains('aria-current="page"', $customScenario['html'], 'Custom URL item includes aria-current attribute');
+assertTrue($renderer->is_sidebar_output_dynamic($customScenario['settings']), 'Custom URL scenario disables cached sidebar output');
+
+if ($testsPassed) {
+    echo "Render sidebar active state tests passed.\n";
+    exit(0);
+}
+
+echo "Render sidebar active state tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- detect the current request when rendering sidebar menu items and add the `current-menu-item` class plus `aria-current="page"`
- expose helper methods in the renderer so menu output can find the active item and disable caching when the state depends on the current URL
- extend the test bootstrap and add a sidebar rendering test that asserts the active state for post, page, category, and custom URL entries

## Testing
- php tests/render_sidebar_active_state_test.php
- php tests/render_sidebar_html_error_handling_test.php

------
https://chatgpt.com/codex/tasks/task_e_68dd9154d364832ea16a846ab6edbd41