### PR TITLE
Add AJAX SVG upload workflow for custom icons

### DIFF
--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -256,7 +256,14 @@
             <p class="description"><?php esc_html_e('Ajoutez, organisez et supprimez les éléments de votre menu. Glissez-déposez pour réorganiser.', 'sidebar-jlg'); ?></p>
             <div id="menu-items-container"></div>
             <button type="button" class="button button-primary" id="add-menu-item"><?php esc_html_e('Ajouter un élément', 'sidebar-jlg'); ?></button>
-            
+
+            <div class="sidebar-jlg-custom-icon-upload">
+                <button type="button" class="button sidebar-jlg-upload-svg" data-context="menu">
+                    <?php esc_html_e('Téléverser un SVG', 'sidebar-jlg'); ?>
+                </button>
+                <span class="sidebar-jlg-upload-feedback" role="status" aria-live="polite"></span>
+            </div>
+
             <hr style="margin: 20px 0;">
 
             <h2><?php esc_html_e('Alignement du Menu', 'sidebar-jlg'); ?></h2>
@@ -317,10 +324,16 @@
                 </tr>
                  <tr>
                     <th scope="row"><?php esc_html_e( 'Icônes', 'sidebar-jlg' ); ?></th>
-                    <td>
+                 <td>
                         <div id="social-icons-container"></div>
                         <button type="button" class="button button-primary" id="add-social-icon"><?php esc_html_e('Ajouter une icône', 'sidebar-jlg'); ?></button>
-                    </td>
+                        <div class="sidebar-jlg-custom-icon-upload">
+                            <button type="button" class="button sidebar-jlg-upload-svg" data-context="social">
+                                <?php esc_html_e('Téléverser un SVG', 'sidebar-jlg'); ?>
+                            </button>
+                            <span class="sidebar-jlg-upload-feedback" role="status" aria-live="polite"></span>
+                        </div>
+                 </td>
                 </tr>
             </table>
         </div>

--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -94,6 +94,8 @@ class MenuPage
             'options' => wp_parse_args($options, $defaults),
             'icons_manifest' => $this->icons->getIconManifest(),
             'icon_fetch_action' => 'jlg_get_icon_svg',
+            'icon_upload_action' => 'jlg_upload_custom_icon',
+            'icon_upload_max_size' => IconLibrary::MAX_CUSTOM_ICON_FILESIZE,
             'svg_url_restrictions' => $this->sanitizer->getSvgUrlRestrictions(),
             'i18n' => [
                 'menuItemDefaultTitle' => __('Nouvel élément', 'sidebar-jlg'),
@@ -103,6 +105,15 @@ class MenuPage
                 'invalidUrl' => __('URL invalide.', 'sidebar-jlg'),
                 'httpOnly' => __('Seuls les liens HTTP(S) sont autorisés.', 'sidebar-jlg'),
                 'iconPreviewAlt' => __('Aperçu', 'sidebar-jlg'),
+                'iconUploadMediaTitle' => __('Sélectionner un fichier SVG', 'sidebar-jlg'),
+                'iconUploadMediaButton' => __('Utiliser ce SVG', 'sidebar-jlg'),
+                'iconUploadInProgress' => __('Téléversement du SVG en cours…', 'sidebar-jlg'),
+                'iconUploadPreparing' => __('Préparation du fichier…', 'sidebar-jlg'),
+                'iconUploadSuccess' => __('Icône SVG ajoutée.', 'sidebar-jlg'),
+                'iconUploadErrorGeneric' => __('Le téléversement du SVG a échoué.', 'sidebar-jlg'),
+                'iconUploadErrorMime' => __('Seuls les fichiers SVG sont acceptés.', 'sidebar-jlg'),
+                'iconUploadErrorSize' => __('Le fichier dépasse la taille maximale autorisée de %d Ko.', 'sidebar-jlg'),
+                'iconUploadErrorFetch' => __('Impossible de récupérer le fichier depuis la médiathèque.', 'sidebar-jlg'),
             ],
         ]);
     }

--- a/sidebar-jlg/src/Icons/IconLibrary.php
+++ b/sidebar-jlg/src/Icons/IconLibrary.php
@@ -4,6 +4,8 @@ namespace JLG\Sidebar\Icons;
 
 class IconLibrary
 {
+    public const MAX_CUSTOM_ICON_FILESIZE = 204800;
+
     private const CUSTOM_ICON_CACHE_KEY = 'sidebar_jlg_custom_icons_cache';
     private const CUSTOM_ICON_INDEX_OPTION = 'sidebar_jlg_custom_icon_index';
     private const CUSTOM_ICON_CACHE_TTL = 86400;
@@ -120,6 +122,17 @@ class IconLibrary
         $this->getAllIcons();
 
         return $this->customIconSources[$iconKey] ?? null;
+    }
+
+    public function clearCustomIconCache(): void
+    {
+        $this->allIcons = null;
+        $this->resetCustomIconCacheArtifacts();
+    }
+
+    public function createUploadsContextFrom(string $baseDir, string $baseUrl): ?array
+    {
+        return $this->createUploadsContext($baseDir, $baseUrl);
     }
 
     public function consumeRejectedCustomIcons(): array
@@ -292,7 +305,7 @@ class IconLibrary
             }
         }
 
-        $maxFileSize = 200 * 1024;
+        $maxFileSize = self::MAX_CUSTOM_ICON_FILESIZE;
         $allowedMimes = ['svg' => 'image/svg+xml'];
         $customIcons = [];
 
@@ -469,7 +482,7 @@ class IconLibrary
         return sprintf('%s (%s)', $fileLabel, $reasonMessage);
     }
 
-    private function getRejectionReasonMessage(string $reasonKey, array $context): string
+    public function getRejectionReasonMessage(string $reasonKey, array $context): string
     {
         switch ($reasonKey) {
             case 'invalid_type':


### PR DESCRIPTION
## Summary
- add SVG upload buttons to the menu and social sections of the admin page
- implement an authenticated AJAX endpoint that sanitizes, stores, and returns new icon metadata while clearing caches
- extend the admin script to drive the upload flow, handle errors, and refresh the icon manifest without reloading

## Testing
- npm test -- --runTestsByPath sidebar-jlg/assets/js/__tests__/admin-script.test.js
- php -l sidebar-jlg/src/Ajax/Endpoints.php
- php -l sidebar-jlg/src/Icons/IconLibrary.php

------
https://chatgpt.com/codex/tasks/task_e_68dda1927a00832ebf1e77050d9d8dcc