### PR TITLE
Add localized message for missing sidebar elements

### DIFF
--- a/sidebar-jlg/assets/js/__tests__/public-script.test.js
+++ b/sidebar-jlg/assets/js/__tests__/public-script.test.js
@@ -324,6 +324,25 @@ describe('public-script.js', () => {
     expect(link.style.getPropertyValue('--rotate-y')).toBe('');
   });
 
+  test('logs localized missing elements message when provided', () => {
+    document.body.innerHTML = '<div id="app"></div>';
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      loadScript({
+        debug_mode: '1',
+        messages: {
+          missingElements: 'Message localisé personnalisé',
+        },
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith('Message localisé personnalisé');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   test('respects the reduced motion preference', () => {
     loadScript({ close_on_link_click: '1' }, { prefersReducedMotion: true });
 

--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -6,9 +6,29 @@ document.addEventListener('DOMContentLoaded', function() {
     const openLabel = hamburgerBtn ? (hamburgerBtn.getAttribute('data-open-label') || hamburgerBtn.getAttribute('aria-label') || '') : '';
     const closeLabel = hamburgerBtn ? (hamburgerBtn.getAttribute('data-close-label') || openLabel) : '';
 
+    function getMissingElementsMessage() {
+        if (
+            typeof sidebarSettings !== 'undefined' &&
+            sidebarSettings.messages &&
+            sidebarSettings.messages.missingElements
+        ) {
+            return sidebarSettings.messages.missingElements;
+        }
+
+        if (
+            typeof wp !== 'undefined' &&
+            wp.i18n &&
+            typeof wp.i18n.__ === 'function'
+        ) {
+            return wp.i18n.__('Sidebar JLG : menu introuvable.', 'sidebar-jlg');
+        }
+
+        return 'Sidebar JLG : menu introuvable.';
+    }
+
     if (!sidebar || !hamburgerBtn) {
         if (typeof sidebarSettings !== 'undefined' && sidebarSettings.debug_mode == '1') {
-            console.error('Sidebar JLG: Sidebar or hamburger button not found.');
+            console.error(getMissingElementsMessage());
         }
         return;
     }

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -110,6 +110,9 @@ class SidebarRenderer
             'animation_type' => $options['animation_type'] ?? 'slide-left',
             'close_on_link_click' => $options['close_on_link_click'] ?? '',
             'debug_mode' => (string) ($options['debug_mode'] ?? '0'),
+            'messages' => [
+                'missingElements' => __('Sidebar JLG : menu introuvable.', 'sidebar-jlg'),
+            ],
         ];
 
         wp_localize_script('sidebar-jlg-public-js', 'sidebarSettings', $localizedOptions);


### PR DESCRIPTION
## Summary
- add a localized "missing elements" message to the sidebar settings localization payload
- update the public script to log the localized message with a translation fallback when elements are missing
- cover the localized message logging behaviour with a dedicated Jest test

## Testing
- npm test -- public-script.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de3e3cb5b4832e98a97dd92e8622fb