### PR TITLE
Normalize sidebar orientation handling

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -76,21 +76,29 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
     }
 }
 @media (min-width: 993px) {
-    body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-left {
+    body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-left,
+    body.jlg-sidebar-active.jlg-sidebar-push[data-sidebar-position="left"] {
         padding-left: var(--sidebar-width-desktop) !important;
     }
-    body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-right {
+    body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-right,
+    body.jlg-sidebar-active.jlg-sidebar-push[data-sidebar-position="right"] {
         padding-right: var(--sidebar-width-desktop) !important;
     }
     body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-left #page,
     body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-left .site-content,
-    body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-left main {
+    body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-left main,
+    body.jlg-sidebar-active.jlg-sidebar-push[data-sidebar-position="left"] #page,
+    body.jlg-sidebar-active.jlg-sidebar-push[data-sidebar-position="left"] .site-content,
+    body.jlg-sidebar-active.jlg-sidebar-push[data-sidebar-position="left"] main {
         margin-left: var(--content-margin, 2rem);
         margin-right: 0;
     }
     body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-right #page,
     body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-right .site-content,
-    body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-right main {
+    body.jlg-sidebar-active.jlg-sidebar-push.jlg-sidebar-position-right main,
+    body.jlg-sidebar-active.jlg-sidebar-push[data-sidebar-position="right"] #page,
+    body.jlg-sidebar-active.jlg-sidebar-push[data-sidebar-position="right"] .site-content,
+    body.jlg-sidebar-active.jlg-sidebar-push[data-sidebar-position="right"] main {
         margin-right: var(--content-margin, 2rem);
         margin-left: 0;
     }
@@ -117,7 +125,8 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
     display: flex; flex-direction: column; z-index: 1000;
     transition: transform var(--transition-speed, 0.4s) ease, opacity var(--transition-speed, 0.4s) ease;
 }
-.jlg-sidebar-position-right .pro-sidebar {
+.jlg-sidebar-position-right .pro-sidebar,
+body[data-sidebar-position="right"] .pro-sidebar {
     left: auto;
     right: 0;
 }
@@ -154,8 +163,10 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
         backdrop-filter: blur(var(--mobile-blur));
     }
     body.sidebar-open .pro-sidebar { visibility: visible; }
-    body.jlg-sidebar-position-left .pro-sidebar.animation-slide-left { transform: translateX(-100%); }
-    body.jlg-sidebar-position-right .pro-sidebar.animation-slide-left { transform: translateX(100%); }
+    body.jlg-sidebar-position-left .pro-sidebar.animation-slide-left,
+    body[data-sidebar-position="left"] .pro-sidebar.animation-slide-left { transform: translateX(-100%); }
+    body.jlg-sidebar-position-right .pro-sidebar.animation-slide-left,
+    body[data-sidebar-position="right"] .pro-sidebar.animation-slide-left { transform: translateX(100%); }
     body.sidebar-open .pro-sidebar.animation-slide-left { transform: translateX(0); }
     .pro-sidebar.animation-fade { opacity: 0; }
     body.sidebar-open .pro-sidebar.animation-fade { opacity: 1; }
@@ -436,6 +447,14 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
     right: 15px;
 }
 .hamburger-menu.orientation-left {
+    right: auto;
+}
+body[data-sidebar-position="right"] .hamburger-menu {
+    left: auto;
+    right: 15px;
+}
+body[data-sidebar-position="left"] .hamburger-menu {
+    left: 15px;
     right: auto;
 }
 

--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -37,6 +37,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const sidebarPosition = sidebarPositionAttr === 'right' ? 'right' : 'left';
     document.body.classList.remove('jlg-sidebar-position-left', 'jlg-sidebar-position-right');
     document.body.classList.add(`jlg-sidebar-position-${sidebarPosition}`);
+    document.body.setAttribute('data-sidebar-position', sidebarPosition);
     hamburgerBtn.classList.remove('orientation-left', 'orientation-right');
     hamburgerBtn.classList.add(`orientation-${sidebarPosition}`);
 

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -109,12 +109,15 @@ $textTransformLabels = [
                 <tr>
                     <th scope="row"><?php esc_html_e( 'Orientation', 'sidebar-jlg' ); ?></th>
                     <td>
-                        <p>
-                            <label><input type="radio" name="sidebar_jlg_settings[sidebar_position]" value="left" <?php checked($options['sidebar_position'], 'left'); ?>> <?php esc_html_e( 'Alignée à gauche', 'sidebar-jlg' ); ?></label>
-                            <br>
-                            <label><input type="radio" name="sidebar_jlg_settings[sidebar_position]" value="right" <?php checked($options['sidebar_position'], 'right'); ?>> <?php esc_html_e( 'Alignée à droite', 'sidebar-jlg' ); ?></label>
-                        </p>
-                        <p class="description"><?php esc_html_e( 'Choisissez le côté d\'affichage de la sidebar et du bouton hamburger.', 'sidebar-jlg' ); ?></p>
+                        <fieldset class="sidebar-orientation-fieldset">
+                            <legend><?php esc_html_e( 'Orientation', 'sidebar-jlg' ); ?></legend>
+                            <p>
+                                <label><input type="radio" name="sidebar_jlg_settings[sidebar_position]" value="left" <?php checked($options['sidebar_position'], 'left'); ?>> <?php esc_html_e( 'Alignée à gauche', 'sidebar-jlg' ); ?></label>
+                                <br>
+                                <label><input type="radio" name="sidebar_jlg_settings[sidebar_position]" value="right" <?php checked($options['sidebar_position'], 'right'); ?>> <?php esc_html_e( 'Alignée à droite', 'sidebar-jlg' ); ?></label>
+                            </p>
+                            <p class="description"><?php esc_html_e( 'Choisissez le côté d\'affichage de la sidebar et du bouton hamburger.', 'sidebar-jlg' ); ?></p>
+                        </fieldset>
                     </td>
                 </tr>
                 <tr>

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -846,8 +846,6 @@ class SidebarRenderer
 
     private function resolveSidebarPosition(array $options): string
     {
-        $position = \sanitize_key($options['sidebar_position'] ?? '');
-
-        return $position === 'right' ? 'right' : 'left';
+        return $this->settings->normalizeSidebarPosition($options['sidebar_position'] ?? null);
     }
 }

--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -119,17 +119,14 @@ class Plugin
      */
     private function hasSidebarPositionChanged($oldValue, $newValue): bool
     {
-        $normalize = static function ($value): string {
-            if (!is_array($value)) {
-                return 'left';
-            }
+        $oldPosition = is_array($oldValue)
+            ? $this->settings->normalizeSidebarPosition($oldValue['sidebar_position'] ?? null)
+            : $this->settings->normalizeSidebarPosition(null);
+        $newPosition = is_array($newValue)
+            ? $this->settings->normalizeSidebarPosition($newValue['sidebar_position'] ?? null)
+            : $this->settings->normalizeSidebarPosition(null);
 
-            $position = \sanitize_key($value['sidebar_position'] ?? '');
-
-            return $position === 'right' ? 'right' : 'left';
-        };
-
-        return $normalize($oldValue) !== $normalize($newValue);
+        return $oldPosition !== $newPosition;
     }
 
     public function getDefaultSettings(): array


### PR DESCRIPTION
## Summary
- normalize the persisted sidebar orientation and reuse the repository helper across the renderer and plugin cache hooks
- restructure the admin orientation control and expose the sidebar position via body data attributes for scripts and styles
- extend public CSS/JS to react to the `data-sidebar-position` marker for padding, transitions, and hamburger placement

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68de6d5219c8832eaa8879e8004388c1