### PR TITLE
Use logical safe-area positioning for sidebar UI

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -174,11 +174,11 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
     }
     body.jlg-sidebar-floating.jlg-sidebar-position-left .pro-sidebar {
         border-radius: 0 var(--border-radius, 12px) var(--border-radius, 12px) 0;
-        border-left: none;
+        border-inline-start: none;
     }
     body.jlg-sidebar-floating.jlg-sidebar-position-right .pro-sidebar {
         border-radius: var(--border-radius, 12px) 0 0 var(--border-radius, 12px);
-        border-right: none;
+        border-inline-end: none;
     }
 }
 
@@ -366,8 +366,8 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
     }
     .close-sidebar-btn {
         position: absolute;
-        right: 1.5rem;
-        top: 50%;
+        inset-inline-end: calc(1.5rem + var(--jlg-safe-area-inset-inline-end));
+        inset-block-start: 50%;
         transform: translateY(-50%);
     }
 }
@@ -488,17 +488,22 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
 }
 .hamburger-icon { position: relative; width: 32px; height: 24px; }
 .icon-1, .icon-2, .icon-3 {
-    position: absolute; left: 0;
+    position: absolute;
+    inset-inline-start: 0;
     width: 32px; height: 3px;
     background-color: var(--hamburger-color, var(--sidebar-text-color, #fff));
     transition: all 400ms cubic-bezier(.84,.06,.52,1.8);
 }
-.icon-1 { top: 0; }
-.icon-2 { top: 50%; transform: translateY(-50%); }
-.icon-3 { bottom: 0; }
-.hamburger-menu.is-active .icon-1 { transform: rotate(40deg); top: 10px; }
+.icon-1 { inset-block-start: 0; }
+.icon-2 { inset-block-start: 50%; transform: translateY(-50%); }
+.icon-3 { inset-block-end: 0; }
+.hamburger-menu.is-active .icon-1 { transform: rotate(40deg); inset-block-start: 10px; }
 .hamburger-menu.is-active .icon-2 { opacity: 0; }
-.hamburger-menu.is-active .icon-3 { transform: rotate(-40deg); top: 10px; }
+.hamburger-menu.is-active .icon-3 {
+    transform: rotate(-40deg);
+    inset-block-start: 10px;
+    inset-block-end: auto;
+}
 @media (min-width: 993px) { .hamburger-menu { display: none !important; } }
 
 /* --- Effets de survol --- */
@@ -538,7 +543,10 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
 
 .pro-sidebar[data-hover-desktop="tile-slide"] .sidebar-menu a::before,
 .pro-sidebar[data-hover-mobile="tile-slide"] .sidebar-menu a::before {
-    content: ''; position: absolute; top: 0; left: 0;
+    content: '';
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-start: 0;
     width: 100%; height: 100%;
     background-color: var(--primary-accent-color);
     background-image: var(--primary-accent-image);
@@ -586,7 +594,8 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
 .pro-sidebar[data-hover-mobile="glossy-tilt"] .sidebar-menu a::before {
     content: '';
     position: absolute;
-    top: 0; left: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
     width: 100%; height: 100%;
     background: linear-gradient(
         135deg,
@@ -638,8 +647,8 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
 .pro-sidebar[data-hover-mobile="underline-center"] .sidebar-menu a::before {
     content: '';
     position: absolute;
-    bottom: 0.5rem;
-    left: 50%;
+    inset-block-end: 0.5rem;
+    inset-inline-start: 50%;
     transform: translateX(-50%);
     width: 0;
     height: 2px;
@@ -659,8 +668,8 @@ html.jlg-prefers-reduced-motion .pro-sidebar {
 .pro-sidebar[data-hover-mobile="pill-center"] .sidebar-menu a::before {
     content: '';
     position: absolute;
-    top: 50%;
-    left: 50%;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
     width: 0;
     height: 80%;
     transform: translate(-50%, -50%);


### PR DESCRIPTION
## Summary
- replace physical left/right borders with logical inline sides on floating sidebar variants
- update the close button and hamburger icon layout to rely on safe-area aware logical insets
- align hover effect pseudo-elements with logical positioning to avoid clashes with dynamic margins

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de9f513de4832e90ebe3aa7ad975df