### PR TITLE
Add nav menu integration to sidebar builder

### DIFF
--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -560,6 +560,7 @@ $textTransformLabels = [
                     <option value="post" <# if (data.type === 'post') { #>selected<# } #>><?php echo esc_html__( 'Article', 'sidebar-jlg' ); ?></option>
                     <option value="page" <# if (data.type === 'page') { #>selected<# } #>><?php echo esc_html__( 'Page', 'sidebar-jlg' ); ?></option>
                     <option value="category" <# if (data.type === 'category') { #>selected<# } #>><?php echo esc_html__( 'Catégorie', 'sidebar-jlg' ); ?></option>
+                    <option value="nav_menu" <# if (data.type === 'nav_menu') { #>selected<# } #>><?php echo esc_html__( 'Menu WordPress', 'sidebar-jlg' ); ?></option>
                 </select>
             </p>
             <div class="menu-item-value-wrapper">

--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -86,7 +86,7 @@ class MenuPage
         wp_enqueue_script(
             'sidebar-jlg-admin-js',
             plugin_dir_url($this->pluginFile) . 'assets/js/admin-script.js',
-            ['jquery', 'wp-color-picker', 'jquery-ui-sortable', 'wp-util'],
+            ['jquery', 'wp-color-picker', 'jquery-ui-sortable', 'wp-util', 'wp-data', 'wp-api-fetch'],
             $this->version,
             true
         );
@@ -134,6 +134,14 @@ class MenuPage
                 'importSuccess' => __('Réglages importés avec succès. Rechargement de la page…', 'sidebar-jlg'),
                 'importError' => __('L’import des réglages a échoué.', 'sidebar-jlg'),
                 'importMissingFile' => __('Veuillez sélectionner un fichier JSON avant de lancer l’import.', 'sidebar-jlg'),
+                'navMenuFieldLabel' => __('Menu WordPress', 'sidebar-jlg'),
+                'navMenuSelectPlaceholder' => __('Sélectionnez un menu…', 'sidebar-jlg'),
+                'navMenuDepthLabel' => __('Profondeur maximale', 'sidebar-jlg'),
+                'navMenuDepthHelp' => __('0 = illimité', 'sidebar-jlg'),
+                'navMenuFilterLabel' => __('Filtrage', 'sidebar-jlg'),
+                'navMenuFilterAll' => __('Tous les éléments', 'sidebar-jlg'),
+                'navMenuFilterTopLevel' => __('Uniquement le niveau 1', 'sidebar-jlg'),
+                'navMenuFilterBranch' => __('Branche de la page courante', 'sidebar-jlg'),
             ],
             'preview_messages' => [
                 'loading' => __('Chargement de l’aperçu…', 'sidebar-jlg'),

--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -63,6 +63,7 @@ class Plugin
         add_action('admin_notices', [$this, 'renderActivationErrorNotice']);
         add_action('update_option_sidebar_jlg_settings', [$this, 'handleSettingsUpdated'], 10, 3);
         add_action('sidebar_jlg_custom_icons_changed', [$this->cache, 'clear'], 10, 0);
+        add_action('wp_update_nav_menu', [$this->cache, 'clear'], 10, 0);
 
         $this->settings->revalidateStoredOptions();
         $this->menuPage->registerHooks();

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -2,6 +2,7 @@
 
 namespace JLG\Sidebar\Settings;
 
+use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\ValueNormalizer;
 
@@ -234,6 +235,8 @@ class SettingsRepository
         $menuItemsChanged = false;
         $socialIconsChanged = false;
 
+        $navFilters = SettingsSanitizer::getAllowedNavMenuFilters();
+
         if (!empty($options['menu_items']) && is_array($options['menu_items'])) {
             foreach ($options['menu_items'] as $index => $item) {
                 if (!is_array($item)) {
@@ -245,20 +248,58 @@ class SettingsRepository
                 $iconType = $item['icon_type'] ?? '';
                 $iconValue = $item['icon'] ?? '';
 
-                if ($iconType === 'svg_url' || $iconValue === '') {
-                    continue;
+                if ($iconType !== 'svg_url' && $iconValue !== '') {
+                    if (strpos($iconValue, 'custom_') === 0) {
+                        $iconKey = sanitize_key($iconValue);
+
+                        if ($iconKey === '' || !isset($availableIcons[$iconKey])) {
+                            $options['menu_items'][$index]['icon'] = '';
+                            $options['menu_items'][$index]['icon_type'] = 'svg_inline';
+                            $menuItemsChanged = true;
+                        } elseif ($iconKey !== $iconValue) {
+                            $options['menu_items'][$index]['icon'] = $iconKey;
+                            $menuItemsChanged = true;
+                        }
+                    }
                 }
 
-                if (strpos($iconValue, 'custom_') === 0) {
-                    $iconKey = sanitize_key($iconValue);
+                if (($item['type'] ?? '') === 'nav_menu') {
+                    $rawMenuId = isset($item['value']) ? $item['value'] : 0;
+                    $menuId = absint($rawMenuId);
 
-                    if ($iconKey === '' || !isset($availableIcons[$iconKey])) {
-                        $options['menu_items'][$index]['icon'] = '';
-                        $options['menu_items'][$index]['icon_type'] = 'svg_inline';
+                    if ($menuId > 0 && function_exists('wp_get_nav_menu_object')) {
+                        $menuObject = wp_get_nav_menu_object($menuId);
+                        if (!$menuObject) {
+                            $menuId = 0;
+                        }
+                    }
+
+                    if (($options['menu_items'][$index]['value'] ?? null) !== $menuId) {
+                        $options['menu_items'][$index]['value'] = $menuId;
                         $menuItemsChanged = true;
-                    } elseif ($iconKey !== $iconValue) {
-                        $options['menu_items'][$index]['icon'] = $iconKey;
+                    }
+
+                    $depth = absint($item['nav_menu_max_depth'] ?? 0);
+                    if (($options['menu_items'][$index]['nav_menu_max_depth'] ?? null) !== $depth) {
+                        $options['menu_items'][$index]['nav_menu_max_depth'] = $depth;
                         $menuItemsChanged = true;
+                    }
+
+                    $rawFilter = isset($item['nav_menu_filter']) ? sanitize_key($item['nav_menu_filter']) : '';
+                    if (!in_array($rawFilter, $navFilters, true)) {
+                        $rawFilter = $navFilters[0];
+                    }
+
+                    if (($options['menu_items'][$index]['nav_menu_filter'] ?? null) !== $rawFilter) {
+                        $options['menu_items'][$index]['nav_menu_filter'] = $rawFilter;
+                        $menuItemsChanged = true;
+                    }
+
+                    if (!array_key_exists('nav_menu_max_depth', $options['menu_items'][$index])) {
+                        $options['menu_items'][$index]['nav_menu_max_depth'] = 0;
+                    }
+                    if (!array_key_exists('nav_menu_filter', $options['menu_items'][$index])) {
+                        $options['menu_items'][$index]['nav_menu_filter'] = $navFilters[0];
                     }
                 }
             }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -799,6 +799,36 @@ if (!function_exists('sanitize_hex_color')) {
     }
 }
 
+if (!function_exists('wp_get_nav_menu_object')) {
+    function wp_get_nav_menu_object($menu)
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        if (is_numeric($menu)) {
+            return (object) ['term_id' => (int) $menu];
+        }
+
+        return false;
+    }
+}
+
+if (!function_exists('wp_get_nav_menu_items')) {
+    function wp_get_nav_menu_items($menu, $args = [])
+    {
+        $handled = false;
+        $result = wp_test_call_override(__FUNCTION__, func_get_args(), $handled);
+        if ($handled) {
+            return $result;
+        }
+
+        return [];
+    }
+}
+
 if (!function_exists('get_permalink')) {
     function get_permalink($post_id)
     {

--- a/tests/sanitize_nav_menu_settings_test.php
+++ b/tests/sanitize_nav_menu_settings_test.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Admin\SettingsSanitizer;
+use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\DefaultSettings;
+
+require __DIR__ . '/bootstrap.php';
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$defaults = new DefaultSettings();
+$icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
+$sanitizer = new SettingsSanitizer($defaults, $icons);
+
+$reflection = new ReflectionClass(SettingsSanitizer::class);
+$menuMethod = $reflection->getMethod('sanitize_menu_settings');
+$menuMethod->setAccessible(true);
+
+$GLOBALS['wp_test_function_overrides']['wp_get_nav_menu_object'] = static function ($menu) {
+    if ((int) $menu === 12) {
+        return (object) ['term_id' => 12];
+    }
+
+    return false;
+};
+
+$existingOptions = $defaults->all();
+
+$input = [
+    'menu_items' => [
+        [
+            'type' => 'nav_menu',
+            'label' => 'Primary',
+            'value' => '12',
+            'nav_menu_max_depth' => '3',
+            'nav_menu_filter' => 'current-branch',
+            'icon_type' => 'svg_inline',
+            'icon' => 'custom_star',
+        ],
+        [
+            'type' => 'nav_menu',
+            'label' => 'Invalid',
+            'value' => '99',
+            'nav_menu_max_depth' => '-4',
+            'nav_menu_filter' => 'unknown',
+        ],
+    ],
+];
+
+$result = $menuMethod->invoke($sanitizer, $input, $existingOptions);
+
+$first = $result['menu_items'][0] ?? [];
+$second = $result['menu_items'][1] ?? [];
+
+if (($first['value'] ?? null) !== 12) {
+    echo "Expected first nav menu value to be 12, got " . var_export($first['value'] ?? null, true) . "\n";
+    exit(1);
+}
+
+if (($first['nav_menu_max_depth'] ?? null) !== 3) {
+    echo "Expected nav menu depth to be 3, got " . var_export($first['nav_menu_max_depth'] ?? null, true) . "\n";
+    exit(1);
+}
+
+if (($first['nav_menu_filter'] ?? null) !== 'current-branch') {
+    echo "Expected nav menu filter to be 'current-branch', got " . var_export($first['nav_menu_filter'] ?? null, true) . "\n";
+    exit(1);
+}
+
+if (($second['value'] ?? null) !== 0) {
+    echo "Expected invalid nav menu id to fall back to 0, got " . var_export($second['value'] ?? null, true) . "\n";
+    exit(1);
+}
+
+if (($second['nav_menu_max_depth'] ?? null) !== 0) {
+    echo "Expected invalid depth to reset to 0, got " . var_export($second['nav_menu_max_depth'] ?? null, true) . "\n";
+    exit(1);
+}
+
+if (($second['nav_menu_filter'] ?? null) !== 'all') {
+    echo "Expected invalid filter to fall back to 'all', got " . var_export($second['nav_menu_filter'] ?? null, true) . "\n";
+    exit(1);
+}
+
+exit(0);


### PR DESCRIPTION
## Summary
- extend the settings sanitizer and repository to persist nav menu selections, including depth and filter options
- add admin UI support for selecting WordPress nav menus via wp.data/wp.apiFetch and expose the new menu type
- render merged static and nav menu trees in the sidebar template and clear the cache when WordPress menus change

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68de9f0f3608832eae046150b6507b52