### PR TITLE
Use WordPress controls for typography spacing and opacity

### DIFF
--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -503,6 +503,7 @@ class SidebarPreviewModule {
             'hamburger_top_position',
             'header_padding_top',
             'horizontal_bar_height',
+            'letter_spacing',
         ];
 
         this.dimensionKeys.forEach((key) => {
@@ -1013,10 +1014,6 @@ class SidebarPreviewModule {
             this.currentOptions.text_transform = value || 'none';
         });
 
-        this.bindField('sidebar_jlg_settings[letter_spacing]', (value) => {
-            this.currentOptions.letter_spacing = value;
-        });
-
         this.bindField('sidebar_jlg_settings[accent_color]', (value) => {
             this.currentOptions.accent_color = value;
         });
@@ -1031,6 +1028,18 @@ class SidebarPreviewModule {
 
         this.bindField('sidebar_jlg_settings[accent_color_end]', (value) => {
             this.currentOptions.accent_color_end = value;
+        });
+
+        this.bindField('sidebar_jlg_settings[mobile_bg_color]', (value) => {
+            this.currentOptions.mobile_bg_color = value;
+        });
+
+        this.bindField('sidebar_jlg_settings[mobile_bg_opacity]', (value) => {
+            this.currentOptions.mobile_bg_opacity = value;
+        });
+
+        this.bindField('sidebar_jlg_settings[mobile_blur]', (value) => {
+            this.currentOptions.mobile_blur = value;
         });
 
         this.bindField('sidebar_jlg_settings[width_desktop]', (value) => {
@@ -1062,6 +1071,7 @@ class SidebarPreviewModule {
         this.bindDimensionField('sidebar_jlg_settings[floating_vertical_margin]', 'floating_vertical_margin');
 
         this.bindDimensionField('sidebar_jlg_settings[border_radius]', 'border_radius');
+        this.bindDimensionField('sidebar_jlg_settings[letter_spacing]', 'letter_spacing');
 
         this.bindField('sidebar_jlg_settings[border_width]', (value) => {
             this.currentOptions.border_width = value;
@@ -1260,7 +1270,10 @@ class SidebarPreviewModule {
             ['--sidebar-font-family', this.resolveFontFamily()],
             ['--sidebar-font-weight', this.currentOptions.font_weight],
             ['--sidebar-text-transform', this.currentOptions.text_transform],
-            ['--sidebar-letter-spacing', this.currentOptions.letter_spacing],
+            ['--sidebar-letter-spacing', this.formatDimension(this.currentOptions.letter_spacing)],
+            ['--mobile-bg-color', this.currentOptions.mobile_bg_color],
+            ['--mobile-bg-opacity', this.formatOpacity(this.currentOptions.mobile_bg_opacity)],
+            ['--mobile-blur', this.formatDimension(this.currentOptions.mobile_blur)],
             ['--sidebar-accent-color', this.resolveAccentBaseColor()],
             ['--sidebar-logo-size', this.formatDimension(this.currentOptions.header_logo_size)],
             ['--sidebar-header-align-desktop', this.currentOptions.header_alignment_desktop],

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -102,6 +102,7 @@ $textTransformLabels = [
             'content_margin'          => ['px', 'rem', 'em', '%'],
             'hamburger_top_position'  => ['px', 'rem', 'em', 'vh', 'vw'],
             'header_padding_top'      => ['px', 'rem', 'em', '%'],
+            'letter_spacing'          => ['px', 'rem', 'em'],
         ];
 
         $dimensionValues = [];
@@ -439,11 +440,22 @@ $textTransformLabels = [
                     <th scope="row"><?php esc_html_e( 'Apparence sur Mobile', 'sidebar-jlg' ); ?></th>
                     <td>
                         <p><label><?php esc_html_e( 'Couleur de fond', 'sidebar-jlg' ); ?></label> <input type="text" name="sidebar_jlg_settings[mobile_bg_color]" value="<?php echo esc_attr( $options['mobile_bg_color'] ); ?>" class="color-picker-rgba"/></p>
-                        <p>
+                        <div class="sidebar-jlg-range-field">
                             <label><?php esc_html_e( 'Opacité du fond', 'sidebar-jlg' ); ?></label>
-                            <input type="range" name="sidebar_jlg_settings[mobile_bg_opacity]" min="0" max="1" step="0.05" value="<?php echo esc_attr($options['mobile_bg_opacity']); ?>">
-                            <span class="range-value"><?php echo esc_html($options['mobile_bg_opacity']); ?></span>
-                        </p>
+                            <div
+                                class="sidebar-jlg-range-control"
+                                data-sidebar-range-control
+                                data-setting-name="sidebar_jlg_settings[mobile_bg_opacity]"
+                                data-label="<?php esc_attr_e( 'Opacité du fond mobile', 'sidebar-jlg' ); ?>"
+                                data-help="<?php esc_attr_e( '0 = totalement transparent, 1 = totalement opaque.', 'sidebar-jlg' ); ?>"
+                                data-error-message="<?php esc_attr_e( 'L’opacité doit rester comprise entre 0 et 1.', 'sidebar-jlg' ); ?>"
+                                data-min="0"
+                                data-max="1"
+                                data-step="0.05"
+                            >
+                                <input type="hidden" data-range-value name="sidebar_jlg_settings[mobile_bg_opacity]" value="<?php echo esc_attr( $options['mobile_bg_opacity'] ); ?>" />
+                            </div>
+                        </div>
                         <p><label><?php esc_html_e( 'Intensité du flou', 'sidebar-jlg' ); ?></label> <input type="number" name="sidebar_jlg_settings[mobile_blur]" value="<?php echo esc_attr($options['mobile_blur']); ?>" class="small-text" /> px</p>
                     </td>
                 </tr>
@@ -478,10 +490,24 @@ $textTransformLabels = [
                                 <?php endforeach; ?>
                             </select>
                         </p>
+                        <?php $letterSpacing = $dimensionValues['letter_spacing']; ?>
                         <p>
                             <label><?php esc_html_e( 'Espacement des lettres', 'sidebar-jlg' ); ?></label>
-                            <input type="text" name="sidebar_jlg_settings[letter_spacing]" value="<?php echo esc_attr( $options['letter_spacing'] ); ?>" class="small-text" placeholder="0.05em" />
-                            <em class="description"><?php esc_html_e( 'Accepte les unités CSS (`px`, `em`, `rem`, etc.) ou une valeur `calc()`.', 'sidebar-jlg' ); ?></em>
+                            <div
+                                class="sidebar-jlg-unit-control"
+                                data-sidebar-unit-control
+                                data-setting-name="sidebar_jlg_settings[letter_spacing]"
+                                data-label="<?php esc_attr_e( 'Espacement des lettres', 'sidebar-jlg' ); ?>"
+                                data-help="<?php esc_attr_e( 'Contrôle la distance entre chaque lettre du menu.', 'sidebar-jlg' ); ?>"
+                                data-error-message="<?php esc_attr_e( 'L’espacement des lettres ne peut pas être vide.', 'sidebar-jlg' ); ?>"
+                                data-default-value="<?php echo esc_attr( $defaults['letter_spacing']['value'] ?? '0' ); ?>"
+                                data-default-unit="<?php echo esc_attr( $defaults['letter_spacing']['unit'] ?? 'em' ); ?>"
+                                data-allowed-units="<?php echo esc_attr( wp_json_encode( $dimensionUnits['letter_spacing'] ) ); ?>"
+                            >
+                                <input type="hidden" data-dimension-value name="sidebar_jlg_settings[letter_spacing][value]" value="<?php echo esc_attr( $letterSpacing['value'] ); ?>" />
+                                <input type="hidden" data-dimension-unit name="sidebar_jlg_settings[letter_spacing][unit]" value="<?php echo esc_attr( $letterSpacing['unit'] ); ?>" />
+                            </div>
+                            <em class="description"><?php esc_html_e( 'Sélectionnez une valeur numérique et l’unité adaptée (`px`, `em` ou `rem`).', 'sidebar-jlg' ); ?></em>
                         </p>
                         <p>
                             <label><?php esc_html_e( 'Casse du texte', 'sidebar-jlg' ); ?></label>

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -17,6 +17,7 @@ class SettingsSanitizer
         'content_margin' => ['px', 'rem', 'em', '%'],
         'hamburger_top_position' => ['px', 'rem', 'em', 'vh', 'vw'],
         'header_padding_top' => ['px', 'rem', 'em', '%'],
+        'letter_spacing' => ['px', 'rem', 'em'],
     ];
 
     private DefaultSettings $defaults;
@@ -286,10 +287,11 @@ class SettingsSanitizer
             $existingOptions['text_transform'] ?? ($defaults['text_transform'] ?? ''),
             $defaults['text_transform'] ?? ''
         );
-        $existingLetterSpacing = $existingOptions['letter_spacing'] ?? ($defaults['letter_spacing'] ?? '0');
-        $sanitized['letter_spacing'] = ValueNormalizer::normalizeCssDimension(
-            $input['letter_spacing'] ?? $existingLetterSpacing,
-            $existingLetterSpacing
+        $sanitized['letter_spacing'] = $this->sanitizeDimension(
+            $input,
+            'letter_spacing',
+            $existingOptions,
+            $defaults
         );
         $sanitized['font_color_type'] = $this->sanitizeChoice(
             $input['font_color_type'] ?? null,

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -57,7 +57,7 @@ class DefaultSettings
             'font_family'       => 'system-ui',
             'font_weight'       => '400',
             'text_transform'    => 'none',
-            'letter_spacing'    => '0em',
+            'letter_spacing'    => ['value' => '0', 'unit' => 'em'],
             'font_color_type'   => 'solid',
             'font_color'        => 'rgba(224, 224, 224, 1)',
             'font_color_start'  => '#fafafa',

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -16,11 +16,10 @@ class SettingsRepository
         'hamburger_top_position',
         'header_padding_top',
         'horizontal_bar_height',
-    ];
-
-    private const SIMPLE_DIMENSION_OPTION_KEYS = [
         'letter_spacing',
     ];
+
+    private const SIMPLE_DIMENSION_OPTION_KEYS = [];
 
     private const OPACITY_OPTION_KEYS = [
         'overlay_opacity',

--- a/tests/sanitize_style_settings_test.php
+++ b/tests/sanitize_style_settings_test.php
@@ -35,7 +35,7 @@ $existing_options = array_merge((new DefaultSettings())->all(), [
     'font_family'              => 'arial',
     'font_weight'              => '500',
     'text_transform'           => 'uppercase',
-    'letter_spacing'           => '0.1em',
+    'letter_spacing'           => ['value' => '0.1', 'unit' => 'em'],
     'header_logo_type'         => 'text',
     'app_name'                 => 'Existing App',
     'header_logo_image'        => 'http://example.com/logo.png',
@@ -63,7 +63,7 @@ $input = [
     'font_family'              => 'google-roboto',
     'font_weight'              => '700',
     'text_transform'           => 'lowercase',
-    'letter_spacing'           => 'calc(0.2em + 1px)',
+    'letter_spacing'           => ['value' => '0.2', 'unit' => 'rem'],
     'header_logo_type'         => 'image',
     'app_name'                 => 'New App',
     'header_logo_image'        => 'http://example.com/new-logo.png',
@@ -107,7 +107,7 @@ assertSame(0.8, $result['mobile_bg_opacity'], 'Valid opacity within range is pre
 assertSame('google-roboto', $result['font_family'], 'Allowed Google font choice is preserved');
 assertSame('700', $result['font_weight'], 'Allowed font weight is preserved');
 assertSame('lowercase', $result['text_transform'], 'Allowed text transform is preserved');
-assertSame('calc(0.2em + 1px)', $result['letter_spacing'], 'Letter spacing accepts calc expressions');
+assertSame(['value' => '0.2', 'unit' => 'rem'], $result['letter_spacing'], 'Letter spacing structure is normalized');
 
 $inputBelowMin = $input;
 $inputBelowMin['mobile_bg_opacity'] = -0.5;
@@ -143,7 +143,7 @@ assertSame('', $resultSanitizedAccentPayload['accent_color'], 'Existing accent c
 $inputInvalidSpacing = $input;
 $inputInvalidSpacing['letter_spacing'] = 'javascript:alert(1)';
 $resultInvalidSpacing = $method->invoke($sanitizer, $inputInvalidSpacing, $existing_options);
-assertSame('0.1em', $resultInvalidSpacing['letter_spacing'], 'Invalid letter spacing falls back to existing value');
+assertSame(['value' => '0.1', 'unit' => 'em'], $resultInvalidSpacing['letter_spacing'], 'Invalid letter spacing falls back to existing value');
 
 if ($testsPassed) {
     echo "All sanitize_style_settings tests passed.\n";


### PR DESCRIPTION
## Summary
- replace the letter spacing text field and mobile opacity slider with `@wordpress/components` controls that expose validation and contextual help
- sync the admin preview with structured letter-spacing/mobile opacity values and emit the corresponding CSS variables
- extend defaults, sanitization, and tests to persist the new value/unit structure safely

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68deed9f14b0832e93d74c28e77bc709