### PR TITLE
Add request-aware profile selection for the sidebar

### DIFF
--- a/sidebar-jlg/src/Frontend/ProfileSelector.php
+++ b/sidebar-jlg/src/Frontend/ProfileSelector.php
@@ -1,0 +1,424 @@
+<?php
+
+namespace JLG\Sidebar\Frontend;
+
+use JLG\Sidebar\Settings\SettingsRepository;
+
+class ProfileSelector
+{
+    private SettingsRepository $settings;
+
+    public function __construct(SettingsRepository $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function selectProfile(): array
+    {
+        $defaultOptions = $this->settings->getOptions();
+        $profiles = $this->settings->getProfiles();
+
+        $selection = [
+            'id' => 'default',
+            'settings' => $defaultOptions,
+            'is_fallback' => true,
+        ];
+
+        if ($profiles === []) {
+            return $selection;
+        }
+
+        $context = $this->buildRequestContext();
+        $bestPriority = -1;
+        $bestScore = -1;
+
+        foreach ($profiles as $profile) {
+            if (!is_array($profile)) {
+                continue;
+            }
+
+            $normalized = $this->normalizeProfile($profile, $defaultOptions);
+            if ($normalized === null) {
+                continue;
+            }
+
+            if (!$this->matchesConditions($normalized['conditions'], $context)) {
+                continue;
+            }
+
+            $priority = $normalized['priority'];
+            $score = $this->calculateSpecificity($normalized['conditions']);
+
+            if ($priority > $bestPriority || ($priority === $bestPriority && $score > $bestScore)) {
+                $bestPriority = $priority;
+                $bestScore = $score;
+                $selection = [
+                    'id' => $normalized['id'],
+                    'settings' => $normalized['settings'],
+                    'is_fallback' => false,
+                ];
+            }
+        }
+
+        return $selection;
+    }
+
+    private function normalizeProfile(array $profile, array $defaults): ?array
+    {
+        $profileId = isset($profile['id']) ? (string) $profile['id'] : '';
+        $profileId = $this->sanitizeIdentifier($profileId);
+
+        if ($profileId === '') {
+            $hashSource = json_encode($profile);
+            if (!is_string($hashSource) || $hashSource === '') {
+                $hashSource = serialize($profile);
+            }
+
+            $profileId = 'profile_' . substr(md5((string) $hashSource), 0, 12);
+        }
+
+        $settings = isset($profile['settings']) && is_array($profile['settings']) ? $profile['settings'] : [];
+
+        if (function_exists('wp_parse_args')) {
+            $mergedSettings = wp_parse_args($settings, $defaults);
+        } else {
+            $mergedSettings = array_merge($defaults, $settings);
+        }
+
+        unset($mergedSettings['profiles']);
+
+        $conditions = isset($profile['conditions']) && is_array($profile['conditions'])
+            ? $profile['conditions']
+            : [];
+
+        $normalizedConditions = $this->normalizeConditions($conditions);
+
+        $priority = 0;
+        if (isset($profile['priority']) && is_numeric($profile['priority'])) {
+            $priority = (int) $profile['priority'];
+        }
+
+        return [
+            'id' => $profileId,
+            'settings' => $mergedSettings,
+            'conditions' => $normalizedConditions,
+            'priority' => $priority,
+        ];
+    }
+
+    private function normalizeConditions(array $conditions): array
+    {
+        $normalized = [
+            'post_types' => [],
+            'taxonomies' => [],
+            'roles' => [],
+            'languages' => [],
+        ];
+
+        if (isset($conditions['post_types']) && is_array($conditions['post_types'])) {
+            foreach ($conditions['post_types'] as $postType) {
+                if (!is_string($postType) && !is_numeric($postType)) {
+                    continue;
+                }
+
+                $sanitized = $this->sanitizeIdentifier((string) $postType);
+                if ($sanitized === '') {
+                    continue;
+                }
+
+                $normalized['post_types'][$sanitized] = true;
+            }
+        }
+
+        if (isset($conditions['taxonomies']) && is_array($conditions['taxonomies'])) {
+            foreach ($conditions['taxonomies'] as $taxonomyCondition) {
+                if (!is_array($taxonomyCondition)) {
+                    continue;
+                }
+
+                $taxonomyName = $this->sanitizeIdentifier((string) ($taxonomyCondition['taxonomy'] ?? ''));
+                if ($taxonomyName === '') {
+                    continue;
+                }
+
+                $terms = [];
+                if (isset($taxonomyCondition['terms'])) {
+                    $terms = $this->normalizeTerms($taxonomyCondition['terms']);
+                }
+
+                $normalized['taxonomies'][] = [
+                    'taxonomy' => $taxonomyName,
+                    'terms' => $terms,
+                ];
+            }
+        }
+
+        if (isset($conditions['roles']) && is_array($conditions['roles'])) {
+            foreach ($conditions['roles'] as $role) {
+                if (!is_string($role) && !is_numeric($role)) {
+                    continue;
+                }
+
+                $sanitized = $this->sanitizeIdentifier((string) $role);
+                if ($sanitized === '') {
+                    continue;
+                }
+
+                $normalized['roles'][$sanitized] = true;
+            }
+        }
+
+        if (isset($conditions['languages']) && is_array($conditions['languages'])) {
+            foreach ($conditions['languages'] as $language) {
+                if (!is_string($language) && !is_numeric($language)) {
+                    continue;
+                }
+
+                $languageValue = strtolower(str_replace('-', '_', (string) $language));
+                $sanitized = $this->sanitizeIdentifier($languageValue);
+                if ($sanitized === '') {
+                    continue;
+                }
+
+                $normalized['languages'][$sanitized] = true;
+            }
+        }
+
+        $normalized['post_types'] = array_keys($normalized['post_types']);
+        $normalized['roles'] = array_keys($normalized['roles']);
+        $normalized['languages'] = array_keys($normalized['languages']);
+
+        return $normalized;
+    }
+
+    private function normalizeTerms($terms): array
+    {
+        $normalized = [];
+
+        if (is_array($terms)) {
+            foreach ($terms as $term) {
+                $normalizedTerm = $this->normalizeTermValue($term);
+                if ($normalizedTerm === null) {
+                    continue;
+                }
+
+                $normalized[$normalizedTerm] = true;
+            }
+        } elseif (is_string($terms) || is_numeric($terms)) {
+            $normalizedTerm = $this->normalizeTermValue($terms);
+            if ($normalizedTerm !== null) {
+                $normalized[$normalizedTerm] = true;
+            }
+        }
+
+        return array_keys($normalized);
+    }
+
+    private function normalizeTermValue($term): ?string
+    {
+        if (is_int($term) || (is_string($term) && preg_match('/^-?\d+$/', $term) === 1)) {
+            $termId = absint((int) $term);
+            if ($termId > 0) {
+                return (string) $termId;
+            }
+
+            return null;
+        }
+
+        if (!is_string($term)) {
+            return null;
+        }
+
+        $sanitized = $this->sanitizeIdentifier($term);
+
+        return $sanitized === '' ? null : $sanitized;
+    }
+
+    private function matchesConditions(array $conditions, array $context): bool
+    {
+        if ($conditions['post_types'] !== []) {
+            $intersection = array_intersect($conditions['post_types'], $context['post_types']);
+            if ($intersection === []) {
+                return false;
+            }
+        }
+
+        if ($conditions['roles'] !== []) {
+            $intersection = array_intersect($conditions['roles'], $context['roles']);
+            if ($intersection === []) {
+                return false;
+            }
+        }
+
+        if ($conditions['languages'] !== []) {
+            $language = $context['language'];
+            if ($language === '' || !in_array($language, $conditions['languages'], true)) {
+                return false;
+            }
+        }
+
+        foreach ($conditions['taxonomies'] as $taxonomyCondition) {
+            if (!$this->matchesTaxonomyCondition($taxonomyCondition, $context['taxonomies'])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function matchesTaxonomyCondition(array $taxonomyCondition, array $contextTaxonomies): bool
+    {
+        $taxonomy = $taxonomyCondition['taxonomy'] ?? '';
+        if ($taxonomy === '') {
+            return false;
+        }
+
+        if (!isset($contextTaxonomies[$taxonomy])) {
+            return false;
+        }
+
+        $contextTerms = $contextTaxonomies[$taxonomy];
+
+        if (!is_array($contextTerms)) {
+            return false;
+        }
+
+        if ($taxonomyCondition['terms'] === []) {
+            return true;
+        }
+
+        foreach ($taxonomyCondition['terms'] as $term) {
+            if (in_array($term, $contextTerms, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function calculateSpecificity(array $conditions): int
+    {
+        $score = 0;
+
+        $score += count($conditions['post_types']);
+        $score += count($conditions['roles']);
+        $score += count($conditions['languages']);
+
+        foreach ($conditions['taxonomies'] as $taxonomyCondition) {
+            $score += 1;
+            $score += count($taxonomyCondition['terms']);
+        }
+
+        return $score;
+    }
+
+    private function buildRequestContext(): array
+    {
+        $postTypes = [];
+        $taxonomies = [];
+
+        $postType = null;
+        if (function_exists('get_post_type')) {
+            $postTypeValue = get_post_type();
+            if (is_string($postTypeValue) || is_numeric($postTypeValue)) {
+                $postType = $this->sanitizeIdentifier((string) $postTypeValue);
+            }
+        }
+
+        if ($postType !== null && $postType !== '') {
+            $postTypes[$postType] = true;
+        }
+
+        $queriedObject = null;
+        if (function_exists('get_queried_object')) {
+            $queriedObject = get_queried_object();
+        }
+
+        if (is_object($queriedObject)) {
+            if (isset($queriedObject->post_type)) {
+                $queriedPostType = $this->sanitizeIdentifier((string) $queriedObject->post_type);
+                if ($queriedPostType !== '') {
+                    $postTypes[$queriedPostType] = true;
+                }
+            }
+
+            if (isset($queriedObject->taxonomy)) {
+                $taxonomyName = $this->sanitizeIdentifier((string) $queriedObject->taxonomy);
+                if ($taxonomyName !== '') {
+                    $terms = [];
+
+                    if (isset($queriedObject->term_id)) {
+                        $termId = absint((int) $queriedObject->term_id);
+                        if ($termId > 0) {
+                            $terms[(string) $termId] = true;
+                        }
+                    }
+
+                    if (isset($queriedObject->slug) && is_string($queriedObject->slug)) {
+                        $slug = $this->sanitizeIdentifier($queriedObject->slug);
+                        if ($slug !== '') {
+                            $terms[$slug] = true;
+                        }
+                    }
+
+                    $taxonomies[$taxonomyName] = array_keys($terms);
+                }
+            }
+        }
+
+        $roles = [];
+        if (function_exists('wp_get_current_user')) {
+            $user = wp_get_current_user();
+            if (is_object($user) && isset($user->roles) && is_array($user->roles)) {
+                foreach ($user->roles as $role) {
+                    if (!is_string($role) && !is_numeric($role)) {
+                        continue;
+                    }
+
+                    $sanitizedRole = $this->sanitizeIdentifier((string) $role);
+                    if ($sanitizedRole === '') {
+                        continue;
+                    }
+
+                    $roles[$sanitizedRole] = true;
+                }
+            }
+        }
+
+        $language = '';
+        $locale = '';
+
+        if (function_exists('determine_locale')) {
+            $locale = determine_locale();
+        } elseif (function_exists('get_locale')) {
+            $locale = get_locale();
+        }
+
+        if (is_string($locale) && $locale !== '') {
+            $locale = strtolower(str_replace('-', '_', $locale));
+            $language = $this->sanitizeIdentifier($locale);
+        }
+
+        return [
+            'post_types' => array_keys($postTypes),
+            'taxonomies' => $taxonomies,
+            'roles' => array_keys($roles),
+            'language' => $language,
+        ];
+    }
+
+    private function sanitizeIdentifier(string $value): string
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        if (function_exists('sanitize_key')) {
+            $sanitized = sanitize_key($value);
+        } else {
+            $sanitized = strtolower(preg_replace('/[^A-Za-z0-9_\-]/', '', $value));
+        }
+
+        return (string) $sanitized;
+    }
+}

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -62,6 +62,7 @@ class SidebarRenderer
     private SettingsRepository $settings;
     private IconLibrary $icons;
     private MenuCache $cache;
+    private ProfileSelector $profileSelector;
     private string $pluginFile;
     private string $version;
     private bool $bodyDataPrinted = false;
@@ -70,12 +71,14 @@ class SidebarRenderer
         SettingsRepository $settings,
         IconLibrary $icons,
         MenuCache $cache,
+        ProfileSelector $profileSelector,
         string $pluginFile,
         string $version
     ) {
         $this->settings = $settings;
         $this->icons = $icons;
         $this->cache = $cache;
+        $this->profileSelector = $profileSelector;
         $this->pluginFile = $pluginFile;
         $this->version = $version;
     }
@@ -91,7 +94,8 @@ class SidebarRenderer
 
     public function enqueueAssets(): void
     {
-        $options = $this->settings->getOptions();
+        $profile = $this->profileSelector->selectProfile();
+        $options = $profile['settings'];
         if (empty($options['enable_sidebar'])) {
             return;
         }
@@ -135,6 +139,8 @@ class SidebarRenderer
             'close_on_link_click' => $options['close_on_link_click'] ?? '',
             'debug_mode' => (string) ($options['debug_mode'] ?? '0'),
             'sidebar_position' => $this->resolveSidebarPosition($options),
+            'active_profile_id' => isset($profile['id']) ? (string) $profile['id'] : 'default',
+            'is_fallback_profile' => (bool) ($profile['is_fallback'] ?? false),
             'messages' => [
                 'missingElements' => __('Sidebar JLG : menu introuvable.', 'sidebar-jlg'),
             ],
@@ -450,7 +456,8 @@ class SidebarRenderer
 
     public function render(): void
     {
-        $options = $this->settings->getOptions();
+        $profile = $this->profileSelector->selectProfile();
+        $options = $profile['settings'];
         if (empty($options['enable_sidebar'])) {
             return;
         }

--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -8,6 +8,7 @@ use JLG\Sidebar\Admin\View\ColorPickerField;
 use JLG\Sidebar\Ajax\Endpoints;
 use JLG\Sidebar\Cache\MenuCache;
 use JLG\Sidebar\Frontend\Blocks\SearchBlock;
+use JLG\Sidebar\Frontend\ProfileSelector;
 use JLG\Sidebar\Frontend\SidebarRenderer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
@@ -23,6 +24,7 @@ class Plugin
     private MenuCache $cache;
     private SettingsSanitizer $sanitizer;
     private MenuPage $menuPage;
+    private ProfileSelector $profileSelector;
     private SidebarRenderer $renderer;
     private Endpoints $ajax;
     private SearchBlock $searchBlock;
@@ -36,6 +38,7 @@ class Plugin
         $this->settings = new SettingsRepository($this->defaults, $this->icons);
         $this->cache = new MenuCache();
         $this->sanitizer = new SettingsSanitizer($this->defaults, $this->icons);
+        $this->profileSelector = new ProfileSelector($this->settings);
         $this->menuPage = new MenuPage(
             $this->settings,
             $this->sanitizer,
@@ -48,6 +51,7 @@ class Plugin
             $this->settings,
             $this->icons,
             $this->cache,
+            $this->profileSelector,
             $pluginFile,
             $version
         );

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -91,6 +91,27 @@ class SettingsRepository
         return $options;
     }
 
+    public function getProfiles(): array
+    {
+        $storedOptions = $this->getStoredOptions();
+
+        if (!isset($storedOptions['profiles']) || !is_array($storedOptions['profiles'])) {
+            return [];
+        }
+
+        $profiles = [];
+
+        foreach ($storedOptions['profiles'] as $profile) {
+            if (!is_array($profile)) {
+                continue;
+            }
+
+            $profiles[] = $profile;
+        }
+
+        return array_values($profiles);
+    }
+
     public function getOptionsWithRevalidation(): array
     {
         $optionsFromDb = $this->getStoredOptions();

--- a/tests/profile_selector_integration_test.php
+++ b/tests/profile_selector_integration_test.php
@@ -1,0 +1,201 @@
+<?php
+declare(strict_types=1);
+
+use function JLG\Sidebar\plugin;
+
+require __DIR__ . '/bootstrap.php';
+
+if (!function_exists('get_post_type')) {
+    function get_post_type($post = null)
+    {
+        return $GLOBALS['test_post_type'] ?? null;
+    }
+}
+
+if (!function_exists('get_queried_object')) {
+    function get_queried_object()
+    {
+        return $GLOBALS['test_queried_object'] ?? null;
+    }
+}
+
+if (!function_exists('wp_get_current_user')) {
+    function wp_get_current_user()
+    {
+        $user = $GLOBALS['test_current_user'] ?? null;
+
+        if ($user === null) {
+            return (object) ['roles' => []];
+        }
+
+        return $user;
+    }
+}
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$plugin = plugin();
+$settingsRepository = $plugin->getSettingsRepository();
+$renderer = $plugin->getSidebarRenderer();
+$cache = $plugin->getMenuCache();
+
+$baseSettings = $settingsRepository->getDefaultSettings();
+$baseSettings['enable_sidebar'] = true;
+$baseSettings['social_icons'] = [];
+$baseSettings['menu_items'] = [];
+$baseSettings['profiles'] = [
+    [
+        'id' => 'subscriber-disabled',
+        'priority' => 20,
+        'conditions' => [
+            'roles' => ['subscriber'],
+        ],
+        'settings' => [
+            'enable_sidebar' => false,
+        ],
+    ],
+    [
+        'id' => 'page-special',
+        'priority' => 5,
+        'conditions' => [
+            'post_types' => ['page'],
+        ],
+        'settings' => [
+            'animation_type' => 'slide-right',
+        ],
+    ],
+    [
+        'id' => 'french-profile',
+        'priority' => 3,
+        'conditions' => [
+            'languages' => ['fr_FR'],
+        ],
+        'settings' => [
+            'animation_type' => 'fade',
+        ],
+    ],
+];
+
+$settingsRepository->saveOptions($baseSettings);
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+function assertSame($expected, $actual, string $message): void
+{
+    assertTrue($expected === $actual, $message);
+}
+
+$previousLocalizeOverride = $GLOBALS['wp_test_function_overrides']['wp_localize_script'] ?? null;
+
+$resetContext = static function (): void {
+    global $cache;
+
+    $cache->clear();
+    $GLOBALS['wp_test_transients'] = [];
+    $GLOBALS['test_post_type'] = null;
+    $GLOBALS['test_queried_object'] = null;
+};
+
+// Scenario 1: Subscriber role disables the sidebar entirely.
+$resetContext();
+$GLOBALS['test_current_user'] = (object) ['roles' => ['subscriber']];
+$GLOBALS['test_post_type'] = 'page';
+$GLOBALS['test_queried_object'] = (object) ['post_type' => 'page'];
+
+$localizedData = 'not-called';
+$GLOBALS['wp_test_function_overrides']['wp_localize_script'] = static function (...$args) use (&$localizedData): void {
+    $localizedData = $args[2] ?? null;
+};
+
+$renderer->enqueueAssets();
+assertSame('not-called', $localizedData, 'Assets skipped when subscriber profile disables sidebar');
+
+ob_start();
+$renderer->render();
+$subscriberHtml = (string) ob_get_clean();
+assertSame('', $subscriberHtml, 'Render output empty when subscriber profile disables sidebar');
+
+// Scenario 2: Editor on a page receives the page-specific profile.
+$resetContext();
+$GLOBALS['test_current_user'] = (object) ['roles' => ['editor']];
+$GLOBALS['test_post_type'] = 'page';
+$GLOBALS['test_queried_object'] = (object) ['post_type' => 'page'];
+
+$localizedData = null;
+$GLOBALS['wp_test_function_overrides']['wp_localize_script'] = static function (...$args) use (&$localizedData): void {
+    $localizedData = $args[2] ?? null;
+};
+
+$renderer->enqueueAssets();
+assertTrue(is_array($localizedData), 'Localized data generated for matching page profile');
+assertSame('page-special', $localizedData['active_profile_id'] ?? null, 'Page profile identifier exposed to scripts');
+assertSame(false, $localizedData['is_fallback_profile'] ?? null, 'Page profile flagged as non-fallback');
+assertSame('slide-right', $localizedData['animation_type'] ?? null, 'Page profile overrides animation type');
+
+// Scenario 3: Locale-specific profile applies on posts when language matches.
+$resetContext();
+$GLOBALS['test_current_user'] = (object) ['roles' => ['editor']];
+$GLOBALS['test_post_type'] = 'post';
+$GLOBALS['test_queried_object'] = (object) ['post_type' => 'post'];
+switch_to_locale('fr_FR');
+
+$localizedData = null;
+$GLOBALS['wp_test_function_overrides']['wp_localize_script'] = static function (...$args) use (&$localizedData): void {
+    $localizedData = $args[2] ?? null;
+};
+
+$renderer->enqueueAssets();
+assertTrue(is_array($localizedData), 'Localized data generated for language profile');
+assertSame('french-profile', $localizedData['active_profile_id'] ?? null, 'Language profile identifier exposed');
+assertSame(false, $localizedData['is_fallback_profile'] ?? null, 'Language profile flagged as non-fallback');
+assertSame('fade', $localizedData['animation_type'] ?? null, 'Language profile overrides animation type');
+
+// Scenario 4: Fallback profile used when no conditions match.
+$resetContext();
+$GLOBALS['test_current_user'] = (object) ['roles' => ['editor']];
+$GLOBALS['test_post_type'] = 'post';
+$GLOBALS['test_queried_object'] = (object) ['post_type' => 'post'];
+switch_to_locale('en_US');
+
+$localizedData = null;
+$GLOBALS['wp_test_function_overrides']['wp_localize_script'] = static function (...$args) use (&$localizedData): void {
+    $localizedData = $args[2] ?? null;
+};
+
+$renderer->enqueueAssets();
+assertTrue(is_array($localizedData), 'Localized data generated for fallback profile');
+assertSame('default', $localizedData['active_profile_id'] ?? null, 'Fallback profile identifier exposed');
+assertSame(true, $localizedData['is_fallback_profile'] ?? null, 'Fallback indicator flagged for default profile');
+assertSame('slide-left', $localizedData['animation_type'] ?? null, 'Fallback profile keeps default animation type');
+
+$resetContext();
+$GLOBALS['test_current_user'] = null;
+switch_to_locale('fr_FR');
+
+if ($previousLocalizeOverride !== null) {
+    $GLOBALS['wp_test_function_overrides']['wp_localize_script'] = $previousLocalizeOverride;
+} else {
+    unset($GLOBALS['wp_test_function_overrides']['wp_localize_script']);
+}
+
+if ($testsPassed) {
+    echo "Profile selector integration tests passed.\n";
+    exit(0);
+}
+
+echo "Profile selector integration tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- add a ProfileSelector that evaluates the current request context to choose the most specific sidebar profile
- update the sidebar renderer and plugin wiring to use the selected profile, surface its identifier to scripts, and fall back cleanly when nothing matches
- extend the settings repository to expose stored profiles and add integration coverage for the new selection logic

## Testing
- php tests/profile_selector_integration_test.php
- php tests/render_sidebar_active_state_test.php
- php tests/enqueue_assets_filter_test.php
- php tests/sidebar_locale_cache_test.php

------
https://chatgpt.com/codex/tasks/task_e_68deed67e274832e957a114781de0b01