### PR TITLE
Add profile-based storage for sidebar settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Après activation, un menu "Sidebar JLG" apparait dans l'administration. Vous po
 
 ### Export / Import des réglages
 
-- Depuis l’onglet **Outils** de la page d’administration, utilisez le bouton **Exporter les réglages** pour générer un fichier JSON contenant la configuration actuelle (`sidebar_jlg_settings`).
+- Depuis l’onglet **Outils** de la page d’administration, utilisez le bouton **Exporter les réglages** pour générer un fichier JSON contenant la configuration actuelle (profil actif enregistré dans `sidebar_jlg_profiles`).
 - Conservez ce fichier dans votre système de contrôle de versions ou partagez-le avec votre équipe pour synchroniser les environnements.
 - Sur l’environnement cible, sélectionnez ce fichier via le bouton **Importer les réglages** puis confirmez l’action. Les options existantes sont validées et remplacées avant que la page ne soit automatiquement rechargée.
 - Les exports incluent la version du plugin et l’URL du site source pour faciliter les audits et vérifier que l’import a été réalisé sur le bon environnement.

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -5,6 +5,7 @@ namespace JLG\Sidebar\Admin;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
 use JLG\Sidebar\Settings\OptionChoices;
+use JLG\Sidebar\Settings\SettingsRepository;
 use JLG\Sidebar\Settings\ValueNormalizer;
 
 class SettingsSanitizer
@@ -21,23 +22,25 @@ class SettingsSanitizer
 
     private DefaultSettings $defaults;
     private IconLibrary $icons;
+    private SettingsRepository $repository;
 
     /**
      * @var array<string, string[]>
      */
     private array $allowedChoices;
 
-    public function __construct(DefaultSettings $defaults, IconLibrary $icons)
+    public function __construct(DefaultSettings $defaults, IconLibrary $icons, SettingsRepository $repository)
     {
         $this->defaults = $defaults;
         $this->icons = $icons;
+        $this->repository = $repository;
         $this->allowedChoices = OptionChoices::getAll();
     }
 
     public function sanitize_settings($input): array
     {
         $defaults = $this->defaults->all();
-        $existingOptions = get_option('sidebar_jlg_settings', $defaults);
+        $existingOptions = $this->repository->getRawProfileOptions();
         if (!is_array($existingOptions)) {
             if (function_exists('error_log')) {
                 error_log('Sidebar JLG settings option was not an array. Resetting to defaults.');

--- a/sidebar-jlg/src/Frontend/Blocks/SearchBlock.php
+++ b/sidebar-jlg/src/Frontend/Blocks/SearchBlock.php
@@ -145,11 +145,7 @@ class SearchBlock
             return;
         }
 
-        $storedOptions = get_option('sidebar_jlg_settings', []);
-        if (!is_array($storedOptions)) {
-            $storedOptions = [];
-        }
-
+        $storedOptions = $this->settings->getRawProfileOptions();
         $this->settings->saveOptions(array_merge($storedOptions, $updates));
     }
 

--- a/sidebar-jlg/uninstall.php
+++ b/sidebar-jlg/uninstall.php
@@ -17,6 +17,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // 1. Supprimer l'option principale du plugin de la table wp_options.
 // C'est ici que tous les réglages de la sidebar sont stockés.
 delete_option( 'sidebar_jlg_settings' );
+delete_option( 'sidebar_jlg_profiles' );
 delete_option( 'sidebar_jlg_plugin_version' );
 
 // 2. Supprimer tous les transients de cache générés pour les locales mémorisées.

--- a/tests/ajax_endpoints_test.php
+++ b/tests/ajax_endpoints_test.php
@@ -538,28 +538,57 @@ assertSame("Termé alert('x')", $GLOBALS['test_get_categories_requests'][0]['sea
 
 reset_test_environment();
 $GLOBALS['test_current_user_can'] = false;
-$GLOBALS['wp_test_options'] = ['sidebar_jlg_settings' => ['should' => 'stay']];
+$GLOBALS['wp_test_options'] = [
+    'sidebar_jlg_profiles' => [
+        'active' => 'default',
+        'profiles' => [
+            'default' => ['should' => 'stay'],
+        ],
+    ],
+];
 $GLOBALS['wp_test_transients'] = ['sidebar_jlg_full_html_default' => '<div>keep</div>'];
 invoke_endpoint($endpoints, 'ajax_reset_settings');
 assertSame('Permission refusée.', $GLOBALS['json_error_payloads'][0] ?? null, 'Unauthorized reset request rejected');
 assertSame([], $GLOBALS['checked_nonces'], 'Nonce not validated when reset unauthorized');
-assertSame(['should' => 'stay'], get_option('sidebar_jlg_settings'), 'Unauthorized reset leaves settings untouched');
+assertSame([
+    'active' => 'default',
+    'profiles' => [
+        'default' => ['should' => 'stay'],
+    ],
+], get_option('sidebar_jlg_profiles'), 'Unauthorized reset leaves settings untouched');
 assertSame('<div>keep</div>', get_transient('sidebar_jlg_full_html_default'), 'Unauthorized reset leaves caches untouched');
 
 reset_test_environment();
-$GLOBALS['wp_test_options'] = ['sidebar_jlg_settings' => ['should' => 'stay']];
+$GLOBALS['wp_test_options'] = [
+    'sidebar_jlg_profiles' => [
+        'active' => 'default',
+        'profiles' => [
+            'default' => ['should' => 'stay'],
+        ],
+    ],
+];
 $GLOBALS['wp_test_transients'] = ['sidebar_jlg_full_html_default' => '<div>keep</div>'];
 $GLOBALS['test_nonce_results']['jlg_reset_nonce'] = 'Nonce invalide.';
 $_POST = ['nonce' => 'bad'];
 invoke_endpoint($endpoints, 'ajax_reset_settings');
 assertSame('Nonce invalide.', $GLOBALS['json_error_payloads'][0] ?? null, 'Reset nonce failure returns error');
 assertSame(['jlg_reset_nonce', 'nonce', 'bad'], $GLOBALS['checked_nonces'][0] ?? null, 'Reset nonce validated before failure');
-assertSame(['should' => 'stay'], get_option('sidebar_jlg_settings'), 'Nonce failure leaves settings untouched');
+assertSame([
+    'active' => 'default',
+    'profiles' => [
+        'default' => ['should' => 'stay'],
+    ],
+], get_option('sidebar_jlg_profiles'), 'Nonce failure leaves settings untouched');
 assertSame('<div>keep</div>', get_transient('sidebar_jlg_full_html_default'), 'Nonce failure leaves caches untouched');
 
 reset_test_environment();
 $GLOBALS['wp_test_options'] = [
-    'sidebar_jlg_settings' => ['foo' => 'bar'],
+    'sidebar_jlg_profiles' => [
+        'active' => 'default',
+        'profiles' => [
+            'default' => ['foo' => 'bar'],
+        ],
+    ],
     'sidebar_jlg_cached_locales' => ['default', 'fr_FR'],
 ];
 $GLOBALS['wp_test_transients'] = [
@@ -570,7 +599,12 @@ $GLOBALS['wp_test_transients'] = [
 $_POST = ['nonce' => 'reset-nonce'];
 invoke_endpoint($endpoints, 'ajax_reset_settings');
 assertSame('Réglages réinitialisés.', $GLOBALS['json_success_payloads'][0] ?? null, 'Reset settings success message returned');
-assertSame('missing', get_option('sidebar_jlg_settings', 'missing'), 'Settings option deleted during reset');
+assertSame([
+    'active' => 'default',
+    'profiles' => [
+        'default' => [],
+    ],
+], get_option('sidebar_jlg_profiles'), 'Settings reset clears active profile');
 assertSame('missing', get_option('sidebar_jlg_cached_locales', 'missing'), 'Cached locales option deleted during reset');
 assertSame(false, get_transient('sidebar_jlg_full_html_default'), 'Default locale cache cleared during reset');
 assertSame(false, get_transient('sidebar_jlg_full_html_fr_FR'), 'Additional locale cache cleared during reset');

--- a/tests/external_svg_icon_rejection_test.php
+++ b/tests/external_svg_icon_rejection_test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -11,7 +12,8 @@ require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
 $defaults = new DefaultSettings();
 $icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
+$repository = new SettingsRepository($defaults, $icons);
+$sanitizer = new SettingsSanitizer($defaults, $icons, $repository);
 
 $input = [
     'menu_items' => [

--- a/tests/hamburger_button_markup_regression_test.php
+++ b/tests/hamburger_button_markup_regression_test.php
@@ -16,7 +16,7 @@ $defaultSettings['enable_sidebar'] = true;
 $defaultSettings['menu_items'] = [];
 $defaultSettings['social_icons'] = [];
 
-update_option('sidebar_jlg_settings', $defaultSettings);
+$settingsRepository->saveOptions($defaultSettings);
 $menuCache->clear();
 $GLOBALS['wp_test_transients'] = [];
 

--- a/tests/render_sidebar_active_state_test.php
+++ b/tests/render_sidebar_active_state_test.php
@@ -63,12 +63,12 @@ function assertContains(string $needle, string $haystack, string $message): void
 
 function runSidebarScenario(array $menuItem, callable $configureContext): array
 {
-    global $renderer, $menuCache, $baseSettings;
+    global $renderer, $menuCache, $baseSettings, $settingsRepository;
 
     $settings = $baseSettings;
     $settings['menu_items'] = [$menuItem];
 
-    update_option('sidebar_jlg_settings', $settings);
+    $settingsRepository->saveOptions($settings);
 
     $GLOBALS['test_queried_object'] = null;
     $_SERVER['HTTP_HOST'] = 'example.com';

--- a/tests/render_sidebar_html_error_handling_test.php
+++ b/tests/render_sidebar_html_error_handling_test.php
@@ -32,7 +32,7 @@ $default_settings['menu_items'] = [
 ];
 $default_settings['social_icons'] = [];
 
-update_option('sidebar_jlg_settings', $default_settings);
+$settingsRepository->saveOptions($default_settings);
 $menuCache->clear();
 $GLOBALS['wp_test_transients'] = [];
 $GLOBALS['test_category_link_return'] = new WP_Error('invalid_term', 'Invalid term');

--- a/tests/render_sidebar_output_buffer_failure_test.php
+++ b/tests/render_sidebar_output_buffer_failure_test.php
@@ -45,7 +45,7 @@ namespace {
 
     $defaultSettings = $settingsRepository->getDefaultSettings();
     $defaultSettings['enable_sidebar'] = '1';
-    update_option('sidebar_jlg_settings', $defaultSettings);
+    $settingsRepository->saveOptions($defaultSettings);
 
     $menuCache->clear();
     $GLOBALS['wp_test_transients'] = [];

--- a/tests/revalidate_border_color_test.php
+++ b/tests/revalidate_border_color_test.php
@@ -32,12 +32,17 @@ function assertSame($expected, $actual, string $message): void
 }
 
 $maliciousBorderColor = '#fff; background: url(javascript:alert(1))';
-$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
-    'border_color' => $maliciousBorderColor,
+$GLOBALS['wp_test_options']['sidebar_jlg_profiles'] = [
+    'active' => 'default',
+    'profiles' => [
+        'default' => [
+            'border_color' => $maliciousBorderColor,
+        ],
+    ],
 ];
 
 $repository->revalidateStoredOptions();
-$storedAfterRevalidation = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+$storedAfterRevalidation = $repository->getRawProfileOptions();
 
 assertSame(
     $defaultBorderColor,
@@ -46,12 +51,17 @@ assertSame(
 );
 
 $validBorderColor = '#123abc';
-$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
-    'border_color' => $validBorderColor,
+$GLOBALS['wp_test_options']['sidebar_jlg_profiles'] = [
+    'active' => 'default',
+    'profiles' => [
+        'default' => [
+            'border_color' => $validBorderColor,
+        ],
+    ],
 ];
 
 $repository->revalidateStoredOptions();
-$storedAfterValidRevalidation = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+$storedAfterValidRevalidation = $repository->getRawProfileOptions();
 
 assertSame(
     $validBorderColor,

--- a/tests/revalidate_color_options_test.php
+++ b/tests/revalidate_color_options_test.php
@@ -76,26 +76,31 @@ $expectedFontHoverColor = normalize_expected_color($defaults['font_hover_color']
 $expectedMobileBgColor = normalize_expected_color($defaults['mobile_bg_color'] ?? '');
 $expectedOverlayColor = normalize_expected_color($defaults['overlay_color'] ?? '');
 
-$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
-    'enable_sidebar' => true,
-    'bg_color_type' => 'gradient',
-    'accent_color_type' => 'gradient',
-    'bg_color' => '',
-    'bg_color_start' => '',
-    'bg_color_end' => '',
-    'accent_color' => '',
-    'accent_color_start' => '',
-    'accent_color_end' => '',
-    'font_color' => '',
-    'font_hover_color' => '',
-    'overlay_color' => '',
-    'mobile_bg_color' => '',
+$GLOBALS['wp_test_options']['sidebar_jlg_profiles'] = [
+    'active' => 'default',
+    'profiles' => [
+        'default' => [
+            'enable_sidebar' => true,
+            'bg_color_type' => 'gradient',
+            'accent_color_type' => 'gradient',
+            'bg_color' => '',
+            'bg_color_start' => '',
+            'bg_color_end' => '',
+            'accent_color' => '',
+            'accent_color_start' => '',
+            'accent_color_end' => '',
+            'font_color' => '',
+            'font_hover_color' => '',
+            'overlay_color' => '',
+            'mobile_bg_color' => '',
+        ],
+    ],
 ];
 
 $menuCache->clear();
 $repository->revalidateStoredOptions();
 
-$storedAfterRevalidation = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+$storedAfterRevalidation = $repository->getRawProfileOptions();
 
 $testsPassed = true;
 

--- a/tests/revalidate_css_dimension_test.php
+++ b/tests/revalidate_css_dimension_test.php
@@ -15,15 +15,20 @@ $menuCache = $plugin->getMenuCache();
 $defaults = $repository->getDefaultSettings();
 $defaultContentMargin = $defaults['content_margin'] ?? '';
 
-$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
-    'enable_sidebar' => true,
-    'content_margin' => '',
+$GLOBALS['wp_test_options']['sidebar_jlg_profiles'] = [
+    'active' => 'default',
+    'profiles' => [
+        'default' => [
+            'enable_sidebar' => true,
+            'content_margin' => '',
+        ],
+    ],
 ];
 
 $menuCache->clear();
 $repository->revalidateStoredOptions();
 
-$storedAfterRevalidation = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+$storedAfterRevalidation = $repository->getRawProfileOptions();
 
 $testsPassed = true;
 

--- a/tests/revalidate_enumerated_options_test.php
+++ b/tests/revalidate_enumerated_options_test.php
@@ -13,13 +13,18 @@ $renderer = $plugin->getSidebarRenderer();
 
 $defaults = $repository->getDefaultSettings();
 
-$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
-    'desktop_behavior' => 'invalid-behavior',
+$GLOBALS['wp_test_options']['sidebar_jlg_profiles'] = [
+    'active' => 'default',
+    'profiles' => [
+        'default' => [
+            'desktop_behavior' => 'invalid-behavior',
+        ],
+    ],
 ];
 
 $repository->revalidateStoredOptions();
 
-$storedAfter = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+$storedAfter = $repository->getRawProfileOptions();
 
 $testsPassed = true;
 

--- a/tests/revalidate_opacity_options_test.php
+++ b/tests/revalidate_opacity_options_test.php
@@ -12,17 +12,22 @@ $repository = $plugin->getSettingsRepository();
 
 $defaults = $repository->getDefaultSettings();
 
-$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
-    'overlay_opacity' => 5.2,
-    'mobile_bg_opacity' => 'not-a-number',
-    'mobile_blur' => '-15',
-    'animation_speed' => '200ms',
-    'social_icon_size' => '90%',
+$GLOBALS['wp_test_options']['sidebar_jlg_profiles'] = [
+    'active' => 'default',
+    'profiles' => [
+        'default' => [
+            'overlay_opacity' => 5.2,
+            'mobile_bg_opacity' => 'not-a-number',
+            'mobile_blur' => '-15',
+            'animation_speed' => '200ms',
+            'social_icon_size' => '90%',
+        ],
+    ],
 ];
 
 $repository->revalidateStoredOptions();
 
-$storedAfterRevalidation = $GLOBALS['wp_test_options']['sidebar_jlg_settings'] ?? [];
+$storedAfterRevalidation = $repository->getRawProfileOptions();
 
 $testsPassed = true;
 

--- a/tests/sanitize_effects_enumerated_settings_test.php
+++ b/tests/sanitize_effects_enumerated_settings_test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -15,7 +16,8 @@ require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
 $defaults = new DefaultSettings();
 $icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
+$repository = new SettingsRepository($defaults, $icons);
+$sanitizer = new SettingsSanitizer($defaults, $icons, $repository);
 
 $reflection = new ReflectionClass(SettingsSanitizer::class);
 $effectsMethod = $reflection->getMethod('sanitize_effects_settings');

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -15,7 +16,8 @@ require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
 $defaults = new DefaultSettings();
 $icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
+$repository = new SettingsRepository($defaults, $icons);
+$sanitizer = new SettingsSanitizer($defaults, $icons, $repository);
 
 $reflection = new ReflectionClass(SettingsSanitizer::class);
 $method = $reflection->getMethod('sanitize_general_settings');

--- a/tests/sanitize_nav_menu_settings_test.php
+++ b/tests/sanitize_nav_menu_settings_test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -11,7 +12,8 @@ require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
 $defaults = new DefaultSettings();
 $icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
+$repository = new SettingsRepository($defaults, $icons);
+$sanitizer = new SettingsSanitizer($defaults, $icons, $repository);
 
 $reflection = new ReflectionClass(SettingsSanitizer::class);
 $menuMethod = $reflection->getMethod('sanitize_menu_settings');

--- a/tests/sanitize_settings_corrupted_option_test.php
+++ b/tests/sanitize_settings_corrupted_option_test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -11,11 +12,17 @@ require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
 $defaults = new DefaultSettings();
 $icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
+$repository = new SettingsRepository($defaults, $icons);
+$sanitizer = new SettingsSanitizer($defaults, $icons, $repository);
 
 $storedOptions = $defaults->all();
 $storedOptions['unexpected'] = 'should disappear';
-$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = $storedOptions;
+$GLOBALS['wp_test_options']['sidebar_jlg_profiles'] = [
+    'active' => 'default',
+    'profiles' => [
+        'default' => $storedOptions,
+    ],
+];
 
 $input = [
     'enable_sidebar' => '1',

--- a/tests/sanitize_style_settings_test.php
+++ b/tests/sanitize_style_settings_test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -15,7 +16,8 @@ require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
 $defaults = new DefaultSettings();
 $icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
+$repository = new SettingsRepository($defaults, $icons);
+$sanitizer = new SettingsSanitizer($defaults, $icons, $repository);
 
 $reflection = new ReflectionClass(SettingsSanitizer::class);
 $method = $reflection->getMethod('sanitize_style_settings');

--- a/tests/sidebar_locale_cache_test.php
+++ b/tests/sidebar_locale_cache_test.php
@@ -55,7 +55,7 @@ function assertNotContains(string $needle, string $haystack, string $message): v
 
 $default_settings = $settingsRepository->getDefaultSettings();
 $default_settings['social_icons'] = [];
-update_option('sidebar_jlg_settings', $default_settings);
+$settingsRepository->saveOptions($default_settings);
 
 $input_settings = [
     'menu_items' => [
@@ -89,7 +89,7 @@ assertTrue(
     'Category ID preserved after sanitization'
 );
 
-update_option('sidebar_jlg_settings', $sanitized_settings);
+$settingsRepository->saveOptions($sanitized_settings);
 
 $menuCache->clear();
 $GLOBALS['wp_test_transients'] = [];
@@ -146,7 +146,7 @@ $dynamic_settings['enable_search'] = true;
 $dynamic_settings['search_method'] = 'shortcode';
 $dynamic_settings['search_shortcode'] = '[dynamic]';
 
-update_option('sidebar_jlg_settings', $dynamic_settings);
+$settingsRepository->saveOptions($dynamic_settings);
 
 switch_to_locale('en_US');
 ob_start();
@@ -177,7 +177,7 @@ $search_disabled_settings['enable_search'] = false;
 $search_disabled_settings['search_method'] = 'shortcode';
 $search_disabled_settings['search_shortcode'] = '[disabled]';
 
-update_option('sidebar_jlg_settings', $search_disabled_settings);
+$settingsRepository->saveOptions($search_disabled_settings);
 
 switch_to_locale('en_US');
 ob_start();
@@ -214,7 +214,7 @@ $default_search_settings['enable_sidebar'] = true;
 $default_search_settings['enable_search'] = true;
 $default_search_settings['search_method'] = 'default';
 
-update_option('sidebar_jlg_settings', $default_search_settings);
+$settingsRepository->saveOptions($default_search_settings);
 
 $default_search_transient_key = 'sidebar_jlg_full_html_en_US';
 switch_to_locale('en_US');
@@ -277,13 +277,18 @@ $GLOBALS['wp_test_function_overrides']['update_option'] = static function ($name
 $GLOBALS['wp_test_options']['sidebar_jlg_plugin_version'] = SIDEBAR_JLG_VERSION;
 $GLOBALS['wp_test_options']['sidebar_jlg_cached_locales'] = ['fr_FR'];
 $GLOBALS['wp_test_transients']['sidebar_jlg_full_html_fr_FR'] = '<div>cached</div>';
-$GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
-    'menu_items' => [
-        [
-            'label' => 'Corrupted item',
-            'type' => 'custom',
-            'icon_type' => 'svg_inline',
-            'icon' => 'custom_missing',
+$GLOBALS['wp_test_options']['sidebar_jlg_profiles'] = [
+    'active' => 'default',
+    'profiles' => [
+        'default' => [
+            'menu_items' => [
+                [
+                    'label' => 'Corrupted item',
+                    'type' => 'custom',
+                    'icon_type' => 'svg_inline',
+                    'icon' => 'custom_missing',
+                ],
+            ],
         ],
     ],
 ];

--- a/tests/social_icon_label_persistence_test.php
+++ b/tests/social_icon_label_persistence_test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
 use function JLG\Sidebar\plugin;
 
 require __DIR__ . '/bootstrap.php';
@@ -12,7 +13,8 @@ require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
 $defaults = new DefaultSettings();
 $icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
+$repository = new SettingsRepository($defaults, $icons);
+$sanitizer = new SettingsSanitizer($defaults, $icons, $repository);
 
 $reflection = new ReflectionClass(SettingsSanitizer::class);
 $method = $reflection->getMethod('sanitize_social_settings');
@@ -88,7 +90,7 @@ $savedSettings['social_position'] = $result['social_position'];
 $savedSettings['social_orientation'] = $result['social_orientation'];
 $savedSettings['social_icon_size'] = $result['social_icon_size'];
 
-update_option('sidebar_jlg_settings', $savedSettings);
+$settingsRepository->saveOptions($savedSettings);
 $menuCache->clear();
 $GLOBALS['wp_test_transients'] = [];
 

--- a/tests/svg_url_path_traversal_rejection_test.php
+++ b/tests/svg_url_path_traversal_rejection_test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\DefaultSettings;
+use JLG\Sidebar\Settings\SettingsRepository;
 
 require __DIR__ . '/bootstrap.php';
 
@@ -11,7 +12,8 @@ require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
 $defaults = new DefaultSettings();
 $icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
-$sanitizer = new SettingsSanitizer($defaults, $icons);
+$repository = new SettingsRepository($defaults, $icons);
+$sanitizer = new SettingsSanitizer($defaults, $icons, $repository);
 
 $input = [
     'menu_items' => [


### PR DESCRIPTION
## Summary
- refactor the settings repository to persist profiles in `sidebar_jlg_profiles` and expose profile helpers
- migrate legacy `sidebar_jlg_settings` data during bootstrap and update consumers to use the new profile-aware APIs
- refresh tests, docs, and uninstall cleanup to align with the profile storage

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68deed277264832ea0c1d5ba1db11b79