### PR TITLE
Add configurable mobile sidebar width

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -201,6 +201,8 @@ body[data-sidebar-position="right"] .pro-sidebar {
         background-color: color-mix(in srgb, var(--mobile-bg-color) calc(var(--mobile-bg-opacity) * 100%), transparent);
         -webkit-backdrop-filter: blur(var(--mobile-blur));
         backdrop-filter: blur(var(--mobile-blur));
+        width: var(--sidebar-width-mobile, 100%);
+        max-width: 100%;
     }
     body.sidebar-open .pro-sidebar { visibility: visible; }
     body.jlg-sidebar-position-left .pro-sidebar.animation-slide-left,

--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -1050,6 +1050,10 @@ class SidebarPreviewModule {
             this.currentOptions.width_tablet = value;
         });
 
+        this.bindField('sidebar_jlg_settings[width_mobile]', (value) => {
+            this.currentOptions.width_mobile = value;
+        });
+
         this.bindDimensionField('sidebar_jlg_settings[horizontal_bar_height]', 'horizontal_bar_height');
 
         this.bindField('sidebar_jlg_settings[overlay_color]', (value) => {
@@ -1254,6 +1258,7 @@ class SidebarPreviewModule {
             ['--sidebar-hover-color', this.currentOptions.font_hover_color],
             ['--sidebar-width-desktop', this.formatDimension(this.currentOptions.width_desktop)],
             ['--sidebar-width-tablet', this.formatDimension(this.currentOptions.width_tablet)],
+            ['--sidebar-width-mobile', this.formatDimension(this.currentOptions.width_mobile)],
             ['--sidebar-overlay-color', this.currentOptions.overlay_color],
             ['--sidebar-overlay-opacity', this.formatOpacity(this.currentOptions.overlay_opacity)],
             ['--sidebar-hamburger-color', this.currentOptions.hamburger_color],

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -286,6 +286,11 @@ $textTransformLabels = [
                     <td>
                         <p><label><?php esc_html_e( 'Largeur (Desktop)', 'sidebar-jlg' ); ?></label> <input type="number" name="sidebar_jlg_settings[width_desktop]" value="<?php echo esc_attr( $options['width_desktop'] ); ?>" class="small-text"/> px</p>
                         <p><label><?php esc_html_e( 'Largeur (Tablette)', 'sidebar-jlg' ); ?></label> <input type="number" name="sidebar_jlg_settings[width_tablet]" value="<?php echo esc_attr( $options['width_tablet'] ); ?>" class="small-text"/> px <em class="description"><?php esc_html_e( 'Appliquée entre 768px et 992px.', 'sidebar-jlg' ); ?></em></p>
+                        <p>
+                            <label><?php esc_html_e( 'Largeur (Mobile)', 'sidebar-jlg' ); ?></label>
+                            <input type="text" name="sidebar_jlg_settings[width_mobile]" value="<?php echo esc_attr( $options['width_mobile'] ); ?>" class="small-text" />
+                            <em class="description"><?php esc_html_e( '100 % par défaut pour couvrir l’écran. Accepte toute valeur CSS (320px, 85%, calc(100% - 2rem)…) appliquée sous 768px.', 'sidebar-jlg' ); ?></em>
+                        </p>
                     </td>
                 </tr>
                 <tr>

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -253,6 +253,12 @@ class SettingsSanitizer
             $existingOptions,
             $defaults
         );
+        $sanitized['width_mobile'] = $this->sanitizeCssDimensionOption(
+            $input,
+            'width_mobile',
+            $existingOptions,
+            $defaults
+        );
         $sanitized['enable_search'] = !empty($input['enable_search']);
         $sanitized['search_method'] = $this->sanitizeChoice(
             $input['search_method'] ?? null,
@@ -847,6 +853,19 @@ class SettingsSanitizer
         }
 
         return absint($existing);
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     * @param array<string, mixed> $existingOptions
+     * @param array<string, mixed> $defaults
+     */
+    private function sanitizeCssDimensionOption(array $input, string $key, array $existingOptions, array $defaults): string
+    {
+        $existing = $existingOptions[$key] ?? ($defaults[$key] ?? '');
+        $fallback = $existing !== '' ? $existing : ($defaults[$key] ?? '');
+
+        return ValueNormalizer::normalizeCssDimension($input[$key] ?? null, $fallback);
     }
 
     /**

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -13,6 +13,7 @@ class SidebarRenderer
     private const DYNAMIC_STYLE_DEFAULTS = [
         'width_desktop' => 280,
         'width_tablet' => 320,
+        'width_mobile' => '100%',
         'bg_color_type' => 'solid',
         'bg_color' => 'rgba(26, 29, 36, 1)',
         'bg_color_start' => '#18181b',
@@ -155,6 +156,7 @@ class SidebarRenderer
 
         $this->assignVariable($variables, '--sidebar-width-desktop', $this->formatPixelValue($this->resolveOption($options, 'width_desktop')));
         $this->assignVariable($variables, '--sidebar-width-tablet', $this->formatPixelValue($this->resolveOption($options, 'width_tablet')));
+        $this->assignVariable($variables, '--sidebar-width-mobile', $this->sanitizeCssString($this->resolveOption($options, 'width_mobile')));
 
         $bgType = $this->sanitizeCssString($this->resolveOption($options, 'bg_color_type')) ?? self::DYNAMIC_STYLE_DEFAULTS['bg_color_type'];
         if ($bgType === 'gradient') {

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -28,6 +28,7 @@ class DefaultSettings
             'content_margin'    => ['value' => '2', 'unit' => 'rem'],
             'width_desktop'     => 280,
             'width_tablet'      => 320,
+            'width_mobile'      => '100%',
             'enable_search'     => false,
             'search_method'     => 'default',
             'search_shortcode'  => '',

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -19,7 +19,9 @@ class SettingsRepository
         'letter_spacing',
     ];
 
-    private const SIMPLE_DIMENSION_OPTION_KEYS = [];
+    private const SIMPLE_DIMENSION_OPTION_KEYS = [
+        'width_mobile',
+    ];
 
     private const OPACITY_OPTION_KEYS = [
         'overlay_opacity',

--- a/tests/revalidate_css_dimension_test.php
+++ b/tests/revalidate_css_dimension_test.php
@@ -19,6 +19,7 @@ $defaultContentMargin = $defaults['content_margin'] ?? '';
 $GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
     'enable_sidebar' => true,
     'content_margin' => '',
+    'width_mobile'   => 'calc(100% - 20pt)',
 ];
 
 $menuCache->clear();
@@ -59,6 +60,11 @@ assertSame(
     $storedAfterRevalidation['content_margin'] ?? null,
     'Content margin reverts to default when stored value is empty'
 );
+assertSame(
+    $defaults['width_mobile'],
+    $storedAfterRevalidation['width_mobile'] ?? null,
+    'Mobile width reverts to default when stored value is invalid'
+);
 
 $GLOBALS['wp_test_inline_styles'] = [];
 $renderer->enqueueAssets();
@@ -73,6 +79,8 @@ $defaultContentMarginCss = is_array($defaultContentMargin)
     : (string) $defaultContentMargin;
 $expectedCss = '--content-margin: calc(var(--sidebar-width-desktop) + ' . $defaultContentMarginCss . ');';
 assertContains($expectedCss, $inlineStyles, 'Rendered CSS uses default content margin after revalidation');
+$expectedMobileWidthCss = '--sidebar-width-mobile: ' . $defaults['width_mobile'] . ';';
+assertContains($expectedMobileWidthCss, $inlineStyles, 'Rendered CSS exposes mobile width variable');
 
 if (!$testsPassed) {
     exit(1);

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -51,6 +51,7 @@ $input_invalid = [
     'overlay_color'   => 'not-a-color',
     'overlay_opacity' => 1.7,
     'border_color'    => '#fff; background: url(javascript:alert(1))',
+    'width_mobile'    => 'calc(100% - 20pt)',
 ];
 
 $result_invalid = $method->invoke($sanitizer, $input_invalid, $existing_options);
@@ -62,10 +63,12 @@ assertSame(
     $result_invalid['border_color'] ?? '',
     'Border color falls back to existing value when sanitized input is invalid'
 );
+assertSame('100%', $result_invalid['width_mobile'] ?? '', 'Invalid mobile width falls back to existing value');
 
 $input_valid = [
     'overlay_color'   => '#ABCDEF',
     'border_color'    => '#EECCDD',
+    'width_mobile'    => '88%',
 ];
 
 $result_valid = $method->invoke($sanitizer, $input_valid, $existing_options);
@@ -73,6 +76,7 @@ $result_valid = $method->invoke($sanitizer, $input_valid, $existing_options);
 assertSame('#abcdef', $result_valid['overlay_color'] ?? '', 'Overlay color accepts valid hex values');
 assertSame(0.4, $result_valid['overlay_opacity'] ?? null, 'Overlay opacity falls back to existing value when missing');
 assertSame('#eeccdd', $result_valid['border_color'] ?? '', 'Border color accepts valid hex values without modification');
+assertSame('88%', $result_valid['width_mobile'] ?? '', 'Mobile width accepts valid CSS dimension values');
 
 $input_close_on_click = [
     'close_on_link_click' => '1',
@@ -105,16 +109,18 @@ $result_close_zero = $method->invoke($sanitizer, $input_close_on_click_zero, $ex
 assertSame(false, $result_close_zero['close_on_link_click'] ?? null, 'Close-on-click option treats "0" as disabled');
 
 $existing_numeric_general = array_merge($defaults->all(), [
-    'border_width'   => 4,
-    'width_desktop'  => 360,
-    'width_tablet'   => 280,
+    'border_width'     => 4,
+    'width_desktop'    => 360,
+    'width_tablet'     => 280,
+    'width_mobile'     => '75%',
     'header_logo_size' => 96,
 ]);
 
 $input_empty_numeric_general = [
-    'border_width'   => '',
-    'width_desktop'  => '   ',
-    'width_tablet'   => 'abc',
+    'border_width'     => '',
+    'width_desktop'    => '   ',
+    'width_tablet'     => 'abc',
+    'width_mobile'     => ['value' => 'oops'],
     'header_logo_size' => false,
 ];
 
@@ -124,6 +130,7 @@ assertSame(4, $result_numeric_general['border_width'] ?? null, 'Empty border wid
 assertSame(360, $result_numeric_general['width_desktop'] ?? null, 'Empty desktop width keeps existing value');
 assertSame(280, $result_numeric_general['width_tablet'] ?? null, 'Non-numeric tablet width keeps existing value');
 assertSame(96, $result_numeric_general['header_logo_size'] ?? null, 'Non-numeric header logo size keeps existing value');
+assertSame('75%', $result_numeric_general['width_mobile'] ?? null, 'Invalid mobile width keeps existing value');
 
 $input_min = [
     'overlay_opacity' => -0.3,


### PR DESCRIPTION
## Summary
- add a `width_mobile` option with defaults, sanitization, and repository normalization so the dimension is persisted safely
- expose the mobile width control in the general settings UI, propagate the value through the admin preview, and export `--sidebar-width-mobile`
- apply the new CSS variable below 992px and extend regression tests to cover the normalization and revalidation logic

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68def9c07008832ea5288ef0f98f3b3c