### PR TITLE
Add customizable navigation accessibility labels

### DIFF
--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -528,6 +528,10 @@ class SidebarPreviewModule {
         this.hamburger = null;
         this.overlay = null;
 
+        this.defaultNavAriaLabel = '';
+        this.defaultToggleExpandLabel = '';
+        this.defaultToggleCollapseLabel = '';
+
         this.menuContainer = null;
         this.socialContainer = null;
         this.menuObserver = null;
@@ -802,6 +806,13 @@ class SidebarPreviewModule {
         this.hamburger = this.viewport ? this.viewport.querySelector('#hamburger-btn') : null;
 
         this.overlay = this.viewport ? this.viewport.querySelector('.sidebar-overlay') : null;
+
+        if (this.nav) {
+            this.defaultNavAriaLabel = this.nav.getAttribute('data-default-aria-label') || this.nav.getAttribute('aria-label') || '';
+            this.defaultToggleExpandLabel = this.nav.getAttribute('data-default-toggle-expand') || '';
+            this.defaultToggleCollapseLabel = this.nav.getAttribute('data-default-toggle-collapse') || '';
+        }
+
         this.syncOverlayVisibility();
 
         if (this.hamburger) {
@@ -815,6 +826,7 @@ class SidebarPreviewModule {
 
         this.captureDefaultFontStackFromMarkup();
         this.updatePreviewSizeClasses();
+        this.updateAccessibilityLabels();
     }
 
     setupToolbar() {
@@ -1093,6 +1105,18 @@ class SidebarPreviewModule {
             this.currentOptions.app_name = value;
         });
 
+        this.bindField('sidebar_jlg_settings[nav_aria_label]', (value) => {
+            this.currentOptions.nav_aria_label = value;
+        });
+
+        this.bindField('sidebar_jlg_settings[toggle_open_label]', (value) => {
+            this.currentOptions.toggle_open_label = value;
+        });
+
+        this.bindField('sidebar_jlg_settings[toggle_close_label]', (value) => {
+            this.currentOptions.toggle_close_label = value;
+        });
+
         this.bindField('sidebar_jlg_settings[header_logo_type]', (value) => {
             this.currentOptions.header_logo_type = value;
         });
@@ -1241,6 +1265,7 @@ class SidebarPreviewModule {
         this.updateHeader();
         this.renderMenu();
         this.renderSocial();
+        this.updateAccessibilityLabels();
     }
 
     applyCssVariables() {
@@ -1680,6 +1705,66 @@ class SidebarPreviewModule {
                 this.menuSocialItem.parentElement.removeChild(this.menuSocialItem);
             }
         }
+    }
+
+    updateAccessibilityLabels() {
+        const navLabelValue = typeof this.currentOptions.nav_aria_label === 'string'
+            ? this.currentOptions.nav_aria_label.trim()
+            : '';
+        const navLabel = navLabelValue !== ''
+            ? navLabelValue
+            : (this.defaultNavAriaLabel || '');
+
+        if (this.nav) {
+            if (navLabel) {
+                this.nav.setAttribute('aria-label', navLabel);
+            } else {
+                this.nav.removeAttribute('aria-label');
+            }
+        }
+
+        const expandValue = typeof this.currentOptions.toggle_open_label === 'string'
+            ? this.currentOptions.toggle_open_label.trim()
+            : '';
+        const collapseValue = typeof this.currentOptions.toggle_close_label === 'string'
+            ? this.currentOptions.toggle_close_label.trim()
+            : '';
+
+        const expandLabel = expandValue !== '' ? expandValue : (this.defaultToggleExpandLabel || '');
+        const collapseLabel = collapseValue !== '' ? collapseValue : (this.defaultToggleCollapseLabel || '');
+
+        if (!this.menuList) {
+            return;
+        }
+
+        const toggles = this.menuList.querySelectorAll('.submenu-toggle');
+        toggles.forEach((button) => {
+            if (expandLabel) {
+                button.setAttribute('data-label-expand', expandLabel);
+            } else {
+                button.removeAttribute('data-label-expand');
+            }
+
+            if (collapseLabel) {
+                button.setAttribute('data-label-collapse', collapseLabel);
+            } else {
+                button.removeAttribute('data-label-collapse');
+            }
+
+            const isExpanded = button.getAttribute('aria-expanded') === 'true';
+            const labelForState = isExpanded ? collapseLabel : expandLabel;
+
+            if (labelForState) {
+                button.setAttribute('aria-label', labelForState);
+            } else {
+                button.removeAttribute('aria-label');
+            }
+
+            const srText = button.querySelector('.screen-reader-text');
+            if (srText) {
+                srText.textContent = labelForState || '';
+            }
+        });
     }
 }
 

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -322,6 +322,28 @@ $textTransformLabels = [
                     </td>
                 </tr>
                 <tr>
+                    <th scope="row"><?php esc_html_e( 'Libellé ARIA de la navigation', 'sidebar-jlg' ); ?></th>
+                    <td>
+                        <input type="text" class="regular-text" name="sidebar_jlg_settings[nav_aria_label]" value="<?php echo esc_attr( $options['nav_aria_label'] ?? '' ); ?>" />
+                        <p class="description"><?php esc_html_e( 'Définit le texte de l’attribut aria-label du bloc de navigation pour les lecteurs d’écran.', 'sidebar-jlg' ); ?></p>
+                        <p class="description"><?php esc_html_e( 'Laissez vide pour utiliser automatiquement la traduction fournie par le plugin.', 'sidebar-jlg' ); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Libellés du bouton de sous-menu', 'sidebar-jlg' ); ?></th>
+                    <td>
+                        <p>
+                            <label for="sidebar-jlg-toggle-open-label"><?php esc_html_e( 'Texte lorsque le sous-menu est fermé', 'sidebar-jlg' ); ?></label>
+                            <input type="text" id="sidebar-jlg-toggle-open-label" name="sidebar_jlg_settings[toggle_open_label]" value="<?php echo esc_attr( $options['toggle_open_label'] ?? '' ); ?>" class="regular-text" />
+                        </p>
+                        <p>
+                            <label for="sidebar-jlg-toggle-close-label"><?php esc_html_e( 'Texte lorsque le sous-menu est ouvert', 'sidebar-jlg' ); ?></label>
+                            <input type="text" id="sidebar-jlg-toggle-close-label" name="sidebar_jlg_settings[toggle_close_label]" value="<?php echo esc_attr( $options['toggle_close_label'] ?? '' ); ?>" class="regular-text" />
+                        </p>
+                        <p class="description"><?php esc_html_e( 'Ces textes alimentent les attributs aria-label et la mention pour les lecteurs d’écran. Laissez vide pour conserver les libellés traduits par défaut.', 'sidebar-jlg' ); ?></p>
+                    </td>
+                </tr>
+                <tr>
                     <th scope="row"><?php esc_html_e( 'Barre de recherche', 'sidebar-jlg' ); ?></th>
                     <td>
                         <label><input type="checkbox" name="sidebar_jlg_settings[enable_search]" value="1" <?php checked( $options['enable_search'], 1 ); ?> /> <?php esc_html_e( 'Activer la barre de recherche.', 'sidebar-jlg' ); ?></label>

--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -35,7 +35,38 @@ if (isset($options['social_orientation']) && is_string($options['social_orientat
     $socialOrientation = $options['social_orientation'];
 }
 
-$renderMenuNodes = static function (array $nodes, string $layout) use (&$renderMenuNodes): string {
+$defaultNavAriaLabel = __('Navigation principale', 'sidebar-jlg');
+$navAriaLabelOption = '';
+if (isset($options['nav_aria_label']) && is_string($options['nav_aria_label'])) {
+    $navAriaLabelOption = trim((string) $options['nav_aria_label']);
+}
+if ($navAriaLabelOption !== '') {
+    $navAriaLabelOption = sanitize_text_field($navAriaLabelOption);
+}
+$navAriaLabel = $navAriaLabelOption !== '' ? $navAriaLabelOption : $defaultNavAriaLabel;
+
+$defaultToggleExpandLabel = __('Afficher le sous-menu', 'sidebar-jlg');
+$defaultToggleCollapseLabel = __('Masquer le sous-menu', 'sidebar-jlg');
+
+$toggleExpandLabelOption = '';
+if (isset($options['toggle_open_label']) && is_string($options['toggle_open_label'])) {
+    $toggleExpandLabelOption = trim((string) $options['toggle_open_label']);
+}
+if ($toggleExpandLabelOption !== '') {
+    $toggleExpandLabelOption = sanitize_text_field($toggleExpandLabelOption);
+}
+$toggleExpandLabel = $toggleExpandLabelOption !== '' ? $toggleExpandLabelOption : $defaultToggleExpandLabel;
+
+$toggleCollapseLabelOption = '';
+if (isset($options['toggle_close_label']) && is_string($options['toggle_close_label'])) {
+    $toggleCollapseLabelOption = trim((string) $options['toggle_close_label']);
+}
+if ($toggleCollapseLabelOption !== '') {
+    $toggleCollapseLabelOption = sanitize_text_field($toggleCollapseLabelOption);
+}
+$toggleCollapseLabel = $toggleCollapseLabelOption !== '' ? $toggleCollapseLabelOption : $defaultToggleCollapseLabel;
+
+$renderMenuNodes = static function (array $nodes, string $layout) use (&$renderMenuNodes, $toggleExpandLabel, $toggleCollapseLabel): string {
     if ($nodes === []) {
         return '';
     }
@@ -81,8 +112,6 @@ $renderMenuNodes = static function (array $nodes, string $layout) use (&$renderM
 
         $submenuId = '';
         $toggleExpandedAttr = 'false';
-        $toggleLabelExpand = esc_attr__('Afficher le sous-menu', 'sidebar-jlg');
-        $toggleLabelCollapse = esc_attr__('Masquer le sous-menu', 'sidebar-jlg');
         if ($isInitiallyExpanded) {
             $toggleExpandedAttr = 'true';
         }
@@ -127,11 +156,11 @@ $renderMenuNodes = static function (array $nodes, string $layout) use (&$renderM
                     aria-expanded="<?php echo esc_attr($toggleExpandedAttr); ?>"
                     aria-controls="<?php echo esc_attr($submenuId); ?>"
                     aria-haspopup="true"
-                    aria-label="<?php echo esc_attr($toggleExpandedAttr === 'true' ? $toggleLabelCollapse : $toggleLabelExpand); ?>"
-                    data-label-expand="<?php echo esc_attr($toggleLabelExpand); ?>"
-                    data-label-collapse="<?php echo esc_attr($toggleLabelCollapse); ?>"
+                    aria-label="<?php echo esc_attr($toggleExpandedAttr === 'true' ? $toggleCollapseLabel : $toggleExpandLabel); ?>"
+                    data-label-expand="<?php echo esc_attr($toggleExpandLabel); ?>"
+                    data-label-collapse="<?php echo esc_attr($toggleCollapseLabel); ?>"
                 >
-                    <span class="screen-reader-text"><?php echo esc_html($toggleExpandedAttr === 'true' ? $toggleLabelCollapse : $toggleLabelExpand); ?></span>
+                    <span class="screen-reader-text"><?php echo esc_html($toggleExpandedAttr === 'true' ? $toggleCollapseLabel : $toggleExpandLabel); ?></span>
                     <span aria-hidden="true" class="submenu-toggle-indicator"></span>
                 </button>
                 <ul
@@ -152,7 +181,14 @@ $renderMenuNodes = static function (array $nodes, string $layout) use (&$renderM
 
 ob_start();
 ?>
-<nav class="<?php echo esc_attr($navigationClassAttr); ?>" role="navigation" aria-label="<?php esc_attr_e('Navigation principale', 'sidebar-jlg'); ?>">
+<nav
+    class="<?php echo esc_attr($navigationClassAttr); ?>"
+    role="navigation"
+    aria-label="<?php echo esc_attr($navAriaLabel); ?>"
+    data-default-aria-label="<?php echo esc_attr($defaultNavAriaLabel); ?>"
+    data-default-toggle-expand="<?php echo esc_attr($defaultToggleExpandLabel); ?>"
+    data-default-toggle-collapse="<?php echo esc_attr($defaultToggleCollapseLabel); ?>"
+>
     <ul class="<?php echo esc_attr($menuClassAttr); ?>">
         <?php echo $renderMenuNodes($menuNodes, $layoutStyle); ?>
 

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -271,6 +271,9 @@ class SettingsSanitizer
         $sanitized['show_close_button'] = !empty($input['show_close_button']);
         // Checkbox -> boolean conversion for the automatic closing behaviour.
         $sanitized['close_on_link_click'] = !empty($input['close_on_link_click']);
+        $sanitized['nav_aria_label'] = sanitize_text_field($input['nav_aria_label'] ?? $existingOptions['nav_aria_label']);
+        $sanitized['toggle_open_label'] = sanitize_text_field($input['toggle_open_label'] ?? $existingOptions['toggle_open_label']);
+        $sanitized['toggle_close_label'] = sanitize_text_field($input['toggle_close_label'] ?? $existingOptions['toggle_close_label']);
         $sanitized['hamburger_top_position'] = $this->sanitizeDimension(
             $input,
             'hamburger_top_position',

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -272,6 +272,14 @@ class SidebarRenderer
             $this->assignVariable($variables, '--neon-spread', $this->formatPixelValue($this->resolveOption($options, 'neon_spread')));
         }
 
+        $navAriaLabel = $this->resolveAccessibleLabelOption($options, 'nav_aria_label', __('Navigation principale', 'sidebar-jlg'));
+        $toggleExpandLabel = $this->resolveAccessibleLabelOption($options, 'toggle_open_label', __('Afficher le sous-menu', 'sidebar-jlg'));
+        $toggleCollapseLabel = $this->resolveAccessibleLabelOption($options, 'toggle_close_label', __('Masquer le sous-menu', 'sidebar-jlg'));
+
+        $this->assignVariable($variables, '--sidebar-nav-label', $this->formatCssStringValue($navAriaLabel));
+        $this->assignVariable($variables, '--sidebar-toggle-open-label', $this->formatCssStringValue($toggleExpandLabel));
+        $this->assignVariable($variables, '--sidebar-toggle-close-label', $this->formatCssStringValue($toggleCollapseLabel));
+
         $safeAreaFallbackDefaults = [
             'block_start' => '0px',
             'block_end' => '0px',
@@ -427,6 +435,37 @@ class SidebarRenderer
         }
 
         return rtrim(rtrim(sprintf('%.4f', $floatValue), '0'), '.');
+    }
+
+    private function resolveAccessibleLabelOption(array $options, string $key, string $fallback): string
+    {
+        $rawValue = $options[$key] ?? null;
+
+        if (!is_string($rawValue)) {
+            return $fallback;
+        }
+
+        $trimmed = trim($rawValue);
+
+        if ($trimmed === '') {
+            return $fallback;
+        }
+
+        return sanitize_text_field($trimmed);
+    }
+
+    private function formatCssStringValue(?string $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        return $trimmed;
     }
 
     private function resolveContentMargin(array $options): ?string

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -36,6 +36,9 @@ class DefaultSettings
             'show_close_button' => true,
             // Automatically close the sidebar after clicking menu or social links.
             'close_on_link_click' => false,
+            'nav_aria_label'   => '',
+            'toggle_open_label'  => '',
+            'toggle_close_label' => '',
             'hamburger_top_position' => ['value' => '4', 'unit' => 'rem'],
             'hamburger_color'      => 'rgba(255, 255, 255, 1)',
             'header_logo_type'  => 'text',

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -225,6 +225,24 @@ class SettingsRepository
             }
         }
 
+        $textOptionKeys = ['nav_aria_label', 'toggle_open_label', 'toggle_close_label'];
+        foreach ($textOptionKeys as $textKey) {
+            if (!array_key_exists($textKey, $revalidated)) {
+                continue;
+            }
+
+            $rawValue = $revalidated[$textKey];
+            if (!is_string($rawValue)) {
+                $revalidated[$textKey] = '';
+                continue;
+            }
+
+            $sanitizedValue = sanitize_text_field($rawValue);
+            if ($sanitizedValue !== $rawValue) {
+                $revalidated[$textKey] = $sanitizedValue;
+            }
+        }
+
         foreach (self::ABSINT_OPTION_KEYS as $intKey) {
             $defaultValue = isset($defaults[$intKey]) ? absint($defaults[$intKey]) : 0;
             $currentValue = $revalidated[$intKey] ?? $defaultValue;


### PR DESCRIPTION
## Summary
- add new settings for the navigation aria label and submenu toggle labels, including defaults, sanitization, and repository revalidation
- expose the accessibility text fields on the General tab and keep the admin live preview in sync with user edits
- read the new options in the frontend renderer/template while falling back to the existing translated strings

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68def9beae1c832e8082579fa85c3c68