### PR TITLE
Add configuration for hamburger button offset and size

### DIFF
--- a/sidebar-jlg/assets/css/admin-preview.css
+++ b/sidebar-jlg/assets/css/admin-preview.css
@@ -276,18 +276,25 @@
 #sidebar-jlg-preview .hamburger-menu {
     position: absolute;
     inset-block-start: var(--sidebar-hamburger-top);
-    inset-inline-start: calc(100% + 24px);
+    inset-inline-start: calc(100% + var(--sidebar-hamburger-inline-offset, 24px));
     transform: translateX(-50%);
     background: transparent;
     border: none;
     padding: 0;
     cursor: default;
+    width: var(--sidebar-hamburger-size, 50px);
+    height: var(--sidebar-hamburger-size, 50px);
 }
 
 #sidebar-jlg-preview .hamburger-menu .icon-1,
 #sidebar-jlg-preview .hamburger-menu .icon-2,
 #sidebar-jlg-preview .hamburger-menu .icon-3 {
     background-color: var(--sidebar-hamburger-color);
+}
+
+#sidebar-jlg-preview .hamburger-menu .hamburger-icon {
+    width: calc(var(--sidebar-hamburger-size, 50px) * 0.64);
+    height: calc(var(--sidebar-hamburger-size, 50px) * 0.48);
 }
 
 #sidebar-jlg-preview .sidebar-menu {

--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -610,18 +610,18 @@ body.sidebar-js-enhanced .sidebar-menu .submenu.is-open {
     display: block;
     position: fixed;
     inset-block-start: calc(var(--hamburger-top-position, 2rem) + var(--jlg-safe-area-inset-block-start));
-    inset-inline-start: calc(15px + var(--jlg-safe-area-inset-inline-start));
+    inset-inline-start: calc(var(--hamburger-inline-offset, 15px) + var(--jlg-safe-area-inset-inline-start));
     inset-inline-end: auto;
     z-index: 1001;
     background: none; border: none;
     padding: 0; cursor: pointer;
-    width: 50px; height: 50px;
+    width: var(--hamburger-size, 50px); height: var(--hamburger-size, 50px);
     display: flex; align-items: center; justify-content: center;
 }
 .hamburger-menu.orientation-right,
 .hamburger-menu[data-position="right"] {
     inset-inline-start: auto;
-    inset-inline-end: calc(15px + var(--jlg-safe-area-inset-inline-end));
+    inset-inline-end: calc(var(--hamburger-inline-offset, 15px) + var(--jlg-safe-area-inset-inline-end));
 }
 .hamburger-menu.orientation-left,
 .hamburger-menu[data-position="left"] {
@@ -634,22 +634,22 @@ body.sidebar-js-enhanced .sidebar-menu .submenu.is-open {
     background-color: rgba(255,255,255,0.1);
     color: var(--sidebar-text-hover-color);
 }
-.hamburger-icon { position: relative; width: 32px; height: 24px; }
+.hamburger-icon { position: relative; width: calc(var(--hamburger-size, 50px) * 0.64); height: calc(var(--hamburger-size, 50px) * 0.48); }
 .icon-1, .icon-2, .icon-3 {
     position: absolute;
     inset-inline-start: 0;
-    width: 32px; height: 3px;
+    width: 100%; height: calc(var(--hamburger-size, 50px) * 0.06);
     background-color: var(--hamburger-color, var(--sidebar-text-color, #fff));
     transition: all 400ms cubic-bezier(.84,.06,.52,1.8);
 }
 .icon-1 { inset-block-start: 0; }
 .icon-2 { inset-block-start: 50%; transform: translateY(-50%); }
 .icon-3 { inset-block-end: 0; }
-.hamburger-menu.is-active .icon-1 { transform: rotate(40deg); inset-block-start: 10px; }
+.hamburger-menu.is-active .icon-1 { transform: rotate(40deg); inset-block-start: calc(var(--hamburger-size, 50px) * 0.2); }
 .hamburger-menu.is-active .icon-2 { opacity: 0; }
 .hamburger-menu.is-active .icon-3 {
     transform: rotate(-40deg);
-    inset-block-start: 10px;
+    inset-block-start: calc(var(--hamburger-size, 50px) * 0.2);
     inset-block-end: auto;
 }
 @media (min-width: 993px) { .hamburger-menu { display: none !important; } }

--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -501,6 +501,8 @@ class SidebarPreviewModule {
             'floating_vertical_margin',
             'border_radius',
             'hamburger_top_position',
+            'hamburger_horizontal_offset',
+            'hamburger_size',
             'header_padding_top',
             'horizontal_bar_height',
             'letter_spacing',
@@ -1065,6 +1067,8 @@ class SidebarPreviewModule {
         });
 
         this.bindDimensionField('sidebar_jlg_settings[hamburger_top_position]', 'hamburger_top_position');
+        this.bindDimensionField('sidebar_jlg_settings[hamburger_horizontal_offset]', 'hamburger_horizontal_offset');
+        this.bindDimensionField('sidebar_jlg_settings[hamburger_size]', 'hamburger_size');
 
         this.bindDimensionField('sidebar_jlg_settings[content_margin]', 'content_margin');
 
@@ -1258,6 +1262,8 @@ class SidebarPreviewModule {
             ['--sidebar-overlay-opacity', this.formatOpacity(this.currentOptions.overlay_opacity)],
             ['--sidebar-hamburger-color', this.currentOptions.hamburger_color],
             ['--sidebar-hamburger-top', this.formatDimension(this.currentOptions.hamburger_top_position)],
+            ['--sidebar-hamburger-inline-offset', this.formatDimension(this.currentOptions.hamburger_horizontal_offset)],
+            ['--sidebar-hamburger-size', this.formatDimension(this.currentOptions.hamburger_size)],
             ['--sidebar-content-margin', this.formatDimension(this.currentOptions.content_margin)],
             ['--sidebar-floating-margin', this.formatDimension(this.currentOptions.floating_vertical_margin)],
             ['--sidebar-border-radius', this.formatDimension(this.currentOptions.border_radius)],

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -101,6 +101,8 @@ $textTransformLabels = [
             'horizontal_bar_height'   => ['px', 'rem', 'em', 'vh', 'vw'],
             'content_margin'          => ['px', 'rem', 'em', '%'],
             'hamburger_top_position'  => ['px', 'rem', 'em', 'vh', 'vw'],
+            'hamburger_horizontal_offset' => ['px', 'rem', 'em', '%', 'vw'],
+            'hamburger_size'          => ['px', 'rem', 'em', 'vw'],
             'header_padding_top'      => ['px', 'rem', 'em', '%'],
             'letter_spacing'          => ['px', 'rem', 'em'],
         ];
@@ -309,6 +311,44 @@ $textTransformLabels = [
                                 <input type="hidden" data-dimension-unit name="sidebar_jlg_settings[hamburger_top_position][unit]" value="<?php echo esc_attr( $hamburgerOffset['unit'] ); ?>" />
                             </div>
                             <em class="description"><?php esc_html_e( 'Unités CSS (ex: 4rem, 15px).', 'sidebar-jlg' ); ?></em>
+                        </p>
+                        <?php $hamburgerInlineOffset = $dimensionValues['hamburger_horizontal_offset']; ?>
+                        <p>
+                            <label><?php esc_html_e( 'Décalage horizontal', 'sidebar-jlg' ); ?></label>
+                            <div
+                                class="sidebar-jlg-unit-control"
+                                data-sidebar-unit-control
+                                data-setting-name="sidebar_jlg_settings[hamburger_horizontal_offset]"
+                                data-label="<?php esc_attr_e( 'Décalage horizontal', 'sidebar-jlg' ); ?>"
+                                data-help="<?php esc_attr_e( 'Distance par rapport au bord de l’écran.', 'sidebar-jlg' ); ?>"
+                                data-error-message="<?php esc_attr_e( 'Le décalage horizontal ne peut pas être vide.', 'sidebar-jlg' ); ?>"
+                                data-default-value="<?php echo esc_attr( $defaults['hamburger_horizontal_offset']['value'] ?? '15' ); ?>"
+                                data-default-unit="<?php echo esc_attr( $defaults['hamburger_horizontal_offset']['unit'] ?? 'px' ); ?>"
+                                data-allowed-units="<?php echo esc_attr( wp_json_encode( $dimensionUnits['hamburger_horizontal_offset'] ) ); ?>"
+                            >
+                                <input type="hidden" data-dimension-value name="sidebar_jlg_settings[hamburger_horizontal_offset][value]" value="<?php echo esc_attr( $hamburgerInlineOffset['value'] ); ?>" />
+                                <input type="hidden" data-dimension-unit name="sidebar_jlg_settings[hamburger_horizontal_offset][unit]" value="<?php echo esc_attr( $hamburgerInlineOffset['unit'] ); ?>" />
+                            </div>
+                            <em class="description"><?php esc_html_e( 'Ex: 15px, 2rem, 5vw.', 'sidebar-jlg' ); ?></em>
+                        </p>
+                        <?php $hamburgerSize = $dimensionValues['hamburger_size']; ?>
+                        <p>
+                            <label><?php esc_html_e( 'Taille du bouton', 'sidebar-jlg' ); ?></label>
+                            <div
+                                class="sidebar-jlg-unit-control"
+                                data-sidebar-unit-control
+                                data-setting-name="sidebar_jlg_settings[hamburger_size]"
+                                data-label="<?php esc_attr_e( 'Taille du bouton', 'sidebar-jlg' ); ?>"
+                                data-help="<?php esc_attr_e( 'Largeur et hauteur du bouton hamburger.', 'sidebar-jlg' ); ?>"
+                                data-error-message="<?php esc_attr_e( 'La taille du bouton ne peut pas être vide.', 'sidebar-jlg' ); ?>"
+                                data-default-value="<?php echo esc_attr( $defaults['hamburger_size']['value'] ?? '50' ); ?>"
+                                data-default-unit="<?php echo esc_attr( $defaults['hamburger_size']['unit'] ?? 'px' ); ?>"
+                                data-allowed-units="<?php echo esc_attr( wp_json_encode( $dimensionUnits['hamburger_size'] ) ); ?>"
+                            >
+                                <input type="hidden" data-dimension-value name="sidebar_jlg_settings[hamburger_size][value]" value="<?php echo esc_attr( $hamburgerSize['value'] ); ?>" />
+                                <input type="hidden" data-dimension-unit name="sidebar_jlg_settings[hamburger_size][unit]" value="<?php echo esc_attr( $hamburgerSize['unit'] ); ?>" />
+                            </div>
+                            <em class="description"><?php esc_html_e( 'Ex: 50px, 3.5rem.', 'sidebar-jlg' ); ?></em>
                         </p>
                         <p><label><?php esc_html_e( 'Couleur des barres', 'sidebar-jlg' ); ?></label> <input type="text" name="sidebar_jlg_settings[hamburger_color]" value="<?php echo esc_attr( $options['hamburger_color'] ); ?>" class="color-picker-rgba"/> <em class="description"><?php esc_html_e( 'Utilisez une couleur contrastée pour les barres du bouton.', 'sidebar-jlg' ); ?></em></p>
                         <p><label><input type="checkbox" name="sidebar_jlg_settings[show_close_button]" value="1" <?php checked( $options['show_close_button'], 1 ); ?> /> <?php esc_html_e( 'Afficher le bouton de fermeture (X) dans la sidebar.', 'sidebar-jlg' ); ?></label></p>

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -16,6 +16,8 @@ class SettingsSanitizer
         'border_radius' => ['px', 'rem', 'em', '%'],
         'content_margin' => ['px', 'rem', 'em', '%'],
         'hamburger_top_position' => ['px', 'rem', 'em', 'vh', 'vw'],
+        'hamburger_horizontal_offset' => ['px', 'rem', 'em', '%', 'vw'],
+        'hamburger_size' => ['px', 'rem', 'em', 'vw'],
         'header_padding_top' => ['px', 'rem', 'em', '%'],
         'letter_spacing' => ['px', 'rem', 'em'],
     ];
@@ -274,6 +276,18 @@ class SettingsSanitizer
         $sanitized['hamburger_top_position'] = $this->sanitizeDimension(
             $input,
             'hamburger_top_position',
+            $existingOptions,
+            $defaults
+        );
+        $sanitized['hamburger_horizontal_offset'] = $this->sanitizeDimension(
+            $input,
+            'hamburger_horizontal_offset',
+            $existingOptions,
+            $defaults
+        );
+        $sanitized['hamburger_size'] = $this->sanitizeDimension(
+            $input,
+            'hamburger_size',
             $existingOptions,
             $defaults
         );

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -34,6 +34,8 @@ class SidebarRenderer
         'header_alignment_mobile' => 'center',
         'header_logo_size' => 150,
         'hamburger_top_position' => '4rem',
+        'hamburger_horizontal_offset' => '15px',
+        'hamburger_size' => '50px',
         'hamburger_color' => 'rgba(255, 255, 255, 1)',
         'content_margin' => '2rem',
         'floating_vertical_margin' => '4rem',
@@ -224,6 +226,8 @@ class SidebarRenderer
         $this->assignVariable($variables, '--header-alignment-mobile', $this->sanitizeCssString($this->resolveOption($options, 'header_alignment_mobile')));
         $this->assignVariable($variables, '--header-logo-size', $this->formatPixelValue($this->resolveOption($options, 'header_logo_size')));
         $this->assignVariable($variables, '--hamburger-top-position', $this->sanitizeCssString($this->resolveOption($options, 'hamburger_top_position')));
+        $this->assignVariable($variables, '--hamburger-inline-offset', $this->sanitizeCssString($this->resolveOption($options, 'hamburger_horizontal_offset')));
+        $this->assignVariable($variables, '--hamburger-size', $this->sanitizeCssString($this->resolveOption($options, 'hamburger_size')));
 
         $hamburgerColor = $this->sanitizeCssString($options['hamburger_color'] ?? null);
         if ($hamburgerColor === null) {

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -36,8 +36,10 @@ class DefaultSettings
             'show_close_button' => true,
             // Automatically close the sidebar after clicking menu or social links.
             'close_on_link_click' => false,
-            'hamburger_top_position' => ['value' => '4', 'unit' => 'rem'],
-            'hamburger_color'      => 'rgba(255, 255, 255, 1)',
+            'hamburger_top_position'     => ['value' => '4', 'unit' => 'rem'],
+            'hamburger_horizontal_offset'=> ['value' => '15', 'unit' => 'px'],
+            'hamburger_size'             => ['value' => '50', 'unit' => 'px'],
+            'hamburger_color'            => 'rgba(255, 255, 255, 1)',
             'header_logo_type'  => 'text',
             'header_logo_image' => '',
             'header_logo_size'  => 150,

--- a/sidebar-jlg/src/Settings/SettingsRepository.php
+++ b/sidebar-jlg/src/Settings/SettingsRepository.php
@@ -14,6 +14,8 @@ class SettingsRepository
         'floating_vertical_margin',
         'border_radius',
         'hamburger_top_position',
+        'hamburger_horizontal_offset',
+        'hamburger_size',
         'header_padding_top',
         'horizontal_bar_height',
         'letter_spacing',

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -74,6 +74,47 @@ assertSame('#abcdef', $result_valid['overlay_color'] ?? '', 'Overlay color accep
 assertSame(0.4, $result_valid['overlay_opacity'] ?? null, 'Overlay opacity falls back to existing value when missing');
 assertSame('#eeccdd', $result_valid['border_color'] ?? '', 'Border color accepts valid hex values without modification');
 
+$hamburger_dimensions_input = [
+    'hamburger_horizontal_offset' => ['value' => '2.5', 'unit' => 'rem'],
+    'hamburger_size' => ['value' => '3.75', 'unit' => 'rem'],
+];
+
+$hamburger_dimensions_result = $method->invoke($sanitizer, $hamburger_dimensions_input, $defaults->all());
+
+assertSame(
+    '2.5rem',
+    ValueNormalizer::dimensionToCss($hamburger_dimensions_result['hamburger_horizontal_offset'] ?? null, ''),
+    'Hamburger horizontal offset accepts valid dimension values'
+);
+assertSame(
+    '3.75rem',
+    ValueNormalizer::dimensionToCss($hamburger_dimensions_result['hamburger_size'] ?? null, ''),
+    'Hamburger size accepts valid dimension values'
+);
+
+$existing_hamburger_dimensions = array_merge($defaults->all(), [
+    'hamburger_horizontal_offset' => ['value' => '20', 'unit' => 'px'],
+    'hamburger_size' => ['value' => '60', 'unit' => 'px'],
+]);
+
+$hamburger_dimensions_invalid = [
+    'hamburger_horizontal_offset' => ['value' => 'invalid', 'unit' => 'vh'],
+    'hamburger_size' => ['value' => '', 'unit' => 'rem'],
+];
+
+$hamburger_dimensions_invalid_result = $method->invoke($sanitizer, $hamburger_dimensions_invalid, $existing_hamburger_dimensions);
+
+assertSame(
+    ValueNormalizer::dimensionToCss($existing_hamburger_dimensions['hamburger_horizontal_offset'], ''),
+    ValueNormalizer::dimensionToCss($hamburger_dimensions_invalid_result['hamburger_horizontal_offset'] ?? null, ''),
+    'Hamburger horizontal offset falls back to existing value when input is invalid'
+);
+assertSame(
+    ValueNormalizer::dimensionToCss($existing_hamburger_dimensions['hamburger_size'], ''),
+    ValueNormalizer::dimensionToCss($hamburger_dimensions_invalid_result['hamburger_size'] ?? null, ''),
+    'Hamburger size falls back to existing value when input is invalid'
+);
+
 $input_close_on_click = [
     'close_on_link_click' => '1',
 ];


### PR DESCRIPTION
## Summary
- add horizontal offset and size defaults for the hamburger button and normalize them through the sanitizer and repository
- expose new controls in the general settings tab and update the preview script/CSS to reflect the configured values
- generate front-end CSS variables for the new settings and consume them in the public styles

## Testing
- php tests/sanitize_general_settings_test.php

------
https://chatgpt.com/codex/tasks/task_e_68def9bf509c832e8226f4ac0e703fe2