### PR TITLE
Ensure sidebar cache keys include profile context

### DIFF
--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -503,27 +503,31 @@ class SidebarRenderer
     {
         $profile = $this->profileSelector->selectProfile();
         $options = $profile['settings'];
+        $profileId = isset($profile['id']) && is_string($profile['id']) && $profile['id'] !== ''
+            ? $profile['id']
+            : 'default';
         if (empty($options['enable_sidebar'])) {
             return;
         }
 
         $currentLocale = $this->cache->getLocaleForCache();
-        $transientKey = $this->cache->getTransientKey($currentLocale);
+        $transientKey = $this->cache->getTransientKey($currentLocale, $profileId);
 
         $cacheEnabled = (bool) \apply_filters(
             'sidebar_jlg_cache_enabled',
             !$this->is_sidebar_output_dynamic($options),
             $options,
             $currentLocale,
-            $transientKey
+            $transientKey,
+            $profileId
         );
 
         $html = false;
 
         if ($cacheEnabled) {
-            $html = $this->cache->get($currentLocale);
+            $html = $this->cache->get($currentLocale, $profileId);
         } else {
-            $this->cache->delete($currentLocale);
+            $this->cache->delete($currentLocale, $profileId);
             $this->cache->forgetLocaleIndex();
         }
 
@@ -562,7 +566,7 @@ class SidebarRenderer
             }
 
             if ($cacheEnabled) {
-                $this->cache->set($currentLocale, $html);
+                $this->cache->set($currentLocale, $html, $profileId);
             }
         }
 

--- a/tests/ajax_endpoints_test.php
+++ b/tests/ajax_endpoints_test.php
@@ -539,32 +539,37 @@ assertSame("Termé alert('x')", $GLOBALS['test_get_categories_requests'][0]['sea
 reset_test_environment();
 $GLOBALS['test_current_user_can'] = false;
 $GLOBALS['wp_test_options'] = ['sidebar_jlg_settings' => ['should' => 'stay']];
-$GLOBALS['wp_test_transients'] = ['sidebar_jlg_full_html_default' => '<div>keep</div>'];
+$GLOBALS['wp_test_transients'] = ['sidebar_jlg_full_html_default_default' => '<div>keep</div>'];
 invoke_endpoint($endpoints, 'ajax_reset_settings');
 assertSame('Permission refusée.', $GLOBALS['json_error_payloads'][0] ?? null, 'Unauthorized reset request rejected');
 assertSame([], $GLOBALS['checked_nonces'], 'Nonce not validated when reset unauthorized');
 assertSame(['should' => 'stay'], get_option('sidebar_jlg_settings'), 'Unauthorized reset leaves settings untouched');
-assertSame('<div>keep</div>', get_transient('sidebar_jlg_full_html_default'), 'Unauthorized reset leaves caches untouched');
+assertSame('<div>keep</div>', get_transient('sidebar_jlg_full_html_default_default'), 'Unauthorized reset leaves caches untouched');
 
 reset_test_environment();
 $GLOBALS['wp_test_options'] = ['sidebar_jlg_settings' => ['should' => 'stay']];
-$GLOBALS['wp_test_transients'] = ['sidebar_jlg_full_html_default' => '<div>keep</div>'];
+$GLOBALS['wp_test_transients'] = ['sidebar_jlg_full_html_default_default' => '<div>keep</div>'];
 $GLOBALS['test_nonce_results']['jlg_reset_nonce'] = 'Nonce invalide.';
 $_POST = ['nonce' => 'bad'];
 invoke_endpoint($endpoints, 'ajax_reset_settings');
 assertSame('Nonce invalide.', $GLOBALS['json_error_payloads'][0] ?? null, 'Reset nonce failure returns error');
 assertSame(['jlg_reset_nonce', 'nonce', 'bad'], $GLOBALS['checked_nonces'][0] ?? null, 'Reset nonce validated before failure');
 assertSame(['should' => 'stay'], get_option('sidebar_jlg_settings'), 'Nonce failure leaves settings untouched');
-assertSame('<div>keep</div>', get_transient('sidebar_jlg_full_html_default'), 'Nonce failure leaves caches untouched');
+assertSame('<div>keep</div>', get_transient('sidebar_jlg_full_html_default_default'), 'Nonce failure leaves caches untouched');
 
 reset_test_environment();
 $GLOBALS['wp_test_options'] = [
     'sidebar_jlg_settings' => ['foo' => 'bar'],
-    'sidebar_jlg_cached_locales' => ['default', 'fr_FR'],
+    'sidebar_jlg_cached_locales' => [
+        'default',
+        ['locale' => 'default', 'suffix' => 'default'],
+        ['locale' => 'fr_FR', 'suffix' => 'default'],
+    ],
 ];
 $GLOBALS['wp_test_transients'] = [
-    'sidebar_jlg_full_html_default' => '<div>cached</div>',
-    'sidebar_jlg_full_html_fr_FR' => '<div>cached-fr</div>',
+    'sidebar_jlg_full_html_default' => '<div>legacy-default</div>',
+    'sidebar_jlg_full_html_default_default' => '<div>cached</div>',
+    'sidebar_jlg_full_html_fr_FR_default' => '<div>cached-fr</div>',
     'sidebar_jlg_full_html' => '<div>legacy</div>',
 ];
 $_POST = ['nonce' => 'reset-nonce'];
@@ -572,8 +577,9 @@ invoke_endpoint($endpoints, 'ajax_reset_settings');
 assertSame('Réglages réinitialisés.', $GLOBALS['json_success_payloads'][0] ?? null, 'Reset settings success message returned');
 assertSame('missing', get_option('sidebar_jlg_settings', 'missing'), 'Settings option deleted during reset');
 assertSame('missing', get_option('sidebar_jlg_cached_locales', 'missing'), 'Cached locales option deleted during reset');
-assertSame(false, get_transient('sidebar_jlg_full_html_default'), 'Default locale cache cleared during reset');
-assertSame(false, get_transient('sidebar_jlg_full_html_fr_FR'), 'Additional locale cache cleared during reset');
+assertSame(false, get_transient('sidebar_jlg_full_html_default'), 'Legacy default locale cache cleared during reset');
+assertSame(false, get_transient('sidebar_jlg_full_html_default_default'), 'Default locale profile cache cleared during reset');
+assertSame(false, get_transient('sidebar_jlg_full_html_fr_FR_default'), 'Additional locale cache cleared during reset');
 assertSame(false, get_transient('sidebar_jlg_full_html'), 'Legacy cache cleared during reset');
 assertSame(['jlg_reset_nonce', 'nonce', 'reset-nonce'], $GLOBALS['checked_nonces'][0] ?? null, 'Reset nonce validated before clearing settings');
 

--- a/tests/custom_icon_cache_invalidation_test.php
+++ b/tests/custom_icon_cache_invalidation_test.php
@@ -73,9 +73,12 @@ $GLOBALS['wp_test_function_overrides']['do_action'] = static function ($hook, ..
 require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
 
 $GLOBALS['wp_test_options']['sidebar_jlg_plugin_version'] = SIDEBAR_JLG_VERSION;
-$GLOBALS['wp_test_options']['sidebar_jlg_cached_locales'] = ['fr_FR', 'en_US'];
-$GLOBALS['wp_test_transients']['sidebar_jlg_full_html_fr_FR'] = '<div>FR</div>';
-$GLOBALS['wp_test_transients']['sidebar_jlg_full_html_en_US'] = '<div>EN</div>';
+$GLOBALS['wp_test_options']['sidebar_jlg_cached_locales'] = [
+    ['locale' => 'fr_FR', 'suffix' => 'default'],
+    ['locale' => 'en_US', 'suffix' => 'default'],
+];
+$GLOBALS['wp_test_transients']['sidebar_jlg_full_html_fr_FR_default'] = '<div>FR</div>';
+$GLOBALS['wp_test_transients']['sidebar_jlg_full_html_en_US_default'] = '<div>EN</div>';
 $GLOBALS['wp_test_options']['sidebar_jlg_custom_icon_index'] = [
     'custom-change.svg' => [
         'mtime' => 0,
@@ -90,11 +93,11 @@ $iconLibrary = $plugin->getIconLibrary();
 $iconLibrary->getAllIcons();
 
 assertTrue(
-    !isset($GLOBALS['wp_test_transients']['sidebar_jlg_full_html_fr_FR']),
+    !isset($GLOBALS['wp_test_transients']['sidebar_jlg_full_html_fr_FR_default']),
     'French sidebar cache cleared when custom icons change'
 );
 assertTrue(
-    !isset($GLOBALS['wp_test_transients']['sidebar_jlg_full_html_en_US']),
+    !isset($GLOBALS['wp_test_transients']['sidebar_jlg_full_html_en_US_default']),
     'English sidebar cache cleared when custom icons change'
 );
 assertTrue(

--- a/tests/sidebar_profile_cache_isolation_test.php
+++ b/tests/sidebar_profile_cache_isolation_test.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+
+use function JLG\Sidebar\plugin;
+
+require __DIR__ . '/bootstrap.php';
+
+if (!function_exists('get_post_type')) {
+    function get_post_type($post = null)
+    {
+        return $GLOBALS['test_post_type'] ?? null;
+    }
+}
+
+if (!function_exists('get_queried_object')) {
+    function get_queried_object()
+    {
+        return $GLOBALS['test_queried_object'] ?? null;
+    }
+}
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$plugin = plugin();
+$settingsRepository = $plugin->getSettingsRepository();
+$renderer = $plugin->getSidebarRenderer();
+$cache = $plugin->getMenuCache();
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+function assertContains(string $needle, string $haystack, string $message): void
+{
+    assertTrue(strpos($haystack, $needle) !== false, $message);
+}
+
+function assertNotContains(string $needle, string $haystack, string $message): void
+{
+    assertTrue(strpos($haystack, $needle) === false, $message);
+}
+
+function assertSame($expected, $actual, string $message): void
+{
+    assertTrue($expected === $actual, $message);
+}
+
+$baseSettings = $settingsRepository->getDefaultSettings();
+$baseSettings['enable_sidebar'] = true;
+$baseSettings['social_icons'] = [];
+$baseSettings['menu_items'] = [];
+$baseSettings['nav_aria_label'] = 'Default Profile Nav';
+$baseSettings['profiles'] = [
+    [
+        'id' => 'post-profile',
+        'priority' => 10,
+        'conditions' => [
+            'post_types' => ['post'],
+        ],
+        'settings' => [
+            'nav_aria_label' => 'Post Profile Nav',
+        ],
+    ],
+    [
+        'id' => 'page-profile',
+        'priority' => 10,
+        'conditions' => [
+            'post_types' => ['page'],
+        ],
+        'settings' => [
+            'nav_aria_label' => 'Page Profile Nav',
+        ],
+    ],
+];
+
+$settingsRepository->saveOptions($baseSettings);
+
+$cache->clear();
+$GLOBALS['wp_test_transients'] = [];
+switch_to_locale('en_US');
+
+$setPostContext = static function (string $postType): void {
+    $GLOBALS['test_post_type'] = $postType;
+    $GLOBALS['test_queried_object'] = (object) ['post_type' => $postType];
+};
+
+$setPostContext('post');
+ob_start();
+$renderer->render();
+$postProfileHtml = (string) ob_get_clean();
+
+assertContains('Post Profile Nav', $postProfileHtml, 'Post profile navigation label rendered');
+assertNotContains('Page Profile Nav', $postProfileHtml, 'Page profile label absent from post profile cache');
+assertTrue(
+    isset($GLOBALS['wp_test_transients']['sidebar_jlg_full_html_en_US_post-profile']),
+    'Post profile cache stored with profile suffix'
+);
+
+$setPostContext('page');
+ob_start();
+$renderer->render();
+$pageProfileHtml = (string) ob_get_clean();
+
+assertContains('Page Profile Nav', $pageProfileHtml, 'Page profile navigation label rendered');
+assertNotContains('Post Profile Nav', $pageProfileHtml, 'Page profile render does not reuse post profile cache');
+assertTrue(
+    isset($GLOBALS['wp_test_transients']['sidebar_jlg_full_html_en_US_page-profile']),
+    'Page profile cache stored under unique key'
+);
+assertTrue($pageProfileHtml !== $postProfileHtml, 'Page profile HTML differs from post profile HTML');
+
+$setPostContext('post');
+ob_start();
+$renderer->render();
+$secondPostHtml = (string) ob_get_clean();
+
+assertSame($postProfileHtml, $secondPostHtml, 'Post profile cache reused on subsequent render');
+assertTrue(
+    isset($GLOBALS['wp_test_transients']['sidebar_jlg_full_html_en_US_post-profile']),
+    'Post profile transient persists after reuse'
+);
+
+if ($testsPassed) {
+    echo "Sidebar profile cache isolation tests passed.\n";
+    exit(0);
+}
+
+echo "Sidebar profile cache isolation tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- extend the menu cache to accept optional profile suffixes for transient keys and stored indexes
- update the frontend renderer to pass the active profile identifier through all cache get/set/delete operations
- refresh cache-related tests and add a functional test that verifies profile-specific HTML is no longer reused across profiles

## Testing
- composer test
- php tests/sidebar_profile_cache_isolation_test.php
- php tests/sidebar_locale_cache_test.php
- php tests/custom_icon_cache_invalidation_test.php
- php tests/ajax_endpoints_test.php

------
https://chatgpt.com/codex/tasks/task_e_68dfc1a7020c832ea583aec93ea4d82f