### PR TITLE
Scope touch-action rules to JS-enhanced sidebar state

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -32,7 +32,7 @@ body.sidebar-scroll-lock {
     overflow: hidden;
 }
 .sidebar-overlay,
-body.sidebar-open .pro-sidebar {
+body.sidebar-js-enhanced.sidebar-open .pro-sidebar {
     touch-action: pan-y;
 }
 body.jlg-sidebar-active.jlg-sidebar-horizontal-bar { padding-inline-start: 0 !important; }
@@ -883,8 +883,8 @@ body.sidebar-js-enhanced .sidebar-menu .submenu.is-open {
     .social-icons a:hover,
     .social-icons a:focus,
     .social-icons a:focus-visible,
-    body.sidebar-open .pro-sidebar,
-    body.jlg-sidebar-horizontal-bar.sidebar-open .pro-sidebar {
+    body.sidebar-js-enhanced.sidebar-open .pro-sidebar,
+    body.sidebar-js-enhanced.jlg-sidebar-horizontal-bar.sidebar-open .pro-sidebar {
         transform: none !important;
     }
 


### PR DESCRIPTION
## Summary
- scope the sidebar touch-action styles to the JS-enhanced open state
- keep reduced-motion transform overrides aligned with the JS-enhanced sidebar selector

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfccacdb84832eb6fd4905cc3a64f6