### PR TITLE
Skip disabled profiles during selection

### DIFF
--- a/sidebar-jlg/src/Frontend/ProfileSelector.php
+++ b/sidebar-jlg/src/Frontend/ProfileSelector.php
@@ -46,6 +46,10 @@ class ProfileSelector
                 continue;
             }
 
+            if ($this->isProfileDisabled($profile)) {
+                continue;
+            }
+
             $normalized = $this->normalizeProfile($profile, $defaultOptions);
             if ($normalized === null) {
                 continue;

--- a/tests/profile_selector_disabled_profile_test.php
+++ b/tests/profile_selector_disabled_profile_test.php
@@ -39,52 +39,77 @@ $settingsRepository = $plugin->getSettingsRepository();
 
 $baseSettings = $settingsRepository->getDefaultSettings();
 $baseSettings['enable_sidebar'] = true;
-$baseSettings['profiles'] = [
-    [
-        'id' => 'disabled-profile',
-        'is_enabled' => '0',
-        'priority' => 50,
-        'conditions' => [
-            'post_types' => ['post'],
-        ],
-        'settings' => [
-            'animation_type' => 'fade',
-        ],
-    ],
-    [
-        'id' => 'active-profile',
-        'priority' => 10,
-        'conditions' => [
-            'post_types' => ['post'],
-        ],
-        'settings' => [
-            'animation_type' => 'slide-right',
-        ],
-    ],
-];
-
-$settingsRepository->saveOptions($baseSettings);
 
 $GLOBALS['test_post_type'] = 'post';
 $GLOBALS['test_queried_object'] = (object) ['post_type' => 'post'];
 $GLOBALS['test_current_user'] = (object) ['roles' => ['editor']];
 
-$selector = new ProfileSelector($settingsRepository);
-$selection = $selector->selectProfile();
+$disabledFlagVariants = [
+    ['label' => 'enabled empty string', 'flags' => ['enabled' => '']],
+    ['label' => 'enabled zero', 'flags' => ['enabled' => '0']],
+    ['label' => 'enabled false', 'flags' => ['enabled' => false]],
+    ['label' => 'is_enabled zero', 'flags' => ['is_enabled' => '0']],
+    ['label' => 'is_enabled false', 'flags' => ['is_enabled' => false]],
+    ['label' => 'active zero', 'flags' => ['active' => '0']],
+    ['label' => 'active no', 'flags' => ['active' => 'no']],
+    ['label' => 'is_active zero', 'flags' => ['is_active' => '0']],
+    ['label' => 'is_active false', 'flags' => ['is_active' => false]],
+    ['label' => 'disabled true', 'flags' => ['disabled' => true]],
+    ['label' => 'disabled truthy string', 'flags' => ['disabled' => 'yes']],
+    ['label' => 'is_disabled true', 'flags' => ['is_disabled' => true]],
+    ['label' => 'is_disabled numeric string', 'flags' => ['is_disabled' => '1']],
+];
 
-if (($selection['id'] ?? '') !== 'active-profile') {
-    echo 'Disabled profile should not be selected even with higher priority.' . "\n";
-    exit(1);
+$disabledProfileTemplate = [
+    'id' => 'disabled-profile',
+    'priority' => 50,
+    'conditions' => [
+        'post_types' => ['post'],
+    ],
+    'settings' => [
+        'animation_type' => 'fade',
+    ],
+];
+
+$activeProfile = [
+    'id' => 'active-profile',
+    'priority' => 10,
+    'conditions' => [
+        'post_types' => ['post'],
+    ],
+    'settings' => [
+        'animation_type' => 'slide-right',
+    ],
+];
+
+foreach ($disabledFlagVariants as $variant) {
+    $settings = $baseSettings;
+    $settings['profiles'] = [
+        array_merge($disabledProfileTemplate, $variant['flags']),
+        $activeProfile,
+    ];
+
+    $settingsRepository->saveOptions($settings);
+
+    $selector = new ProfileSelector($settingsRepository);
+    $selection = $selector->selectProfile();
+
+    if (($selection['id'] ?? '') !== 'active-profile') {
+        echo 'Disabled profile should not be selected when ' . $variant['label'] . " flag is present.\n";
+        exit(1);
+    }
+
+    if (($selection['is_fallback'] ?? null) !== false) {
+        echo 'Active profile should not be treated as fallback when ' . $variant['label'] . " flag is present.\n";
+        exit(1);
+    }
+
+    if (($selection['settings']['animation_type'] ?? '') !== 'slide-right') {
+        echo 'Active profile settings should be applied when ' . $variant['label'] . " flag is present.\n";
+        exit(1);
+    }
 }
 
-if (($selection['is_fallback'] ?? null) !== false) {
-    echo 'Active profile should not be treated as fallback.' . "\n";
-    exit(1);
-}
-
-if (($selection['settings']['animation_type'] ?? '') !== 'slide-right') {
-    echo 'Active profile settings should be applied when disabled profile is ignored.' . "\n";
-    exit(1);
-}
+$settingsRepository->deleteOptions();
 
 exit(0);


### PR DESCRIPTION
## Summary
- skip disabled profiles before normalization so they are ignored without evaluating priority or settings
- expand the disabled profile selector test to cover multiple flag variants and ensure active settings prevail

## Testing
- composer test
- php tests/profile_selector_disabled_profile_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e0ee8eb934832e9459dbe10c361444