### PR TITLE
Refine sidebar body hooks to use active profile settings

### DIFF
--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -97,8 +97,9 @@ class SidebarRenderer
 
     public function enqueueAssets(): void
     {
-        $profile = $this->getActiveProfile();
-        $options = isset($profile['settings']) && is_array($profile['settings']) ? $profile['settings'] : [];
+        $activeProfile = $this->getActiveProfileData();
+        $profile = $activeProfile['profile'];
+        $options = $activeProfile['settings'];
         if (empty($options['enable_sidebar'])) {
             return;
         }
@@ -501,8 +502,9 @@ class SidebarRenderer
 
     public function render(): void
     {
-        $profile = $this->getActiveProfile();
-        $options = isset($profile['settings']) && is_array($profile['settings']) ? $profile['settings'] : [];
+        $activeProfile = $this->getActiveProfileData();
+        $profile = $activeProfile['profile'];
+        $options = $activeProfile['settings'];
         $profileId = isset($profile['id']) && is_string($profile['id']) && $profile['id'] !== ''
             ? $profile['id']
             : 'default';
@@ -1336,10 +1338,26 @@ class SidebarRenderer
         return $this->profileSelector->selectProfile();
     }
 
-    private function resolveActiveSidebarState(): ?array
+    private function getActiveProfileData(): array
     {
         $profile = $this->getActiveProfile();
-        $settings = isset($profile['settings']) && is_array($profile['settings']) ? $profile['settings'] : [];
+        $settings = [];
+
+        if (isset($profile['settings']) && is_array($profile['settings'])) {
+            $settings = $profile['settings'];
+        }
+
+        return [
+            'profile' => $profile,
+            'settings' => $settings,
+        ];
+    }
+
+    private function resolveActiveSidebarState(): ?array
+    {
+        $activeProfile = $this->getActiveProfileData();
+        $profile = $activeProfile['profile'];
+        $settings = $activeProfile['settings'];
 
         if (empty($settings['enable_sidebar'])) {
             return null;

--- a/tests/sidebar_profile_hooks_test.php
+++ b/tests/sidebar_profile_hooks_test.php
@@ -129,6 +129,17 @@ $bodyOpenOutput = (string) ob_get_clean();
 
 assertContains('document.body.dataset.sidebarPosition', $bodyOpenOutput, 'Body data script sets sidebar position dataset');
 assertContains('data-sidebar-position', $bodyOpenOutput, 'Body data script sets data-sidebar-position attribute');
+assertContains('"right"', $bodyOpenOutput, 'Body data script encodes active sidebar position');
+
+ob_start();
+foreach ($bodyOpenCallbacks as $callback) {
+    if (is_callable($callback)) {
+        $callback();
+    }
+}
+$secondBodyOpenOutput = (string) ob_get_clean();
+
+assertTrue($secondBodyOpenOutput === '', 'Body data script only printed once');
 
 if ($testsPassed) {
     echo "Sidebar profile hooks tests passed.\n";


### PR DESCRIPTION
## Summary
- add a helper to expose the selected profile alongside its settings for reuse
- reuse the active profile settings in render hooks to keep body classes and data script in sync
- extend the sidebar profile hooks test to assert classes, data attributes, and single script output when a conditional profile is active

## Testing
- ./vendor/bin/phpunit tests/sidebar_profile_hooks_test.php
- php tests/render_sidebar_active_state_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e148e7dc04832ebf48f9359ca189c8