### PR TITLE
Add contextual filters to profile selection

### DIFF
--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -815,6 +815,31 @@ $textTransformLabels = [
                                     <label for="sidebar-jlg-profile-languages"><?php esc_html_e( 'Langues', 'sidebar-jlg' ); ?></label>
                                     <select id="sidebar-jlg-profile-languages" multiple></select>
                                 </p>
+                                <p>
+                                    <label for="sidebar-jlg-profile-devices"><?php esc_html_e( 'Appareils ciblés', 'sidebar-jlg' ); ?></label>
+                                    <select id="sidebar-jlg-profile-devices" multiple></select>
+                                    <span class="description"><?php esc_html_e( 'Laisser vide pour tous les appareils.', 'sidebar-jlg' ); ?></span>
+                                </p>
+                                <p>
+                                    <label for="sidebar-jlg-profile-login-state"><?php esc_html_e( 'Statut de connexion', 'sidebar-jlg' ); ?></label>
+                                    <select id="sidebar-jlg-profile-login-state"></select>
+                                </p>
+                                <fieldset class="sidebar-jlg-profile-schedule">
+                                    <legend><?php esc_html_e( 'Créneau horaire (heure locale)', 'sidebar-jlg' ); ?></legend>
+                                    <p class="description"><?php esc_html_e( 'Limitez l’affichage du profil à certaines heures ou journées.', 'sidebar-jlg' ); ?></p>
+                                    <div class="sidebar-jlg-profile-schedule__row">
+                                        <label for="sidebar-jlg-profile-schedule-start"><?php esc_html_e( 'Début', 'sidebar-jlg' ); ?></label>
+                                        <input type="time" id="sidebar-jlg-profile-schedule-start" />
+                                    </div>
+                                    <div class="sidebar-jlg-profile-schedule__row">
+                                        <label for="sidebar-jlg-profile-schedule-end"><?php esc_html_e( 'Fin', 'sidebar-jlg' ); ?></label>
+                                        <input type="time" id="sidebar-jlg-profile-schedule-end" />
+                                    </div>
+                                    <p>
+                                        <label for="sidebar-jlg-profile-schedule-days"><?php esc_html_e( 'Jours concernés', 'sidebar-jlg' ); ?></label>
+                                        <select id="sidebar-jlg-profile-schedule-days" multiple></select>
+                                    </p>
+                                </fieldset>
                             </fieldset>
                             <div class="sidebar-jlg-profile-editor__fieldset">
                                 <h3><?php esc_html_e( 'Réglages associés', 'sidebar-jlg' ); ?></h3>

--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -132,6 +132,9 @@ class MenuPage
             'taxonomies' => $this->getProfileTaxonomyChoices(),
             'roles' => $this->getProfileRoleChoices(),
             'languages' => $this->getProfileLanguageChoices(),
+            'devices' => $this->getProfileDeviceChoices(),
+            'login_states' => $this->getProfileLoginStateChoices(),
+            'schedule_days' => $this->getProfileScheduleDayChoices(),
         ];
 
         wp_localize_script('sidebar-jlg-admin-js', 'sidebarJLG', [
@@ -417,5 +420,44 @@ class MenuPage
         }
 
         return array_values($choices);
+    }
+
+    /**
+     * @return array<int, array{value: string, label: string}>
+     */
+    private function getProfileDeviceChoices(): array
+    {
+        return [
+            ['value' => 'desktop', 'label' => __('Ordinateur (bureau)', 'sidebar-jlg')],
+            ['value' => 'mobile', 'label' => __('Mobile', 'sidebar-jlg')],
+        ];
+    }
+
+    /**
+     * @return array<int, array{value: string, label: string}>
+     */
+    private function getProfileLoginStateChoices(): array
+    {
+        return [
+            ['value' => 'any', 'label' => __('Tous les visiteurs', 'sidebar-jlg')],
+            ['value' => 'logged-in', 'label' => __('Utilisateurs connectés', 'sidebar-jlg')],
+            ['value' => 'logged-out', 'label' => __('Visiteurs non connectés', 'sidebar-jlg')],
+        ];
+    }
+
+    /**
+     * @return array<int, array{value: string, label: string}>
+     */
+    private function getProfileScheduleDayChoices(): array
+    {
+        return [
+            ['value' => 'mon', 'label' => __('Lundi', 'sidebar-jlg')],
+            ['value' => 'tue', 'label' => __('Mardi', 'sidebar-jlg')],
+            ['value' => 'wed', 'label' => __('Mercredi', 'sidebar-jlg')],
+            ['value' => 'thu', 'label' => __('Jeudi', 'sidebar-jlg')],
+            ['value' => 'fri', 'label' => __('Vendredi', 'sidebar-jlg')],
+            ['value' => 'sat', 'label' => __('Samedi', 'sidebar-jlg')],
+            ['value' => 'sun', 'label' => __('Dimanche', 'sidebar-jlg')],
+        ];
     }
 }

--- a/tests/profile_selector_context_filters_test.php
+++ b/tests/profile_selector_context_filters_test.php
@@ -1,0 +1,159 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Frontend\ProfileSelector;
+use function JLG\Sidebar\plugin;
+
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+if (!function_exists('get_post_type')) {
+    function get_post_type($post = null)
+    {
+        return $GLOBALS['test_post_type'] ?? null;
+    }
+}
+
+if (!function_exists('get_queried_object')) {
+    function get_queried_object()
+    {
+        return $GLOBALS['test_queried_object'] ?? null;
+    }
+}
+
+if (!function_exists('wp_get_current_user')) {
+    function wp_get_current_user()
+    {
+        return $GLOBALS['test_current_user'] ?? (object) ['roles' => []];
+    }
+}
+
+if (!function_exists('wp_is_mobile')) {
+    function wp_is_mobile()
+    {
+        return $GLOBALS['test_is_mobile'] ?? false;
+    }
+}
+
+if (!function_exists('is_user_logged_in')) {
+    function is_user_logged_in()
+    {
+        return $GLOBALS['test_is_logged_in'] ?? false;
+    }
+}
+
+if (!function_exists('current_time')) {
+    function current_time($type = 'timestamp')
+    {
+        $timestamp = $GLOBALS['test_current_time'] ?? time();
+
+        if ($type === 'timestamp') {
+            return $timestamp;
+        }
+
+        return date($type, $timestamp);
+    }
+}
+
+$plugin = plugin();
+$settingsRepository = $plugin->getSettingsRepository();
+
+$baseSettings = $settingsRepository->getDefaultSettings();
+$baseSettings['enable_sidebar'] = true;
+
+$GLOBALS['test_post_type'] = 'post';
+$GLOBALS['test_queried_object'] = (object) ['post_type' => 'post'];
+$GLOBALS['test_current_user'] = (object) ['roles' => ['editor']];
+$GLOBALS['test_is_mobile'] = false;
+$GLOBALS['test_is_logged_in'] = false;
+$GLOBALS['test_current_time'] = strtotime('2024-04-08 10:00:00'); // Monday 10:00
+
+$profiles = [
+    [
+        'id' => 'mobile-only',
+        'priority' => 30,
+        'conditions' => [
+            'post_types' => ['post'],
+            'devices' => ['mobile'],
+        ],
+        'settings' => [
+            'animation_type' => 'fade',
+        ],
+    ],
+    [
+        'id' => 'logged-in-only',
+        'priority' => 40,
+        'conditions' => [
+            'post_types' => ['post'],
+            'logged_in' => true,
+        ],
+        'settings' => [
+            'animation_type' => 'slide-left',
+        ],
+    ],
+    [
+        'id' => 'friday-evening',
+        'priority' => 50,
+        'conditions' => [
+            'post_types' => ['post'],
+            'schedule' => [
+                'start' => '21:00',
+                'end' => '23:59',
+                'days' => ['fri'],
+            ],
+        ],
+        'settings' => [
+            'animation_type' => 'zoom-in',
+        ],
+    ],
+];
+
+$settings = $baseSettings;
+$settings['profiles'] = $profiles;
+$settingsRepository->saveOptions($settings);
+
+$selector = new ProfileSelector($settingsRepository);
+
+$selection = $selector->selectProfile();
+if (($selection['is_fallback'] ?? null) !== true || ($selection['id'] ?? '') !== 'default') {
+    echo "Default profile should be selected when no contextual filter matches.\n";
+    exit(1);
+}
+
+$GLOBALS['test_is_mobile'] = true;
+$selection = $selector->selectProfile();
+if (($selection['id'] ?? '') !== 'mobile-only') {
+    echo "Mobile-specific profile was not selected when device matched.\n";
+    exit(1);
+}
+if (($selection['is_fallback'] ?? null) !== false) {
+    echo "Mobile profile should not be marked as fallback.\n";
+    exit(1);
+}
+
+$GLOBALS['test_is_mobile'] = false;
+$GLOBALS['test_is_logged_in'] = true;
+$selection = $selector->selectProfile();
+if (($selection['id'] ?? '') !== 'logged-in-only') {
+    echo "Logged-in profile was not selected for authenticated users.\n";
+    exit(1);
+}
+
+$GLOBALS['test_is_logged_in'] = false;
+$GLOBALS['test_current_time'] = strtotime('2024-04-12 22:30:00'); // Friday 22:30
+$selection = $selector->selectProfile();
+if (($selection['id'] ?? '') !== 'friday-evening') {
+    echo "Schedule-based profile was not selected during allowed window.\n";
+    exit(1);
+}
+
+$GLOBALS['test_current_time'] = strtotime('2024-04-12 20:00:00');
+$selection = $selector->selectProfile();
+if (($selection['id'] ?? '') === 'friday-evening') {
+    echo "Schedule-based profile should not apply outside the configured time range.\n";
+    exit(1);
+}
+
+$settingsRepository->deleteOptions();
+
+echo "";

--- a/tests/sanitize_profiles_test.php
+++ b/tests/sanitize_profiles_test.php
@@ -20,6 +20,13 @@ $GLOBALS['wp_test_options']['sidebar_jlg_profiles'] = [
         'conditions' => [
             'roles' => ['editor'],
             'languages' => ['en_US'],
+            'devices' => ['desktop'],
+            'logged_in' => 'logged-out',
+            'schedule' => [
+                'start' => '10:00',
+                'end' => '16:00',
+                'days' => ['wed'],
+            ],
         ],
         'settings' => [
             'layout_style' => 'floating',
@@ -38,6 +45,13 @@ $profiles = [
             'taxonomies' => ['category', 'invalid'],
             'roles' => ['administrator', 'ghost'],
             'languages' => ['fr_FR', 'xx_YY'],
+            'devices' => ['mobile', 'desktop', 'tablet'],
+            'logged_in' => 'logged-in',
+            'schedule' => [
+                'start' => '08:30',
+                'end' => '18:00',
+                'days' => ['mon', 'fri', 'holiday'],
+            ],
         ],
         'settings' => [
             'layout_style' => 'floating',
@@ -93,6 +107,23 @@ if (($primaryConditions['languages'] ?? []) !== ['fr_FR']) {
     echo 'Primary languages were not sanitized as expected.' . "\n";
     exit(1);
 }
+if (($primaryConditions['devices'] ?? []) !== ['mobile', 'desktop']) {
+    echo 'Primary devices were not sanitized as expected.' . "\n";
+    exit(1);
+}
+if (($primaryConditions['logged_in'] ?? '') !== 'logged-in') {
+    echo 'Primary logged_in condition was not sanitized as expected.' . "\n";
+    exit(1);
+}
+$primarySchedule = $primaryConditions['schedule'] ?? [];
+if (($primarySchedule['start'] ?? '') !== '08:30' || ($primarySchedule['end'] ?? '') !== '18:00') {
+    echo 'Primary schedule times were not sanitized as expected.' . "\n";
+    exit(1);
+}
+if (($primarySchedule['days'] ?? []) !== ['mon', 'fri']) {
+    echo 'Primary schedule days were not sanitized as expected.' . "\n";
+    exit(1);
+}
 
 $primarySettings = $primary['settings'] ?? [];
 if (($primarySettings['layout_style'] ?? '') !== 'floating') {
@@ -120,6 +151,23 @@ if (($secondaryConditions['roles'] ?? []) !== ['editor']) {
 }
 if (($secondaryConditions['languages'] ?? []) !== ['en_US']) {
     echo 'Secondary languages should fall back to stored values.' . "\n";
+    exit(1);
+}
+if (($secondaryConditions['devices'] ?? []) !== ['desktop']) {
+    echo 'Secondary devices should fall back to stored values.' . "\n";
+    exit(1);
+}
+if (($secondaryConditions['logged_in'] ?? '') !== 'logged-out') {
+    echo 'Secondary logged_in should fall back to stored values.' . "\n";
+    exit(1);
+}
+$secondarySchedule = $secondaryConditions['schedule'] ?? [];
+if (($secondarySchedule['start'] ?? '') !== '10:00' || ($secondarySchedule['end'] ?? '') !== '16:00') {
+    echo 'Secondary schedule times should fall back to stored values.' . "\n";
+    exit(1);
+}
+if (($secondarySchedule['days'] ?? []) !== ['wed']) {
+    echo 'Secondary schedule days should fall back to stored values.' . "\n";
     exit(1);
 }
 


### PR DESCRIPTION
## Summary
- extend the profile selector to normalize and evaluate device, login state, and schedule constraints using richer request context data
- expose new filtering controls in the admin UI and sanitize the associated profile conditions when saving
- add automated coverage for the new sanitizer paths and runtime matching behaviour

## Testing
- php tests/sanitize_profiles_test.php
- php tests/profile_selector_context_filters_test.php
- php tests/profile_selector_disabled_profile_test.php
- php tests/profile_selector_integration_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e24e0abda8832e8cb6c8821ca40869