### PR TITLE
Align profile condition serialization with stored content types

### DIFF
--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -2341,8 +2341,12 @@ jQuery(document).ready(function($) {
     function normalizeProfileConditions(rawConditions) {
         const conditions = rawConditions && typeof rawConditions === 'object' ? rawConditions : {};
 
+        const postTypes = Array.isArray(conditions.post_types)
+            ? conditions.post_types
+            : (Array.isArray(conditions.content_types) ? conditions.content_types : []);
+
         return {
-            post_types: normalizeStringArray(conditions.post_types),
+            post_types: normalizeStringArray(postTypes),
             roles: normalizeStringArray(conditions.roles),
             languages: normalizeLanguageArray(conditions.languages),
             taxonomies: normalizeTaxonomyCollection(conditions.taxonomies),
@@ -2446,19 +2450,31 @@ jQuery(document).ready(function($) {
 
         const normalized = [];
         rawTaxonomies.forEach((entry) => {
-            if (!entry || typeof entry !== 'object') {
+            if (!entry) {
                 return;
             }
 
-            const taxonomy = sanitizeProfileSlug(entry.taxonomy || entry.name || '');
-            if (!taxonomy) {
+            if (typeof entry === 'string' || typeof entry === 'number') {
+                const taxonomy = sanitizeProfileSlug(String(entry));
+                if (!taxonomy) {
+                    return;
+                }
+
+                normalized.push({ taxonomy, terms: [] });
                 return;
             }
 
-            normalized.push({
-                taxonomy,
-                terms: normalizeTaxonomyTerms(entry.terms),
-            });
+            if (typeof entry === 'object') {
+                const taxonomy = sanitizeProfileSlug(entry.taxonomy || entry.name || '');
+                if (!taxonomy) {
+                    return;
+                }
+
+                normalized.push({
+                    taxonomy,
+                    terms: normalizeTaxonomyTerms(entry.terms),
+                });
+            }
         });
 
         return normalized;
@@ -3183,6 +3199,7 @@ jQuery(document).ready(function($) {
             appendHiddenField(`${base}[enabled]`, profile.enabled ? '1' : '0');
 
             appendArrayFields(`${base}[conditions][post_types]`, profile.conditions.post_types);
+            appendArrayFields(`${base}[conditions][content_types]`, profile.conditions.post_types);
             appendTaxonomyFields(`${base}[conditions][taxonomies]`, profile.conditions.taxonomies);
             appendArrayFields(`${base}[conditions][roles]`, profile.conditions.roles);
             appendArrayFields(`${base}[conditions][languages]`, profile.conditions.languages);


### PR DESCRIPTION
## Summary
- ensure profile normalization accepts `content_types` payloads alongside `post_types`
- tolerate taxonomy conditions persisted as simple slugs when rebuilding the editor state
- emit `content_types` values when synchronising profiles back to hidden fields for sanitization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e24e026ae0832e9476adc541559902