### PR TITLE
Add CTA menu block support

### DIFF
--- a/sidebar-jlg/assets/css/public-style.css
+++ b/sidebar-jlg/assets/css/public-style.css
@@ -457,6 +457,83 @@ body[data-sidebar-position="right"] .pro-sidebar {
 .sidebar-menu .menu-separator hr { border: none; border-top: 1px solid rgba(255, 255, 255, 0.1); }
 .sidebar-menu .social-icons-wrapper { padding-top: 0.5rem; }
 .sidebar-menu .social-icons-wrapper .social-icons { padding: 0 1.5rem; }
+.sidebar-menu .menu-item-cta {
+    padding: 1.5rem;
+}
+.sidebar-menu .menu-item-cta + .menu-item-cta {
+    padding-top: 0;
+}
+.sidebar-menu .menu-item-cta .menu-cta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.5rem;
+    border-radius: clamp(0.5rem, var(--border-radius, 12px), 1.25rem);
+    background: rgba(255, 255, 255, 0.08);
+    background: color-mix(in srgb, var(--primary-accent-color, rgba(13, 110, 253, 1)) 18%, rgba(255, 255, 255, 0.06));
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+}
+.sidebar-menu .menu-item-cta .menu-cta::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0) 60%);
+}
+.sidebar-menu .menu-item-cta .menu-cta__title {
+    margin: 0;
+    font-size: 1.15em;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+.sidebar-menu .menu-item-cta .menu-cta__description {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.95em;
+    line-height: 1.6;
+}
+.sidebar-menu .menu-item-cta .menu-cta__shortcode {
+    font-size: 0.85em;
+    color: rgba(255, 255, 255, 0.78);
+    line-height: 1.6;
+}
+.sidebar-menu .menu-item-cta .menu-cta__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.75rem;
+    border-radius: 999px;
+    background: var(--primary-accent-color, rgba(13, 110, 253, 1));
+    color: #fff;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    position: relative;
+    z-index: 1;
+}
+.sidebar-menu .menu-item-cta .menu-cta__button:hover,
+.sidebar-menu .menu-item-cta .menu-cta__button:focus,
+.sidebar-menu .menu-item-cta .menu-cta__button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+    outline: none;
+}
+.sidebar-menu .menu-item-cta .menu-cta__button:focus-visible {
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35), 0 10px 25px rgba(0, 0, 0, 0.35);
+}
+.sidebar-menu.is-horizontal .menu-item-cta {
+    flex: 1 1 100%;
+    padding-inline: 0;
+}
+.sidebar-menu.is-horizontal .menu-item-cta .menu-cta {
+    align-items: center;
+}
 
 /* Sous-menus imbriqués */
 .sidebar-menu .has-submenu-toggle {

--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -4349,6 +4349,114 @@ jQuery(document).ready(function($) {
             searchInput.val('');
             statusElement.empty();
             searchContainer.css('display', 'none');
+        } else if (type === 'cta') {
+            const titleLabel = getI18nString('ctaTitleLabel', 'Titre du bloc');
+            const descriptionLabel = getI18nString('ctaDescriptionLabel', 'Description');
+            const buttonLabelLabel = getI18nString('ctaButtonLabel', 'Texte du bouton');
+            const buttonUrlLabel = getI18nString('ctaButtonUrlLabel', 'Lien du bouton');
+            const shortcodeLabel = getI18nString('ctaShortcodeLabel', 'Shortcode (optionnel)');
+            const buttonUrlPlaceholder = getI18nString('ctaButtonUrlPlaceholder', 'https://...');
+
+            const ctaTitle = typeof itemData.cta_title === 'string' ? itemData.cta_title : '';
+            const ctaDescription = typeof itemData.cta_description === 'string' ? itemData.cta_description : '';
+            const ctaButtonLabel = typeof itemData.cta_button_label === 'string' ? itemData.cta_button_label : '';
+            const ctaButtonUrl = typeof itemData.cta_button_url === 'string' && itemData.cta_button_url.trim() !== ''
+                ? itemData.cta_button_url
+                : value;
+            const ctaShortcode = typeof itemData.cta_shortcode === 'string' ? itemData.cta_shortcode : '';
+
+            const $fields = $('<div>', {
+                class: 'menu-item-cta-fields',
+                'data-menu-item-cta-fields': '1'
+            });
+
+            const $titleWrapper = $('<p>');
+            $titleWrapper.append($('<label>').text(titleLabel));
+            const $titleInput = $('<input>', {
+                type: 'text',
+                class: 'widefat menu-item-cta-title',
+                name: `sidebar_jlg_settings[menu_items][${index}][cta_title]`
+            }).val(ctaTitle);
+            $titleWrapper.append($titleInput);
+
+            const $descriptionWrapper = $('<p>');
+            $descriptionWrapper.append($('<label>').text(descriptionLabel));
+            const $descriptionTextarea = $('<textarea>', {
+                class: 'widefat menu-item-cta-description',
+                rows: 3,
+                name: `sidebar_jlg_settings[menu_items][${index}][cta_description]`
+            }).val(ctaDescription);
+            $descriptionWrapper.append($descriptionTextarea);
+
+            const $buttonLabelWrapper = $('<p>');
+            $buttonLabelWrapper.append($('<label>').text(buttonLabelLabel));
+            const $buttonLabelInput = $('<input>', {
+                type: 'text',
+                class: 'widefat menu-item-cta-button-label',
+                name: `sidebar_jlg_settings[menu_items][${index}][cta_button_label]`
+            }).val(ctaButtonLabel);
+            $buttonLabelWrapper.append($buttonLabelInput);
+
+            const $buttonUrlWrapper = $('<p>');
+            $buttonUrlWrapper.append($('<label>').text(buttonUrlLabel));
+            const $buttonUrlInput = $('<input>', {
+                type: 'url',
+                class: 'widefat menu-item-cta-button-url',
+                placeholder: buttonUrlPlaceholder,
+                name: `sidebar_jlg_settings[menu_items][${index}][cta_button_url]`
+            }).val(ctaButtonUrl || '');
+            $buttonUrlWrapper.append($buttonUrlInput);
+
+            const $hiddenValueInput = $('<input>', {
+                type: 'hidden',
+                name: `sidebar_jlg_settings[menu_items][${index}][value]`
+            }).val(ctaButtonUrl || '');
+            $buttonUrlWrapper.append($hiddenValueInput);
+
+            const $shortcodeWrapper = $('<p>');
+            $shortcodeWrapper.append($('<label>').text(shortcodeLabel));
+            const $shortcodeTextarea = $('<textarea>', {
+                class: 'widefat menu-item-cta-shortcode',
+                rows: 2,
+                name: `sidebar_jlg_settings[menu_items][${index}][cta_shortcode]`
+            }).val(ctaShortcode);
+            $shortcodeWrapper.append($shortcodeTextarea);
+
+            $fields
+                .append($titleWrapper)
+                .append($descriptionWrapper)
+                .append($buttonLabelWrapper)
+                .append($buttonUrlWrapper)
+                .append($shortcodeWrapper);
+
+            fieldContainer.append($fields);
+
+            const defaultFallback = getI18nString('menuItemDefaultTitle', 'Nouvel élément');
+            const updateFallbackTitle = (nextTitle) => {
+                const trimmed = typeof nextTitle === 'string' ? nextTitle.trim() : '';
+                const fallback = trimmed || defaultFallback;
+                $itemBox.data('fallbackTitle', fallback);
+                const $labelField = $itemBox.find('.item-label');
+                const labelValue = $labelField.length && typeof $labelField.val() === 'string'
+                    ? $labelField.val().trim()
+                    : '';
+                $itemBox.find('.item-title').text(labelValue || fallback);
+            };
+
+            updateFallbackTitle(ctaTitle);
+            $titleInput.on('input', function() {
+                updateFallbackTitle(this.value || '');
+            });
+
+            $buttonUrlInput.on('input', function() {
+                const currentValue = typeof this.value === 'string' ? this.value.trim() : '';
+                $hiddenValueInput.val(currentValue);
+                triggerFieldUpdate($hiddenValueInput[0]);
+            });
+
+            searchInput.val('');
+            statusElement.empty();
+            searchContainer.css('display', 'none');
         } else if (type === 'post' || type === 'page' || type === 'category') {
             const isContentType = type === 'post' || type === 'page';
             const action = isContentType ? 'jlg_get_posts' : 'jlg_get_categories';
@@ -4620,7 +4728,12 @@ jQuery(document).ready(function($) {
             icon_type: 'svg_inline',
             icon: '',
             nav_menu_max_depth: 0,
-            nav_menu_filter: 'all'
+            nav_menu_filter: 'all',
+            cta_title: '',
+            cta_description: '',
+            cta_button_label: '',
+            cta_button_url: '',
+            cta_shortcode: ''
         }),
         onAppend: ($itemBox, itemData) => {
             updateValueField($itemBox, itemData);

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -911,6 +911,7 @@ $textTransformLabels = [
                     <option value="page" <# if (data.type === 'page') { #>selected<# } #>><?php echo esc_html__( 'Page', 'sidebar-jlg' ); ?></option>
                     <option value="category" <# if (data.type === 'category') { #>selected<# } #>><?php echo esc_html__( 'Catégorie', 'sidebar-jlg' ); ?></option>
                     <option value="nav_menu" <# if (data.type === 'nav_menu') { #>selected<# } #>><?php echo esc_html__( 'Menu WordPress', 'sidebar-jlg' ); ?></option>
+                    <option value="cta" <# if (data.type === 'cta') { #>selected<# } #>><?php echo esc_html__( 'Bloc CTA', 'sidebar-jlg' ); ?></option>
                 </select>
             </p>
             <div class="menu-item-value-wrapper">

--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -107,6 +107,63 @@ $renderMenuNodes = static function (array $nodes, string $layout) use (&$renderM
             $classAttr = ' class="' . esc_attr(implode(' ', $classes)) . '"';
         }
 
+        $dataAttributes = '';
+        if (!empty($node['data_attributes']) && is_array($node['data_attributes'])) {
+            foreach ($node['data_attributes'] as $attrName => $attrValue) {
+                if (!is_string($attrName) || strpos($attrName, 'data-') !== 0) {
+                    continue;
+                }
+
+                if (!preg_match('/^data-[a-z0-9_-]+$/i', $attrName)) {
+                    continue;
+                }
+
+                if (!is_scalar($attrValue)) {
+                    continue;
+                }
+
+                $dataAttributes .= sprintf(' %s="%s"', esc_attr($attrName), esc_attr((string) $attrValue));
+            }
+        }
+
+        $nodeType = isset($node['type']) ? (string) $node['type'] : '';
+
+        if ($nodeType === 'cta') {
+            $ctaData = is_array($node['cta'] ?? null) ? $node['cta'] : [];
+            $ctaTitle = isset($ctaData['title']) && is_string($ctaData['title']) ? $ctaData['title'] : '';
+            $ctaDescription = isset($ctaData['description']) && is_string($ctaData['description']) ? $ctaData['description'] : '';
+            $ctaButtonLabel = isset($ctaData['button_label']) && is_string($ctaData['button_label']) ? $ctaData['button_label'] : '';
+            $ctaButtonUrl = isset($ctaData['button_url']) && is_string($ctaData['button_url']) ? $ctaData['button_url'] : '#';
+            $ctaShortcode = isset($ctaData['shortcode']) && is_string($ctaData['shortcode']) ? $ctaData['shortcode'] : '';
+
+            ob_start();
+            ?>
+            <li<?php echo $classAttr; ?><?php echo $dataAttributes; ?>>
+                <div class="menu-cta" data-cta-analytics="entry">
+                    <?php if ($ctaTitle !== '') : ?>
+                        <h3 class="menu-cta__title"><?php echo esc_html($ctaTitle); ?></h3>
+                    <?php endif; ?>
+
+                    <?php if ($ctaDescription !== '') : ?>
+                        <div class="menu-cta__description"><?php echo $ctaDescription; ?></div>
+                    <?php endif; ?>
+
+                    <?php if ($ctaShortcode !== '') : ?>
+                        <div class="menu-cta__shortcode"><?php echo $ctaShortcode; ?></div>
+                    <?php endif; ?>
+
+                    <?php if ($ctaButtonLabel !== '') : ?>
+                        <a class="menu-cta__button" href="<?php echo esc_url($ctaButtonUrl); ?>" data-cta-action="button">
+                            <span><?php echo esc_html($ctaButtonLabel); ?></span>
+                        </a>
+                    <?php endif; ?>
+                </div>
+            </li>
+            <?php
+            $html .= ob_get_clean();
+            continue;
+        }
+
         $url = isset($node['url']) && is_string($node['url']) && $node['url'] !== '' ? $node['url'] : '#';
         $ariaCurrent = !empty($node['is_current']) ? ' aria-current="page"' : '';
 
@@ -118,7 +175,7 @@ $renderMenuNodes = static function (array $nodes, string $layout) use (&$renderM
 
         ob_start();
         ?>
-        <li<?php echo $classAttr; ?>>
+        <li<?php echo $classAttr; ?><?php echo $dataAttributes; ?>>
             <a href="<?php echo esc_url($url); ?>"<?php echo $ariaCurrent; ?>>
                 <?php
                 $icon = $node['icon'] ?? null;


### PR DESCRIPTION
## Summary
- add a CTA menu item option in the admin template and extend the builder script with CTA-specific fields (title, description, button, shortcode)
- render CTA entries on the front-end with dedicated markup, shortcode output, and data attributes to support future analytics
- introduce public styles for CTA blocks including layout and button states

## Testing
- php -l sidebar-jlg/src/Frontend/SidebarRenderer.php
- php -l sidebar-jlg/includes/sidebar-template.php

------
https://chatgpt.com/codex/tasks/task_e_68e24e03d78c832eb49191309352f9b0