### PR TITLE
Add style preset catalog and preview compare toggle

### DIFF
--- a/sidebar-jlg/assets/css/admin-style.css
+++ b/sidebar-jlg/assets/css/admin-style.css
@@ -50,6 +50,111 @@ input:checked + .jlg-slider:before { transform: translateX(26px); }
     border: 1px solid #ddd; background: #f0f0f1; padding: 5px;
 }
 
+.sidebar-jlg-style-presets {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 12px;
+}
+
+.sidebar-jlg-style-presets__grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.sidebar-jlg-style-presets__placeholder,
+.sidebar-jlg-style-presets__empty {
+    margin: 0;
+    font-size: 13px;
+    color: #50575e;
+}
+
+.sidebar-jlg-style-presets__empty[hidden] {
+    display: none !important;
+}
+
+.sidebar-jlg-style-preset-card {
+    border: 1px solid #d0d5dd;
+    border-radius: 12px;
+    background: #fff;
+    color: inherit;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    font-family: inherit;
+    box-shadow: none;
+}
+
+.sidebar-jlg-style-preset-card:hover {
+    border-color: #2271b1;
+    box-shadow: 0 6px 16px rgba(34, 113, 177, 0.15);
+    transform: translateY(-2px);
+}
+
+.sidebar-jlg-style-preset-card.is-active {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px rgba(34, 113, 177, 0.4);
+}
+
+.sidebar-jlg-style-preset-card:focus-visible {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+}
+
+.sidebar-jlg-style-preset-card__preview {
+    position: relative;
+    border-radius: 10px;
+    overflow: hidden;
+    height: 96px;
+    background: #1f2937;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 16px;
+}
+
+.sidebar-jlg-style-preset-card__accent {
+    width: 36px;
+    height: 64px;
+    border-radius: 20px;
+    background: rgba(14, 165, 233, 0.9);
+    box-shadow: 0 0 18px rgba(14, 165, 233, 0.45);
+}
+
+.sidebar-jlg-style-preset-card__sample {
+    font-size: 28px;
+    font-weight: 600;
+    color: #f8fafc;
+    letter-spacing: 0.05em;
+}
+
+.sidebar-jlg-style-preset-card__title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.sidebar-jlg-style-preset-card__description {
+    margin: 0;
+    font-size: 13px;
+    color: #50575e;
+}
+
+.sidebar-jlg-style-preset-card__cta {
+    margin-top: auto;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #2271b1;
+}
+
 /* Modale d'icônes */
 #icon-library-modal { display: none; }
 #icon-library-modal .modal-backdrop { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.7); z-index: 100000; }

--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -962,6 +962,10 @@ class SidebarPreviewModule {
 
         this.captureFontStacksFromDom();
 
+        this.bindField('sidebar_jlg_settings[style_preset]', (value) => {
+            this.currentOptions.style_preset = value || 'custom';
+        });
+
         this.bindField('sidebar_jlg_settings[layout_style]', (value) => {
             this.currentOptions.layout_style = value || 'full';
         });
@@ -1830,8 +1834,516 @@ jQuery(document).ready(function($) {
     initializeUnitControls();
     initializeRangeControls();
 
+    const compareControls = setupPreviewCompare(previewModule);
+    initializeStylePresets(compareControls);
+
     if (typeof window !== 'undefined') {
         window.SidebarJLGPreview = previewModule;
+    }
+
+    function setupPreviewCompare(previewModuleInstance) {
+        const button = document.getElementById('sidebar-jlg-preview-compare');
+        const formElement = document.getElementById('sidebar-jlg-form');
+
+        if (!button || !previewModuleInstance) {
+            return {
+                exit: () => Promise.resolve(),
+                isActive: () => false,
+            };
+        }
+
+        const labelSpan = button.querySelector('.sidebar-jlg-preview__toolbar-button-label');
+        const defaultLabelFallback = labelSpan && labelSpan.textContent
+            ? labelSpan.textContent.trim()
+            : (button.textContent || '').trim();
+        const defaultLabel = getI18nString('stylePresetCompareButton', defaultLabelFallback || 'Comparer avant/après');
+        const exitLabel = getI18nString('stylePresetCompareExit', 'Revenir à l’après');
+        const beforeMessage = getI18nString('stylePresetCompareBefore', '');
+        const afterMessage = getI18nString('stylePresetCompareAfter', '');
+
+        if (labelSpan) {
+            labelSpan.textContent = defaultLabel;
+        } else {
+            button.textContent = defaultLabel;
+        }
+
+        button.setAttribute('aria-label', defaultLabel);
+        button.setAttribute('aria-pressed', 'false');
+
+        const state = {
+            active: false,
+            disabledFields: [],
+            afterOptions: null,
+            busy: false,
+        };
+
+        const setButtonState = (active) => {
+            const label = active ? exitLabel : defaultLabel;
+            if (labelSpan) {
+                labelSpan.textContent = label;
+            } else {
+                button.textContent = label;
+            }
+            button.classList.toggle('is-active', active);
+            button.setAttribute('aria-pressed', active ? 'true' : 'false');
+            button.setAttribute('aria-label', label);
+        };
+
+        const toggleButtonBusy = (busy) => {
+            state.busy = busy;
+            button.disabled = busy;
+            button.classList.toggle('is-busy', busy);
+        };
+
+        const disableFormControls = (disabled) => {
+            if (!formElement) {
+                return;
+            }
+
+            if (disabled) {
+                state.disabledFields = [];
+                const elements = Array.from(formElement.querySelectorAll('input, select, textarea, button'));
+                elements.forEach((element) => {
+                    if (element === button) {
+                        return;
+                    }
+                    if (element.disabled) {
+                        return;
+                    }
+                    element.disabled = true;
+                    state.disabledFields.push(element);
+                });
+                formElement.setAttribute('aria-disabled', 'true');
+            } else {
+                state.disabledFields.forEach((element) => {
+                    element.disabled = false;
+                });
+                state.disabledFields = [];
+                formElement.removeAttribute('aria-disabled');
+            }
+        };
+
+        const enterCompare = () => {
+            if (state.active || state.busy) {
+                return Promise.resolve();
+            }
+
+            state.afterOptions = SidebarPreviewModule.cloneObject(previewModuleInstance.currentOptions || {});
+            setButtonState(true);
+            disableFormControls(true);
+            toggleButtonBusy(true);
+            state.active = true;
+
+            previewModuleInstance.currentOptions = SidebarPreviewModule.cloneObject(previewModuleInstance.initialOptions || {});
+
+            return previewModuleInstance.loadPreview()
+                .then(() => {
+                    previewModuleInstance.applyOptions();
+                    if (beforeMessage) {
+                        previewModuleInstance.setStatus(beforeMessage, false);
+                    }
+                })
+                .catch(() => {
+                    state.active = false;
+                    disableFormControls(false);
+                    setButtonState(false);
+                })
+                .finally(() => {
+                    toggleButtonBusy(false);
+                });
+        };
+
+        const exitCompare = () => {
+            if (!state.active || state.busy) {
+                return Promise.resolve();
+            }
+
+            const afterOptions = SidebarPreviewModule.cloneObject(state.afterOptions || previewModuleInstance.currentOptions || {});
+            setButtonState(false);
+            disableFormControls(false);
+            toggleButtonBusy(true);
+            state.active = false;
+            previewModuleInstance.currentOptions = afterOptions;
+
+            return previewModuleInstance.loadPreview()
+                .then(() => {
+                    previewModuleInstance.applyOptions();
+                    if (afterMessage) {
+                        previewModuleInstance.setStatus(afterMessage, false);
+                    } else {
+                        previewModuleInstance.clearStatus();
+                    }
+                })
+                .catch(() => {
+                    previewModuleInstance.clearStatus();
+                })
+                .finally(() => {
+                    state.afterOptions = null;
+                    toggleButtonBusy(false);
+                });
+        };
+
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            if (state.active) {
+                exitCompare();
+            } else {
+                enterCompare();
+            }
+        });
+
+        return {
+            exit: exitCompare,
+            isActive: () => state.active,
+        };
+    }
+
+    function initializeStylePresets(compareControls) {
+        const hiddenInput = document.getElementById('sidebar-jlg-style-preset');
+        const container = document.getElementById('sidebar-jlg-style-presets');
+        if (!hiddenInput || !container) {
+            return;
+        }
+
+        const grid = container.querySelector('[data-style-preset-grid]');
+        if (!grid) {
+            hiddenInput.disabled = false;
+            return;
+        }
+
+        hiddenInput.disabled = false;
+
+        const emptyMessage = container.querySelector('[data-style-preset-empty]');
+        const applyLabel = getI18nString('stylePresetApplyLabel', 'Utiliser ce préréglage');
+        const customLabel = getI18nString('stylePresetCustomLabel', 'Personnalisé');
+        const customDescription = getI18nString('stylePresetCustomDescription', 'Utilisez vos propres combinaisons de couleurs, typographies et effets.');
+        const emptyText = getI18nString('stylePresetEmpty', 'Aucun préréglage n’est disponible pour le moment.');
+
+        if (emptyMessage) {
+            emptyMessage.textContent = emptyText;
+        }
+
+        const rawPresets = (typeof sidebarJLG.style_presets === 'object' && sidebarJLG.style_presets !== null)
+            ? sidebarJLG.style_presets
+            : {};
+
+        const normalizedPresets = Object.keys(rawPresets).map((key) => {
+            const raw = rawPresets[key] || {};
+            const previewData = raw.preview && typeof raw.preview === 'object' ? raw.preview : {};
+            return {
+                key,
+                label: typeof raw.label === 'string' && raw.label.trim() !== '' ? raw.label : key,
+                description: typeof raw.description === 'string' ? raw.description : '',
+                settings: raw.settings && typeof raw.settings === 'object' ? raw.settings : null,
+                preview: {
+                    background: typeof previewData.background === 'string' ? previewData.background : '',
+                    accent: typeof previewData.accent === 'string' ? previewData.accent : '',
+                    text: typeof previewData.text === 'string' ? previewData.text : '',
+                },
+            };
+        });
+
+        grid.innerHTML = '';
+
+        const ensureCompareInactive = () => {
+            if (!compareControls || typeof compareControls.isActive !== 'function') {
+                return Promise.resolve();
+            }
+
+            try {
+                if (compareControls.isActive() && typeof compareControls.exit === 'function') {
+                    return Promise.resolve(compareControls.exit());
+                }
+            } catch (error) {
+                return Promise.resolve();
+            }
+
+            return Promise.resolve();
+        };
+
+        let isApplyingPreset = false;
+        let customCardElement = null;
+
+        const markActiveCard = (key) => {
+            const cards = grid.querySelectorAll('.sidebar-jlg-style-preset-card');
+            cards.forEach((card) => {
+                const isActive = card.dataset.presetKey === key;
+                card.classList.toggle('is-active', isActive);
+                card.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
+            container.setAttribute('data-selected-preset', key);
+        };
+
+        const updateHiddenInput = (key) => {
+            hiddenInput.value = key;
+            triggerFieldUpdate(hiddenInput);
+        };
+
+        const computeCurrentPreview = () => {
+            const source = (previewModule && previewModule.currentOptions) ? previewModule.currentOptions : options;
+            const result = {
+                background: '#1f2937',
+                accent: '#0ea5e9',
+                text: '#f8fafc',
+            };
+
+            const bgType = typeof source.bg_color_type === 'string' ? source.bg_color_type.toLowerCase() : 'solid';
+            if (bgType === 'gradient') {
+                const start = source.bg_color_start || source.bg_color || result.background;
+                const end = source.bg_color_end || start;
+                result.background = `linear-gradient(180deg, ${start} 0%, ${end} 100%)`;
+            } else if (source.bg_color) {
+                result.background = source.bg_color;
+            }
+
+            const accentType = typeof source.accent_color_type === 'string' ? source.accent_color_type.toLowerCase() : 'solid';
+            if (accentType === 'gradient') {
+                const start = source.accent_color_start || source.accent_color || result.accent;
+                const end = source.accent_color_end || start;
+                result.accent = `linear-gradient(135deg, ${start} 0%, ${end} 100%)`;
+            } else if (source.accent_color) {
+                result.accent = source.accent_color;
+            }
+
+            if (source.font_color) {
+                result.text = source.font_color;
+            }
+
+            return result;
+        };
+
+        const updateCustomCardPreview = () => {
+            if (!customCardElement) {
+                return;
+            }
+
+            const previewElement = customCardElement.querySelector('.sidebar-jlg-style-preset-card__preview');
+            const accentElement = customCardElement.querySelector('.sidebar-jlg-style-preset-card__accent');
+            const sampleElement = customCardElement.querySelector('.sidebar-jlg-style-preset-card__sample');
+
+            if (!previewElement || !accentElement || !sampleElement) {
+                return;
+            }
+
+            const currentPreview = computeCurrentPreview();
+            previewElement.style.background = currentPreview.background;
+            accentElement.style.background = currentPreview.accent;
+            sampleElement.style.color = currentPreview.text;
+        };
+
+        const applyPresetSettings = (settings) => {
+            if (!settings || typeof settings !== 'object') {
+                return;
+            }
+
+            Object.keys(settings).forEach((optionKey) => {
+                const optionValue = settings[optionKey];
+
+                if (optionValue && typeof optionValue === 'object' && Object.prototype.hasOwnProperty.call(optionValue, 'value') && Object.prototype.hasOwnProperty.call(optionValue, 'unit')) {
+                    const valueInput = document.querySelector(`[name="sidebar_jlg_settings[${optionKey}][value]"]`);
+                    const unitInput = document.querySelector(`[name="sidebar_jlg_settings[${optionKey}][unit]"]`);
+
+                    if (valueInput) {
+                        valueInput.value = optionValue.value;
+                        triggerFieldUpdate(valueInput);
+                    }
+                    if (unitInput) {
+                        unitInput.value = optionValue.unit;
+                        triggerFieldUpdate(unitInput);
+                    }
+
+                    return;
+                }
+
+                const radioElements = document.querySelectorAll(`input[type="radio"][name="sidebar_jlg_settings[${optionKey}]"]`);
+                if (radioElements.length) {
+                    let matched = null;
+                    radioElements.forEach((radio) => {
+                        const isMatch = radio.value === String(optionValue);
+                        radio.checked = isMatch;
+                        if (isMatch) {
+                            matched = radio;
+                        }
+                    });
+                    if (matched) {
+                        triggerFieldUpdate(matched);
+                    } else if (radioElements[0]) {
+                        triggerFieldUpdate(radioElements[0]);
+                    }
+                    return;
+                }
+
+                const checkbox = document.querySelector(`input[type="checkbox"][name="sidebar_jlg_settings[${optionKey}]"]`);
+                if (checkbox) {
+                    const isChecked = optionValue === true || optionValue === '1' || optionValue === 1 || optionValue === 'on';
+                    checkbox.checked = isChecked;
+                    triggerFieldUpdate(checkbox);
+                    return;
+                }
+
+                const field = document.querySelector(`[name="sidebar_jlg_settings[${optionKey}]"]`);
+                if (!field) {
+                    return;
+                }
+
+                field.value = optionValue;
+                triggerFieldUpdate(field);
+
+                if (window.jQuery) {
+                    const $field = window.jQuery(field);
+                    if (typeof $field.wpColorPicker === 'function' && $field.data('wpColorPicker')) {
+                        $field.wpColorPicker('color', optionValue);
+                    } else if ($field.hasClass('color-picker-rgba')) {
+                        $field.trigger('change');
+                    }
+                }
+            });
+        };
+
+        const refreshPreview = () => {
+            if (!previewModule || typeof previewModule.loadPreview !== 'function') {
+                updateCustomCardPreview();
+                return Promise.resolve();
+            }
+
+            return previewModule.loadPreview()
+                .then(() => {
+                    previewModule.applyOptions();
+                    updateCustomCardPreview();
+                })
+                .catch(() => {
+                    updateCustomCardPreview();
+                });
+        };
+
+        const handlePresetSelection = (preset) => {
+            isApplyingPreset = true;
+
+            ensureCompareInactive()
+                .then(() => {
+                    if (preset.key !== 'custom' && preset.settings) {
+                        applyPresetSettings(preset.settings);
+                    }
+
+                    updateHiddenInput(preset.key);
+                    markActiveCard(preset.key);
+
+                    return refreshPreview();
+                })
+                .catch(() => {
+                    // Silently ignore compare exit failures.
+                })
+                .finally(() => {
+                    isApplyingPreset = false;
+                });
+        };
+
+        const createCardElement = (preset) => {
+            const card = document.createElement('button');
+            card.type = 'button';
+            card.className = 'sidebar-jlg-style-preset-card';
+            card.dataset.presetKey = preset.key;
+            card.setAttribute('aria-pressed', 'false');
+
+            const previewElement = document.createElement('span');
+            previewElement.className = 'sidebar-jlg-style-preset-card__preview';
+            if (preset.preview.background) {
+                previewElement.style.background = preset.preview.background;
+            }
+
+            const accentElement = document.createElement('span');
+            accentElement.className = 'sidebar-jlg-style-preset-card__accent';
+            if (preset.preview.accent) {
+                accentElement.style.background = preset.preview.accent;
+            }
+            previewElement.appendChild(accentElement);
+
+            const sampleElement = document.createElement('span');
+            sampleElement.className = 'sidebar-jlg-style-preset-card__sample';
+            sampleElement.textContent = 'Aa';
+            if (preset.preview.text) {
+                sampleElement.style.color = preset.preview.text;
+            }
+            previewElement.appendChild(sampleElement);
+
+            const titleElement = document.createElement('h4');
+            titleElement.className = 'sidebar-jlg-style-preset-card__title';
+            titleElement.textContent = preset.label;
+
+            card.appendChild(previewElement);
+            card.appendChild(titleElement);
+
+            if (preset.description) {
+                const descriptionElement = document.createElement('p');
+                descriptionElement.className = 'sidebar-jlg-style-preset-card__description';
+                descriptionElement.textContent = preset.description;
+                card.appendChild(descriptionElement);
+            }
+
+            const ctaElement = document.createElement('span');
+            ctaElement.className = 'sidebar-jlg-style-preset-card__cta';
+            ctaElement.textContent = applyLabel;
+            card.appendChild(ctaElement);
+
+            card.addEventListener('click', () => {
+                handlePresetSelection(preset);
+            });
+
+            return card;
+        };
+
+        const presetsToRender = [
+            {
+                key: 'custom',
+                label: customLabel,
+                description: customDescription,
+                settings: null,
+                preview: computeCurrentPreview(),
+            },
+            ...normalizedPresets,
+        ];
+
+        presetsToRender.forEach((preset) => {
+            const card = createCardElement(preset);
+            if (preset.key === 'custom') {
+                customCardElement = card;
+            }
+            grid.appendChild(card);
+        });
+
+        const initialKey = hiddenInput.value && hiddenInput.value !== '' ? hiddenInput.value : 'custom';
+        markActiveCard(initialKey);
+        updateCustomCardPreview();
+
+        const styleTab = document.getElementById('tab-presets');
+        if (styleTab) {
+            const manualChangeHandler = (event) => {
+                if (isApplyingPreset) {
+                    return;
+                }
+
+                const target = event.target;
+                if (!(target instanceof HTMLElement)) {
+                    return;
+                }
+
+                if (!container.contains(target)) {
+                    return;
+                }
+
+                if (hiddenInput.value !== 'custom') {
+                    updateHiddenInput('custom');
+                    markActiveCard('custom');
+                }
+
+                window.requestAnimationFrame(() => {
+                    updateCustomCardPreview();
+                });
+            };
+
+            styleTab.addEventListener('input', manualChangeHandler);
+            styleTab.addEventListener('change', manualChangeHandler);
+        }
     }
 
     function rebuildIconLookups(manifest) {
@@ -3360,29 +3872,6 @@ jQuery(document).ready(function($) {
             $('.logo-preview img').attr('src', attachment.url).show();
         });
         mediaFrame.open();
-    });
-
-    // --- Préréglages de style ---
-    $('#style-preset-select').on('change', function() {
-        const preset = $(this).val();
-        if (preset === 'custom') return;
-
-        const presets = {
-            moderne_dark: {
-                bg_color: '#1a1d24',
-                accent_color: '#0d6efd',
-                font_color: '#e0e0e0',
-                font_hover_color: '#ffffff'
-            }
-        };
-
-        if (presets[preset]) {
-            const p = presets[preset];
-            $('input[name="sidebar_jlg_settings[bg_color]"]').val(p.bg_color).trigger('change');
-            $('input[name="sidebar_jlg_settings[accent_color]"]').val(p.accent_color).trigger('change');
-            $('input[name="sidebar_jlg_settings[font_color]"]').val(p.font_color).trigger('change');
-            $('input[name="sidebar_jlg_settings[font_hover_color]"]').val(p.font_hover_color).trigger('change');
-        }
     });
 
     // --- Modale Icônes ---

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -85,6 +85,10 @@ $textTransformLabels = [
                 <span class="screen-reader-text"><?php esc_html_e( 'Prévisualiser en mode bureau', 'sidebar-jlg' ); ?></span>
                 <span aria-hidden="true"><?php esc_html_e( 'Desktop', 'sidebar-jlg' ); ?></span>
             </button>
+            <button type="button" class="button button-secondary sidebar-jlg-preview__toolbar-button" id="sidebar-jlg-preview-compare" aria-pressed="false">
+                <span class="screen-reader-text"><?php esc_html_e( 'Basculer entre l’aperçu initial et l’aperçu actuel', 'sidebar-jlg' ); ?></span>
+                <span class="sidebar-jlg-preview__toolbar-button-label" aria-hidden="true"><?php esc_html_e( 'Comparer', 'sidebar-jlg' ); ?></span>
+            </button>
         </div>
         <div class="sidebar-jlg-preview__status" role="status" aria-live="polite"></div>
         <div class="sidebar-jlg-preview__viewport" aria-label="<?php esc_attr_e( 'Aperçu de la sidebar', 'sidebar-jlg' ); ?>"></div>
@@ -434,11 +438,32 @@ $textTransformLabels = [
                 <tr>
                     <th scope="row"><?php esc_html_e( 'Préréglage de style', 'sidebar-jlg' ); ?></th>
                     <td>
-                        <select name="sidebar_jlg_settings[style_preset]" id="style-preset-select">
-                            <option value="custom" <?php selected($options['style_preset'], 'custom'); ?>><?php esc_html_e('Personnalisé', 'sidebar-jlg'); ?></option>
-                            <option value="moderne_dark" <?php selected($options['style_preset'], 'moderne_dark'); ?>><?php esc_html_e('Critique Moderne (Dark)', 'sidebar-jlg'); ?></option>
-                        </select>
-                        <p class="description"><?php esc_html_e('Choisir un préréglage mettra à jour automatiquement les options de couleur ci-dessous.', 'sidebar-jlg'); ?></p>
+                        <input type="hidden" name="sidebar_jlg_settings[style_preset]" id="sidebar-jlg-style-preset" value="<?php echo esc_attr( $options['style_preset'] ?? 'custom' ); ?>" disabled>
+                        <div id="sidebar-jlg-style-presets" class="sidebar-jlg-style-presets" data-selected-preset="<?php echo esc_attr( $options['style_preset'] ?? 'custom' ); ?>">
+                            <p class="description"><?php esc_html_e( 'Choisissez un préréglage pour remplir automatiquement les couleurs, la typographie et les effets.', 'sidebar-jlg' ); ?></p>
+                            <div class="sidebar-jlg-style-presets__grid" data-style-preset-grid>
+                                <p class="sidebar-jlg-style-presets__placeholder"><?php esc_html_e( 'Chargement des préréglages…', 'sidebar-jlg' ); ?></p>
+                            </div>
+                            <p class="sidebar-jlg-style-presets__empty" data-style-preset-empty hidden><?php esc_html_e( 'Aucun préréglage n’est disponible pour le moment.', 'sidebar-jlg' ); ?></p>
+                            <noscript>
+                                <p><?php esc_html_e( 'JavaScript est nécessaire pour parcourir les préréglages interactifs. Utilisez la liste déroulante ci-dessous.', 'sidebar-jlg' ); ?></p>
+                                <select name="sidebar_jlg_settings[style_preset]" id="style-preset-select-fallback">
+                                    <option value="custom" <?php selected($options['style_preset'], 'custom'); ?>><?php esc_html_e('Personnalisé', 'sidebar-jlg'); ?></option>
+                                    <?php if ( ! empty( $stylePresets ) && is_array( $stylePresets ) ) : ?>
+                                        <?php foreach ( $stylePresets as $presetKey => $presetData ) : ?>
+                                            <?php
+                                            $presetLabel = '';
+                                            if ( is_array( $presetData ) && isset( $presetData['label'] ) && is_string( $presetData['label'] ) ) {
+                                                $presetLabel = __($presetData['label'], 'sidebar-jlg');
+                                            }
+                                            ?>
+                                            <option value="<?php echo esc_attr( $presetKey ); ?>" <?php selected( $options['style_preset'], $presetKey ); ?>><?php echo esc_html( $presetLabel !== '' ? $presetLabel : $presetKey ); ?></option>
+                                        <?php endforeach; ?>
+                                    <?php endif; ?>
+                                </select>
+                            </noscript>
+                        </div>
+                        <p class="description"><?php esc_html_e( 'Les réglages appliqués peuvent ensuite être ajustés individuellement ci-dessous.', 'sidebar-jlg' ); ?></p>
                     </td>
                 </tr>
                 <tr>

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -4,6 +4,145 @@ namespace JLG\Sidebar\Settings;
 
 class DefaultSettings
 {
+    public const STYLE_PRESETS = [
+        'moderne_dark' => [
+            'label' => 'Critique Moderne (Sombre)',
+            'description' => 'Contraste marqué, typographie audacieuse et accent électrique.',
+            'preview' => [
+                'background' => 'linear-gradient(180deg, #1f2937 0%, #111827 100%)',
+                'accent' => '#0d6efd',
+                'text' => '#f8fafc',
+            ],
+            'settings' => [
+                'bg_color_type' => 'gradient',
+                'bg_color' => 'rgba(31, 41, 55, 1)',
+                'bg_color_start' => '#1f2937',
+                'bg_color_end' => '#111827',
+                'accent_color_type' => 'solid',
+                'accent_color' => 'rgba(13, 110, 253, 1)',
+                'font_color_type' => 'solid',
+                'font_color' => 'rgba(248, 250, 252, 1)',
+                'font_hover_color_type' => 'solid',
+                'font_hover_color' => 'rgba(255, 255, 255, 1)',
+                'font_family' => 'google-montserrat',
+                'font_weight' => '600',
+                'text_transform' => 'uppercase',
+                'letter_spacing' => ['value' => '0.08', 'unit' => 'em'],
+                'hover_effect_desktop' => 'underline-center',
+                'hover_effect_mobile' => 'underline-center',
+                'animation_type' => 'slide-left',
+                'mobile_bg_color' => 'rgba(15, 23, 42, 0.85)',
+                'mobile_bg_opacity' => 0.85,
+                'mobile_blur' => 12,
+                'border_radius' => ['value' => '18', 'unit' => 'px'],
+                'border_width' => 1,
+                'border_color' => 'rgba(148, 163, 184, 0.35)',
+            ],
+        ],
+        'minimal_light' => [
+            'label' => 'Minimal Clair',
+            'description' => 'Palette douce, lisibilité maximale et transitions discrètes.',
+            'preview' => [
+                'background' => '#f8fafc',
+                'accent' => '#2563eb',
+                'text' => '#1f2937',
+            ],
+            'settings' => [
+                'bg_color_type' => 'solid',
+                'bg_color' => 'rgba(248, 250, 252, 1)',
+                'accent_color_type' => 'solid',
+                'accent_color' => 'rgba(37, 99, 235, 1)',
+                'font_color_type' => 'solid',
+                'font_color' => 'rgba(30, 41, 59, 1)',
+                'font_hover_color_type' => 'solid',
+                'font_hover_color' => 'rgba(15, 118, 110, 1)',
+                'font_family' => 'google-open-sans',
+                'font_weight' => '400',
+                'text_transform' => 'none',
+                'letter_spacing' => ['value' => '0', 'unit' => 'em'],
+                'hover_effect_desktop' => 'none',
+                'hover_effect_mobile' => 'none',
+                'animation_type' => 'fade',
+                'mobile_bg_color' => 'rgba(255, 255, 255, 0.95)',
+                'mobile_bg_opacity' => 0.95,
+                'mobile_blur' => 4,
+                'border_radius' => ['value' => '14', 'unit' => 'px'],
+                'border_width' => 1,
+                'border_color' => 'rgba(148, 163, 184, 0.2)',
+            ],
+        ],
+        'retro_warm' => [
+            'label' => 'Retro & Chaleur',
+            'description' => 'Dégradé chaleureux, touches vintage et boutons arrondis.',
+            'preview' => [
+                'background' => 'linear-gradient(180deg, #f97316 0%, #db2777 100%)',
+                'accent' => '#fb923c',
+                'text' => '#fff7ed',
+            ],
+            'settings' => [
+                'bg_color_type' => 'gradient',
+                'bg_color' => 'rgba(249, 115, 22, 1)',
+                'bg_color_start' => '#f97316',
+                'bg_color_end' => '#db2777',
+                'accent_color_type' => 'gradient',
+                'accent_color' => 'rgba(251, 191, 36, 1)',
+                'accent_color_start' => '#fde68a',
+                'accent_color_end' => '#f97316',
+                'font_color_type' => 'solid',
+                'font_color' => 'rgba(255, 247, 237, 1)',
+                'font_hover_color_type' => 'solid',
+                'font_hover_color' => 'rgba(255, 255, 255, 1)',
+                'font_family' => 'georgia',
+                'font_weight' => '600',
+                'text_transform' => 'capitalize',
+                'letter_spacing' => ['value' => '0.05', 'unit' => 'em'],
+                'hover_effect_desktop' => 'pill-center',
+                'hover_effect_mobile' => 'pill-center',
+                'animation_type' => 'scale',
+                'mobile_bg_color' => 'rgba(251, 191, 36, 0.92)',
+                'mobile_bg_opacity' => 0.92,
+                'mobile_blur' => 6,
+                'border_radius' => ['value' => '24', 'unit' => 'px'],
+                'border_width' => 2,
+                'border_color' => 'rgba(251, 146, 60, 0.35)',
+            ],
+        ],
+        'glass_neon' => [
+            'label' => 'Verre Néon',
+            'description' => 'Effet glassmorphism, néons vibrants et ambiance futuriste.',
+            'preview' => [
+                'background' => 'linear-gradient(180deg, rgba(15, 23, 42, 0.85) 0%, rgba(30, 41, 59, 0.65) 100%)',
+                'accent' => 'linear-gradient(135deg, #38bdf8 0%, #f472b6 100%)',
+                'text' => '#e2e8f0',
+            ],
+            'settings' => [
+                'bg_color_type' => 'solid',
+                'bg_color' => 'rgba(15, 23, 42, 0.75)',
+                'accent_color_type' => 'gradient',
+                'accent_color' => 'rgba(56, 189, 248, 1)',
+                'accent_color_start' => '#38bdf8',
+                'accent_color_end' => '#f472b6',
+                'font_color_type' => 'solid',
+                'font_color' => 'rgba(226, 232, 240, 1)',
+                'font_hover_color_type' => 'solid',
+                'font_hover_color' => 'rgba(255, 255, 255, 1)',
+                'font_family' => 'google-roboto',
+                'font_weight' => '500',
+                'text_transform' => 'uppercase',
+                'letter_spacing' => ['value' => '0.12', 'unit' => 'em'],
+                'hover_effect_desktop' => 'glow',
+                'hover_effect_mobile' => 'glow',
+                'animation_type' => 'fade',
+                'mobile_bg_color' => 'rgba(15, 23, 42, 0.9)',
+                'mobile_bg_opacity' => 0.9,
+                'mobile_blur' => 18,
+                'border_radius' => ['value' => '32', 'unit' => 'px'],
+                'border_width' => 1,
+                'border_color' => 'rgba(148, 163, 184, 0.6)',
+            ],
+        ],
+    ];
+
     /**
      * Returns the default plugin settings.
      */
@@ -93,6 +232,12 @@ class DefaultSettings
             'social_orientation'=> 'horizontal',
             'social_position'   => 'footer',
             'social_icon_size'  => 100,
+            'style_presets'     => self::STYLE_PRESETS,
         ];
+    }
+
+    public function getStylePresets(): array
+    {
+        return self::STYLE_PRESETS;
     }
 }

--- a/sidebar-jlg/src/Settings/OptionChoices.php
+++ b/sidebar-jlg/src/Settings/OptionChoices.php
@@ -18,7 +18,7 @@ final class OptionChoices
         'header_logo_type' => ['text', 'image'],
         'header_alignment_desktop' => ['flex-start', 'center', 'flex-end'],
         'header_alignment_mobile' => ['flex-start', 'center', 'flex-end'],
-        'style_preset' => ['custom', 'moderne_dark'],
+        'style_preset' => ['custom', 'moderne_dark', 'minimal_light', 'retro_warm', 'glass_neon'],
         'bg_color_type' => ['solid', 'gradient'],
         'accent_color_type' => ['solid', 'gradient'],
         'font_color_type' => ['solid', 'gradient'],


### PR DESCRIPTION
## Summary
- define additional style presets with metadata and expose the new choices to the admin UI
- render a dynamic gallery of presets, allowing instant application of colors/typography/effects and refresh the preview
- add a preview compare control and styling for the preset cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e24e03baf0832eaac196601307ef1d