### PR TITLE
Handle CTA menu items in sanitizer

### DIFF
--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -514,11 +514,11 @@ class SettingsSanitizer
                     continue;
                 }
 
-                $allowedItemTypes = ['custom', 'post', 'page', 'category', 'nav_menu'];
+                $allowedItemTypes = ['custom', 'post', 'page', 'category', 'nav_menu', 'cta'];
                 $itemType = sanitize_key($item['type'] ?? '');
-                if (!in_array($itemType, $allowedItemTypes, true)) {
-                    $itemType = 'custom';
-                }
+                $normalizedItemType = in_array($itemType, $allowedItemTypes, true)
+                    ? $itemType
+                    : 'custom';
                 $iconType = sanitize_key($item['icon_type'] ?? '');
                 $iconType = ($iconType === 'svg_url') ? 'svg_url' : 'svg_inline';
 
@@ -561,7 +561,7 @@ class SettingsSanitizer
                     $existingItem = $existingMenuItems[$index];
                 }
 
-                switch ($itemType) {
+                switch ($normalizedItemType) {
                     case 'custom':
                         $rawValue = array_key_exists('value', $item) ? $item['value'] : ($existingItem['value'] ?? '');
                         $sanitizedItem['value'] = esc_url_raw($rawValue);
@@ -586,6 +586,29 @@ class SettingsSanitizer
 
                         $sanitizedItem['nav_menu_max_depth'] = $this->sanitizeNavMenuDepth($depthSource);
                         $sanitizedItem['nav_menu_filter'] = $this->sanitizeNavMenuFilter($filterSource);
+                        break;
+                    case 'cta':
+                        $ctaTitleSource = array_key_exists('cta_title', $item)
+                            ? $item['cta_title']
+                            : ($existingItem['cta_title'] ?? '');
+                        $ctaDescriptionSource = array_key_exists('cta_description', $item)
+                            ? $item['cta_description']
+                            : ($existingItem['cta_description'] ?? '');
+                        $ctaShortcodeSource = array_key_exists('cta_shortcode', $item)
+                            ? $item['cta_shortcode']
+                            : ($existingItem['cta_shortcode'] ?? '');
+                        $ctaButtonLabelSource = array_key_exists('cta_button_label', $item)
+                            ? $item['cta_button_label']
+                            : ($existingItem['cta_button_label'] ?? '');
+                        $ctaButtonUrlSource = array_key_exists('cta_button_url', $item)
+                            ? $item['cta_button_url']
+                            : ($existingItem['cta_button_url'] ?? '');
+
+                        $sanitizedItem['cta_title'] = sanitize_text_field($ctaTitleSource);
+                        $sanitizedItem['cta_description'] = wp_kses_post($ctaDescriptionSource);
+                        $sanitizedItem['cta_shortcode'] = wp_kses_post($ctaShortcodeSource);
+                        $sanitizedItem['cta_button_label'] = sanitize_text_field($ctaButtonLabelSource);
+                        $sanitizedItem['cta_button_url'] = esc_url_raw($ctaButtonUrlSource);
                         break;
                     case 'post':
                     case 'page':

--- a/tests/sanitize_cta_menu_item_test.php
+++ b/tests/sanitize_cta_menu_item_test.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Admin\SettingsSanitizer;
+use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\DefaultSettings;
+
+require __DIR__ . '/bootstrap.php';
+
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$defaults = new DefaultSettings();
+$icons = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
+$sanitizer = new SettingsSanitizer($defaults, $icons);
+
+$reflection = new ReflectionClass(SettingsSanitizer::class);
+$menuMethod = $reflection->getMethod('sanitize_menu_settings');
+$menuMethod->setAccessible(true);
+
+$existingOptions = $defaults->all();
+
+$input = [
+    'menu_items' => [
+        [
+            'type' => 'cta',
+            'label' => 'My CTA',
+            'icon_type' => 'svg_inline',
+            'cta_title' => 'Boostez vos ventes',
+            'cta_description' => '<p>Profitez de notre offre spéciale</p>',
+            'cta_button_label' => 'En savoir plus',
+            'cta_button_url' => 'https://example.com/offre',
+            'cta_shortcode' => '[special_offer]',
+        ],
+    ],
+];
+
+$result = $menuMethod->invoke($sanitizer, $input, $existingOptions);
+$ctaItem = $result['menu_items'][0] ?? [];
+
+$expectedFields = [
+    'type' => 'cta',
+    'cta_title' => 'Boostez vos ventes',
+    'cta_description' => '<p>Profitez de notre offre spéciale</p>',
+    'cta_button_label' => 'En savoir plus',
+    'cta_button_url' => 'https://example.com/offre',
+    'cta_shortcode' => '[special_offer]',
+];
+
+foreach ($expectedFields as $field => $expectedValue) {
+    if (($ctaItem[$field] ?? null) !== $expectedValue) {
+        echo "Expected CTA field '{$field}' to be " . var_export($expectedValue, true) . ", got " . var_export($ctaItem[$field] ?? null, true) . "\n";
+        exit(1);
+    }
+}
+
+exit(0);


### PR DESCRIPTION
## Summary
- allow CTA menu items to keep their type while normalizing behaviour
- sanitize CTA-specific fields when saving menu items
- cover CTA handling with a dedicated sanitizer test

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e27fd4548c832ebf700962a59e7d6f