### PR TITLE
Document cache improvement opportunities and add index test

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,38 @@
+# Audit des points d'amélioration
+
+Cette analyse met en évidence des fonctions dont l'implémentation pourrait être renforcée pour s'aligner sur les standards des applications professionnelles, ainsi qu'un plan de tests ciblant les zones les plus sensibles.
+
+## Fonctions prioritaires à améliorer
+
+### `Plugin::register`
+- **Constat :** la méthode invalide la totalité du cache et relance la revalidation des options à chaque chargement du plugin, y compris en frontal, avant d'enregistrer une grande quantité de hooks. Sur des installations importantes, cette séquence peut allonger le temps de réponse initial et déclencher des écritures concurrentes sur la base.【F:sidebar-jlg/src/Plugin.php†L69-L105】
+- **Piste pro :** déclencher `maybeInvalidateCacheOnVersionChange()` et `revalidateStoredOptions()` dans un hook dédié à l'activation ou à l'upgrade (`upgrader_process_complete`), puis différer l'enregistrement des hooks non critiques (`admin_notices`, revalidation) via `wp_lazy_loading_run` ou en les encapsulant derrière des garde-fous basés sur le contexte (front/admin). Cela aligne le comportement sur les plugins premium qui séparent net les opérations coûteuses du cycle de requête utilisateur.
+
+### `SidebarRenderer::buildDynamicStyles`
+- **Constat :** la génération du CSS inline concatène les variables à chaque requête sans mise en cache granulaire, alors que la transformation `STYLE_VARIABLE_MAP` parcourt systématiquement toutes les options.【F:sidebar-jlg/src/Frontend/SidebarRenderer.php†L341-L393】
+- **Piste pro :** pré-calculer les styles par profil et par jeu d'options (hash du tableau) avec stockage court-terme (`wp_cache_set`) et invalider ce cache uniquement lors d'une modification pertinente. Les solutions professionnelles ajoutent également un préfixe de scope (`.sidebar-jlg` au lieu de `:root`) pour éviter les collisions CSS et faciliter l'injection conditionnelle.
+
+### `SidebarRenderer::renderSidebarToHtml`
+- **Constat :** le rendu repose sur `require` direct du template et sur un simple log en cas de fichier manquant, sans gestion de surcharge par thème ni filet de sécurité autour du buffer (pas de `try/finally`).【F:sidebar-jlg/src/Frontend/SidebarRenderer.php†L762-L800】
+- **Piste pro :** exposer un filtre `apply_filters( 'sidebar_jlg_template_path', ... )`, supporter `locate_template()` pour permettre aux thèmes enfants de personnaliser la vue, et encapsuler la mise en tampon dans une structure `try { ... } finally { ob_end_clean(); }` afin de garantir la libération du buffer même en cas d'exception.
+
+### `SidebarRenderer::render`
+- **Constat :** la méthode écrit directement dans la sortie (`echo`) avant de retourner le HTML et repose sur un cache basé sur `transients`. Lorsqu'un filtre désactive le cache, l'index des locales est effacé de manière globale, ce qui peut invalider d'autres profils en parallèle.【F:sidebar-jlg/src/Frontend/SidebarRenderer.php†L802-L849】
+- **Piste pro :** renvoyer le HTML sans l'afficher (la vue pourrait gérer l'écho), utiliser un cache persistant (`wp_cache_get` avec groupe custom) ou une couche d'invalidation par profil, et remplacer l'appel à `forgetLocaleIndex()` par une suppression ciblée de l'entrée concernée pour éviter les effets de bord.
+
+### `SettingsRepository::getOptionsWithRevalidation`
+- **Constat :** en frontal, chaque appel peut déclencher `update_option('sidebar_jlg_settings', ...)` lorsqu'une revalidation ajuste une valeur, même si la requête est anonyme. Cela multiplie les écritures concurrentes sur la table `wp_options` et peut créer des contentions sur des sites à fort trafic.【F:sidebar-jlg/src/Settings/SettingsRepository.php†L118-L135】
+- **Piste pro :** déplacer la revalidation vers des jobs différés (`wp_schedule_single_event`) ou vers l'administration, et ne sauver que si la requête est authentifiée ou provient d'un contexte de maintenance. Les plugins professionnels s'appuient sur des verrous (`update_option` conditionnel, transients de verrouillage) pour éviter les races.
+
+### `MenuCache`
+- **Constat :** l'index des locales est stocké dans une option globale et effacé en bloc lors d'un simple `clear()`, ce qui peut supprimer des caches valides pour d'autres profils. Par ailleurs, aucun mécanisme de surveillance des transients expirés n'est présent pour nettoyer l'index automatiquement.【F:sidebar-jlg/src/Cache/MenuCache.php†L66-L172】
+- **Piste pro :** stocker l'index dans un objet de cache persistant (groupe `sidebar_jlg`) ou utiliser un schéma `locale => [profile => key]` permettant de supprimer finement une seule entrée. Ajouter un cron de maintenance qui purge l'index des combinaisons expirées rapproche le fonctionnement des solutions professionnelles.
+
+## Plan de débogage et tests recommandés
+
+1. **`tests/menu_cache_index_management_test.php` (nouveau)** – Vérifie la déduplication de l'index des locales et la bonne suppression des transients lors d'un `clear()`. Ce test met en évidence les risques d'effacement global du cache et sert de base pour les futures optimisations de ciblage.【F:tests/menu_cache_index_management_test.php†L1-L86】
+2. **`tests/sidebar_profile_cache_isolation_test.php`** – À relancer après toute modification du cache pour s'assurer que les profils restent isolés dans leurs transients et que l'index ne fuit pas entre profils.【F:tests/sidebar_profile_cache_isolation_test.php†L1-L120】
+3. **`tests/render_sidebar_active_state_test.php`** – Garantit que les scénarios dynamiques (page, article, catégorie, URL) continuent à désactiver la mise en cache. Utile pour vérifier les ajustements de `is_sidebar_output_dynamic()` lors de l'ajout de nouveaux cas (shortcodes, CTA dynamiques, etc.).【F:tests/render_sidebar_active_state_test.php†L1-L165】
+4. **Tests manuels** – Activer le mode debug de WordPress (`WP_DEBUG`) puis naviguer sur un environnement de préproduction en surveillant le temps de réponse et le nombre de requêtes SQL pendant l'initialisation du plugin. Comparer les mesures avant/après implémentation des pistes précédentes pour valider le gain de performances.
+
+Ces recommandations fournissent une feuille de route pour rapprocher le plugin des standards observés dans les produits professionnels tout en sécurisant les évolutions grâce à une couverture de tests ciblée.

--- a/tests/menu_cache_index_management_test.php
+++ b/tests/menu_cache_index_management_test.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Cache\MenuCache;
+
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$cache = new MenuCache();
+
+$GLOBALS['wp_test_options'] = [];
+$GLOBALS['wp_test_transients'] = [];
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    $testsPassed = false;
+    echo "[FAIL] {$message}\n";
+}
+
+function assertSame($expected, $actual, string $message): void
+{
+    if ($expected === $actual) {
+        assertTrue(true, $message);
+
+        return;
+    }
+
+    $expectedJson = json_encode($expected, JSON_PRETTY_PRINT);
+    $actualJson = json_encode($actual, JSON_PRETTY_PRINT);
+    assertTrue(false, $message . "\nExpected: {$expectedJson}\nActual: {$actualJson}");
+}
+
+// Populate the cache with repeated writes to ensure locale index deduplicates entries.
+$cache->set('fr_FR', '<div>First FR</div>', 'profile-a');
+$cache->set('fr_FR', '<div>Second FR</div>', 'profile-a');
+$cache->set('en_US', '<div>EN default</div>');
+$cache->set('en_US', '<div>EN profile B</div>', 'profile-b');
+$cache->set('en_US', '<div>EN profile B update</div>', 'profile-b');
+
+$expectedLocales = [
+    ['locale' => 'fr_FR', 'suffix' => 'profile-a'],
+    ['locale' => 'en_US', 'suffix' => null],
+    ['locale' => 'en_US', 'suffix' => 'profile-b'],
+];
+
+assertSame($expectedLocales, $cache->getCachedLocales(), 'Locale index deduplicates entries across repeated cache writes.');
+
+// Ensure clear() removes all stored transients and the locale option.
+$legacyKey = 'sidebar_jlg_full_html';
+set_transient($legacyKey, '<div>legacy</div>', 3600);
+
+$frKey = $cache->getTransientKey('fr_FR', 'profile-a');
+$enDefaultKey = $cache->getTransientKey('en_US', null);
+$enProfileKey = $cache->getTransientKey('en_US', 'profile-b');
+
+assertTrue(isset($GLOBALS['wp_test_transients'][$frKey]), 'FR cached HTML stored.');
+assertTrue(isset($GLOBALS['wp_test_transients'][$enDefaultKey]), 'EN default cached HTML stored.');
+assertTrue(isset($GLOBALS['wp_test_transients'][$enProfileKey]), 'EN profile cached HTML stored.');
+assertTrue(isset($GLOBALS['wp_test_transients'][$legacyKey]), 'Legacy cached HTML stored.');
+assertTrue(get_option('sidebar_jlg_cached_locales') !== [], 'Locale index option stored before clearing.');
+
+$cache->clear();
+
+assertTrue(!isset($GLOBALS['wp_test_transients'][$frKey]), 'FR cached HTML cleared.');
+assertTrue(!isset($GLOBALS['wp_test_transients'][$enDefaultKey]), 'EN default cached HTML cleared.');
+assertTrue(!isset($GLOBALS['wp_test_transients'][$enProfileKey]), 'EN profile cached HTML cleared.');
+assertTrue(!isset($GLOBALS['wp_test_transients'][$legacyKey]), 'Legacy cached HTML cleared.');
+assertSame([], get_option('sidebar_jlg_cached_locales', []), 'Locale index option removed on cache clear.');
+
+if ($testsPassed) {
+    echo "Menu cache index management tests passed.\n";
+    exit(0);
+}
+
+echo "Menu cache index management tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- document priority functions to improve and recommended debug checks in a new audit note
- add a regression-style test ensuring the menu cache index deduplicates entries and clears transients

## Testing
- php tests/menu_cache_index_management_test.php
- php tests/sidebar_profile_cache_isolation_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e2cb9e6560832e910fe01da9170b54