### PR TITLE
Adjust textdomain loading timing

### DIFF
--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -76,7 +76,7 @@ class Plugin
 
         add_filter('sanitize_option_sidebar_jlg_profiles', [$this->sanitizer, 'sanitize_profiles'], 10, 2);
         add_filter('sanitize_option_sidebar_jlg_active_profile', [$this->sanitizer, 'sanitize_active_profile'], 10, 2);
-        add_action('plugins_loaded', [$this, 'loadTextdomain']);
+        add_action('init', [$this, 'loadTextdomain']);
         add_action('admin_notices', [$this, 'renderActivationErrorNotice']);
         add_action('update_option_sidebar_jlg_settings', [$this, 'handleSettingsUpdated'], 10, 3);
         add_action('add_option_sidebar_jlg_profiles', [$this, 'handleProfilesOptionChanged'], 10, 2);


### PR DESCRIPTION
## Summary
- ensure the plugin loads its translations on the `init` hook instead of `plugins_loaded`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2dd5f9ec0832e8b7e97d93ec18dca