### PR TITLE
Fix icon library AJAX URL

### DIFF
--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -141,7 +141,7 @@ class MenuPage
         ];
 
         wp_localize_script('sidebar-jlg-admin-js', 'sidebarJLG', [
-            'ajax_url' => admin_url('admin-ajax.php'),
+            'ajax_url' => admin_url('admin-ajax.php', 'relative'),
             'nonce' => wp_create_nonce('jlg_ajax_nonce'),
             'reset_nonce' => wp_create_nonce('jlg_reset_nonce'),
             'tools_nonce' => wp_create_nonce('jlg_tools_nonce'),


### PR DESCRIPTION
## Summary
- load the admin AJAX endpoint via a relative URL so the icon library works regardless of scheme mismatches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e1c4f738832eb982545dc05be3fb