### PR TITLE
Fix RangeControl props to avoid Gutenberg deprecation warnings

### DIFF
--- a/sidebar-jlg/assets/js/admin-script.js
+++ b/sidebar-jlg/assets/js/admin-script.js
@@ -2572,6 +2572,8 @@ jQuery(document).ready(function($) {
                     max: safeMax,
                     step: safeStep,
                     help: feedback || helpText,
+                    __next40pxDefaultSize: true,
+                    __nextHasNoMarginBottom: true,
                 });
             };
 


### PR DESCRIPTION
## Summary
- opt into the new Gutenberg RangeControl sizing and margin defaults to silence console deprecation warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e8f2d800832eab3720746b53a2a4