### PR TITLE
Improve request context caching and tighten front-end accessibility

### DIFF
--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -145,11 +145,11 @@ $renderMenuNodes = static function (array $nodes, string $layout) use (&$renderM
                     <?php endif; ?>
 
                     <?php if ($ctaDescription !== '') : ?>
-                        <div class="menu-cta__description"><?php echo $ctaDescription; ?></div>
+                        <div class="menu-cta__description"><?php echo wp_kses_post($ctaDescription); ?></div>
                     <?php endif; ?>
 
                     <?php if ($ctaShortcode !== '') : ?>
-                        <div class="menu-cta__shortcode"><?php echo $ctaShortcode; ?></div>
+                        <div class="menu-cta__shortcode"><?php echo wp_kses_post($ctaShortcode); ?></div>
                     <?php endif; ?>
 
                     <?php if ($ctaButtonLabel !== '') : ?>
@@ -182,7 +182,7 @@ $renderMenuNodes = static function (array $nodes, string $layout) use (&$renderM
                 if (is_array($icon)) {
                     if (($icon['type'] ?? '') === 'svg_url' && !empty($icon['url'])) {
                         ?>
-                        <span class="menu-icon svg-icon"><img src="<?php echo esc_url($icon['url']); ?>" alt=""></span>
+                        <span class="menu-icon svg-icon"><img src="<?php echo esc_url($icon['url']); ?>" alt="" loading="lazy" decoding="async"></span>
                         <?php
                     } elseif (($icon['type'] ?? '') === 'svg_inline' && !empty($icon['markup'])) {
                         $iconClass = ($icon['is_custom'] ?? false) ? 'menu-icon svg-icon' : 'menu-icon';
@@ -269,7 +269,7 @@ if ($options['social_position'] === 'footer' && !empty($options['social_icons'])
 
 $sidebar_content_html = ob_get_clean();
 ?>
-<div class="sidebar-overlay" id="sidebar-overlay"></div>
+<div class="sidebar-overlay" id="sidebar-overlay" aria-hidden="true" tabindex="-1"></div>
 
 <?php
     $hamburger_open_label  = esc_attr__( 'Ouvrir le menu', 'sidebar-jlg' );
@@ -311,7 +311,7 @@ $horizontalAlignment = $options['horizontal_bar_alignment'] ?? 'space-between';
     <div class="sidebar-inner">
         <div class="sidebar-header">
         <?php if ($options['header_logo_type'] === 'image' && !empty($options['header_logo_image'])): ?>
-            <img src="<?php echo esc_url($options['header_logo_image']); ?>" alt="<?php echo esc_attr(get_bloginfo('name')); ?>" class="sidebar-logo-image">
+            <img src="<?php echo esc_url($options['header_logo_image']); ?>" alt="<?php echo esc_attr(get_bloginfo('name')); ?>" class="sidebar-logo-image" loading="lazy" decoding="async">
         <?php else: ?>
             <span class="logo-text"><?php echo esc_html($options['app_name']); ?></span>
         <?php endif; ?>

--- a/sidebar-jlg/src/Frontend/RequestContextResolver.php
+++ b/sidebar-jlg/src/Frontend/RequestContextResolver.php
@@ -4,8 +4,14 @@ namespace JLG\Sidebar\Frontend;
 
 class RequestContextResolver
 {
+    private ?array $cachedContext = null;
+
     public function resolve(): array
     {
+        if ($this->cachedContext !== null) {
+            return $this->cachedContext;
+        }
+
         $postContext = $this->resolvePostContext();
         $userContext = $this->resolveUserContext();
 
@@ -15,9 +21,18 @@ class RequestContextResolver
             $normalizedUrl = $this->normalizeUrlForComparison($currentUrl);
         }
 
-        return $postContext + $userContext + [
+        $context = $postContext + $userContext + [
             'current_url' => $normalizedUrl,
         ];
+
+        $this->cachedContext = $context;
+
+        return $context;
+    }
+
+    public function resetCachedContext(): void
+    {
+        $this->cachedContext = null;
     }
 
     public function normalizeUrlForComparison(?string $url): string

--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -93,6 +93,7 @@ class Plugin
         $this->renderer->registerHooks();
         $this->ajax->registerHooks();
         $this->searchBlock->registerHooks();
+        $this->registerContextInvalidationHooks();
 
         $contentChangeHooks = [
             'save_post',
@@ -180,6 +181,24 @@ class Plugin
     {
         $this->cache->clear();
         $this->cache->forgetLocaleIndex();
+    }
+
+    private function registerContextInvalidationHooks(): void
+    {
+        $hooks = [
+            'set_current_user',
+            'wp_set_current_user',
+            'switch_blog',
+            'switch_locale',
+            'restore_previous_locale',
+            'clean_post_cache',
+            'clean_object_term_cache',
+            'clean_term_cache',
+        ];
+
+        foreach ($hooks as $hook) {
+            add_action($hook, [$this->requestContextResolver, 'resetCachedContext'], 10, 0);
+        }
     }
 
     public function getDefaultSettings(): array

--- a/tests/request_context_caching_test.php
+++ b/tests/request_context_caching_test.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Frontend\RequestContextResolver;
+
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$testsPassed = true;
+
+function request_context_assert(bool $condition, string $message): void
+{
+    global $testsPassed;
+
+    if ($condition) {
+        echo "[PASS] {$message}\n";
+
+        return;
+    }
+
+    echo "[FAIL] {$message}\n";
+    $testsPassed = false;
+}
+
+$originalDetermineOverride = $GLOBALS['wp_test_function_overrides']['determine_locale'] ?? null;
+$determineCalls = 0;
+$GLOBALS['wp_test_function_overrides']['determine_locale'] = static function () use (&$determineCalls) {
+    $determineCalls++;
+
+    return 'fr_FR';
+};
+
+$resolver = new RequestContextResolver();
+
+$context = $resolver->resolve();
+request_context_assert(is_array($context), 'Resolver returns an array');
+
+$resolver->resolve();
+request_context_assert($determineCalls === 1, 'Cached context prevents duplicate locale resolution');
+
+$resolver->resetCachedContext();
+$GLOBALS['wp_test_function_overrides']['determine_locale'] = static function () use (&$determineCalls) {
+    $determineCalls++;
+
+    return 'en_US';
+};
+
+$contextAfterReset = $resolver->resolve();
+request_context_assert($determineCalls === 2, 'Resetting the cache triggers a fresh resolution');
+request_context_assert(($contextAfterReset['language'] ?? null) === 'en_us', 'Language reflects the refreshed locale');
+
+if ($originalDetermineOverride !== null) {
+    $GLOBALS['wp_test_function_overrides']['determine_locale'] = $originalDetermineOverride;
+} else {
+    unset($GLOBALS['wp_test_function_overrides']['determine_locale']);
+}
+
+if ($testsPassed) {
+    echo "Request context caching tests passed.\n";
+    exit(0);
+}
+
+echo "Request context caching tests failed.\n";
+exit(1);


### PR DESCRIPTION
## Summary
- cache the resolved request context per request and provide a reset helper to avoid redundant resolver work
- clear the cached context when WordPress switches users, blogs, or locales so runtime targeting stays accurate
- harden CTA markup sanitization, lazily load menu/header imagery, and hide the overlay from assistive tech for better UX
- add a regression test that exercises the resolver cache and reset flow

## Testing
- composer test
- php tests/request_context_caching_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e357279e80832e9e3ec97d258d8a25