### PR TITLE
Add analytics insights module and tracking infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ Une extension WordPress qui fournit une sidebar animée et entièrement personna
 
 - Cache HTML des rendus de sidebar, segmenté par locale et suffixe de profil, avec invalidation automatique lors des mises à jour de contenu, menus, icônes ou version du plugin. 
 - Normalisation et sanitation poussée de tous les réglages (couleurs, dimensions, opacités, champs texte) pour éviter les injections et assurer la cohérence des données. 
-- Gestion des erreurs lors des téléversements d'icônes (journalisation, notices administrateur, rollback) pour que les incidents n'altèrent pas l'expérience de vos utilisateurs. 
+- Gestion des erreurs lors des téléversements d'icônes (journalisation, notices administrateur, rollback) pour que les incidents n'altèrent pas l'expérience de vos utilisateurs.
+
+### Insights & Analytics
+
+- Tableau de bord dédié dans l’administration (« Insights & Analytics ») pour suivre les ouvertures, clics de navigation et conversions CTA.
+- Répartition par profil actif et historique des sept derniers jours afin de comparer rapidement les campagnes contextuelles.
+- Collecte optionnelle activable dans l’onglet Général pour respecter les environnements sensibles aux métriques.
 
 ## Installation
 
@@ -118,7 +124,7 @@ Les constructeurs professionnels (Elementor Pro, JetMenu, Max Mega Menu, Convert
 | **Gestion des icônes/SVG** | Manifest versionné, sanitation stricte, notifications | Upload simple, rarement audité ou mutualisé |
 | **Éditeur visuel** | Formulaire administrateur + prévisualisation AJAX | Constructeurs WYSIWYG temps réel, drag & drop |
 | **Bibliothèque de widgets** | Menu, recherche, icônes sociales | CTA, formulaires, sliders, intégrations CRM/marketing |
-| **Analytique** | Absente | Tableaux de bord intégrés (taux d'ouverture, conversions) |
+| **Analytique** | Module Insights (ouvertures, clics, CTA) | Tableaux de bord intégrés (taux d'ouverture, conversions) |
 | **Personnalisation dynamique** | Profils basés sur contexte WordPress | Déclencheurs comportementaux (scroll depth, sortie, A/B testing) |
 | **Qualité & CI** | Tests unitaires PHP/JS, pas d'E2E ni de CI prête à l'emploi | Pipelines CI/CD, tests visuels, linting complet |
 
@@ -127,12 +133,13 @@ Sidebar JLG se démarque actuellement par :
 - **Une intégration WordPress native** : réglages, profils ciblés et bloc Gutenberg limitent les ruptures d'expérience avec l'écosystème WordPress.
 - **Un ciblage contextuel fin** : résolution de contexte unifiée, hiérarchie de profils et règles temporelles dignes d'offres haut de gamme.
 - **Une gouvernance des actifs SVG** stricte : validation, journalisation et notifications réduisent fortement les risques de sécurité.
+- **Un module Insights embarqué** : collecte activable et tableau de bord mettent en lumière les ouvertures, clics et conversions CTA sans quitter l’interface WordPress.
 
 Pour atteindre (voire dépasser) le niveau de finition des meilleures suites professionnelles, les axes suivants sont recommandés :
 
 1. **Éditeur visuel temps réel** : proposer un mode WYSIWYG drag & drop (à la manière d'Elementor ou de Max Mega Menu Pro) permettant de modifier la structure et les contenus directement sur la page visitée.
 2. **Bibliothèque de composants** : ajouter des modules prêts à l'emploi (CTA, formulaires, flux sociaux, intégrations WooCommerce) avec styles cohérents, états de hover/focus et options de tracking.
-3. **Analyse et personnalisation dynamique** : exposer des métriques d'engagement (taux d'ouverture, clics) et des déclencheurs conditionnels (scroll depth, temps passé, détection d'intention de sortie) pour rivaliser avec des solutions comme ConvertBox ou OptinMonster.
+3. **Analyse et personnalisation dynamique** : enrichir le module Insights avec des déclencheurs conditionnels (scroll depth, temps passé, intention de sortie) et des scénarios A/B pour atteindre le niveau des suites comme ConvertBox ou OptinMonster.
 4. **Internationalisation avancée** : intégrer automatiquement les traductions via WPML/Polylang, synchroniser les profils linguistiques et permettre la duplication rapide d'un profil dans une autre langue.
 5. **Automatisation qualité** : fournir des commandes de tests E2E (Playwright/Cypress), un pipeline CI (GitHub Actions) et des préconfigurations de linting (PHP_CodeSniffer, ESLint, Stylelint) pour sécuriser les contributions open source.
 6. **Accessibilité renforcée** : ajouter une grille d'audit automatique (axe DevTools Lighthouse, tests pa11y) et documenter les cas d'usage pour les lecteurs d'écran afin de se placer au niveau des offres labellisées ADA/WCAG.

--- a/sidebar-jlg/sidebar-jlg.php
+++ b/sidebar-jlg/sidebar-jlg.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Sidebar - JLG
  * Description:       Une sidebar professionnelle, animée et entièrement personnalisable pour votre site WordPress.
- * Version:           4.9.2
+ * Version:           4.10.0
  * Author:            Jérôme Le Gousse
  * Author URI:        https://example.com
  * License:           GPL v2 or later
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'SIDEBAR_JLG_VERSION' ) ) {
-    define( 'SIDEBAR_JLG_VERSION', '4.9.2' );
+    define( 'SIDEBAR_JLG_VERSION', '4.10.0' );
 }
 
 require_once __DIR__ . '/autoload.php';

--- a/sidebar-jlg/src/Admin/MenuPage.php
+++ b/sidebar-jlg/src/Admin/MenuPage.php
@@ -3,6 +3,7 @@
 namespace JLG\Sidebar\Admin;
 
 use JLG\Sidebar\Admin\View\ColorPickerField;
+use JLG\Sidebar\Analytics\AnalyticsRepository;
 use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\SettingsRepository;
 
@@ -12,6 +13,7 @@ class MenuPage
     private SettingsSanitizer $sanitizer;
     private IconLibrary $icons;
     private ColorPickerField $colorPicker;
+    private AnalyticsRepository $analytics;
     private string $pluginFile;
     private string $version;
 
@@ -20,6 +22,7 @@ class MenuPage
         SettingsSanitizer $sanitizer,
         IconLibrary $icons,
         ColorPickerField $colorPicker,
+        AnalyticsRepository $analytics,
         string $pluginFile,
         string $version
     ) {
@@ -27,6 +30,7 @@ class MenuPage
         $this->sanitizer = $sanitizer;
         $this->icons = $icons;
         $this->colorPicker = $colorPicker;
+        $this->analytics = $analytics;
         $this->pluginFile = $pluginFile;
         $this->version = $version;
     }
@@ -237,6 +241,7 @@ class MenuPage
         $stylePresets = $defaults['style_presets'] ?? [];
         $options = $this->settings->getOptionsWithRevalidation();
         $allIcons = $this->icons->getAllIcons();
+        $analyticsSummary = $this->analytics->getSummary();
 
         require plugin_dir_path($this->pluginFile) . 'includes/admin-page.php';
     }

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -165,6 +165,7 @@ class SettingsSanitizer
         $defaults = $this->defaults->all();
 
         $sanitized['enable_sidebar'] = !empty($input['enable_sidebar']);
+        $sanitized['enable_analytics'] = !empty($input['enable_analytics']);
         $sanitized['layout_style'] = $this->sanitizeChoice(
             $input['layout_style'] ?? null,
             $this->allowedChoices['layout_style'],

--- a/sidebar-jlg/src/Analytics/AnalyticsRepository.php
+++ b/sidebar-jlg/src/Analytics/AnalyticsRepository.php
@@ -1,0 +1,441 @@
+<?php
+
+namespace JLG\Sidebar\Analytics;
+
+use function arsort;
+use function array_slice;
+use function count;
+use function get_option;
+use function gmdate;
+use function in_array;
+use function is_array;
+use function is_numeric;
+use function ksort;
+use function max;
+use function preg_match;
+use function preg_replace;
+use function sanitize_key;
+use function sanitize_text_field;
+use function strtolower;
+use function substr;
+use function time;
+use function trim;
+use function update_option;
+
+class AnalyticsRepository
+{
+    private const OPTION_NAME = 'sidebar_jlg_analytics';
+    private const MAX_DAILY_BUCKETS = 30;
+
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_EVENTS = [
+        'sidebar_open',
+        'menu_link_click',
+        'cta_view',
+        'cta_click',
+    ];
+
+    /**
+     * Returns the list of supported analytics event identifiers.
+     *
+     * @return string[]
+     */
+    public function getSupportedEvents(): array
+    {
+        return self::ALLOWED_EVENTS;
+    }
+
+    /**
+     * Returns a normalized snapshot of the analytics option.
+     *
+     * @return array{
+     *     totals: array<string, int>,
+     *     daily: array<string, array<string, int>>,
+     *     profiles: array<string, array{label: string, is_fallback: bool, totals: array<string, int>}>,
+     *     targets: array<string, array<string, int>>,
+     *     last_event_at: ?string,
+     *     last_event_type: ?string
+     * }
+     */
+    public function getSummary(): array
+    {
+        $data = $this->readOption();
+
+        return $this->buildSummaryFromData($data);
+    }
+
+    /**
+     * Records an analytics event and returns the updated summary payload.
+     *
+     * @param array<string, mixed> $context
+     *
+     * @return array{
+     *     totals: array<string, int>,
+     *     daily: array<string, array<string, int>>,
+     *     profiles: array<string, array{label: string, is_fallback: bool, totals: array<string, int>}>,
+     *     targets: array<string, array<string, int>>,
+     *     last_event_at: ?string,
+     *     last_event_type: ?string
+     * }
+     */
+    public function recordEvent(string $event, array $context = []): array
+    {
+        $normalizedEvent = $this->normalizeEventKey($event);
+
+        if ($normalizedEvent === null) {
+            return $this->getSummary();
+        }
+
+        $data = $this->readOption();
+
+        $totals = $this->normalizeTotals($data['totals'] ?? []);
+        $totals[$normalizedEvent] = ($totals[$normalizedEvent] ?? 0) + 1;
+        $data['totals'] = $totals;
+
+        $timestamp = $this->resolveTimestamp();
+        $dateKey = gmdate('Y-m-d', $timestamp);
+
+        $daily = $this->normalizeDaily($data['daily'] ?? []);
+        if (!isset($daily[$dateKey])) {
+            $daily[$dateKey] = $this->getEmptyEventCounts();
+        }
+        $daily[$dateKey][$normalizedEvent] = ($daily[$dateKey][$normalizedEvent] ?? 0) + 1;
+        ksort($daily);
+        if (count($daily) > self::MAX_DAILY_BUCKETS) {
+            $daily = array_slice($daily, -self::MAX_DAILY_BUCKETS, null, true);
+        }
+        $data['daily'] = $daily;
+
+        $profiles = $this->normalizeProfiles($data['profiles'] ?? []);
+        $profileId = $this->sanitizeProfileId($context['profile_id'] ?? '');
+        $profileLabel = isset($context['profile_label']) ? $this->sanitizeLabel($context['profile_label']) : '';
+        $isFallback = !empty($context['is_fallback_profile']);
+
+        if ($profileId !== '') {
+            if (!isset($profiles[$profileId])) {
+                $profiles[$profileId] = [
+                    'label' => $profileLabel,
+                    'is_fallback' => $isFallback,
+                    'totals' => $this->getEmptyEventCounts(),
+                ];
+            }
+
+            if ($profileLabel !== '') {
+                $profiles[$profileId]['label'] = $profileLabel;
+            }
+
+            if ($isFallback) {
+                $profiles[$profileId]['is_fallback'] = true;
+            }
+
+            $profiles[$profileId]['totals'][$normalizedEvent] = ($profiles[$profileId]['totals'][$normalizedEvent] ?? 0) + 1;
+            $data['profiles'] = $profiles;
+        }
+
+        $target = $this->sanitizeTarget($context['target'] ?? null);
+        if ($target !== null) {
+            $targets = $this->normalizeTargets($data['targets'] ?? []);
+            if (!isset($targets[$normalizedEvent])) {
+                $targets[$normalizedEvent] = [];
+            }
+
+            $targets[$normalizedEvent][$target] = ($targets[$normalizedEvent][$target] ?? 0) + 1;
+            arsort($targets[$normalizedEvent]);
+            if (count($targets[$normalizedEvent]) > 10) {
+                $targets[$normalizedEvent] = array_slice($targets[$normalizedEvent], 0, 10, true);
+            }
+            $data['targets'] = $targets;
+        }
+
+        $data['last_event_at'] = gmdate('c', $timestamp);
+        $data['last_event_type'] = $normalizedEvent;
+
+        update_option(self::OPTION_NAME, $data);
+
+        return $this->buildSummaryFromData($data);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readOption(): array
+    {
+        $option = get_option(self::OPTION_NAME, []);
+
+        return is_array($option) ? $option : [];
+    }
+
+    private function resolveTimestamp(): int
+    {
+        $namespacedFunction = __NAMESPACE__ . '\\current_time';
+        if (function_exists($namespacedFunction)) {
+            $timestamp = $namespacedFunction('timestamp', true);
+            if (is_numeric($timestamp)) {
+                return (int) $timestamp;
+            }
+        }
+
+        if (function_exists('current_time')) {
+            $timestamp = current_time('timestamp', true);
+            if (is_numeric($timestamp)) {
+                return (int) $timestamp;
+            }
+        }
+
+        return time();
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getEmptyEventCounts(): array
+    {
+        $counts = [];
+        foreach (self::ALLOWED_EVENTS as $eventKey) {
+            $counts[$eventKey] = 0;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param mixed $totals
+     *
+     * @return array<string, int>
+     */
+    private function normalizeTotals($totals): array
+    {
+        $normalized = $this->getEmptyEventCounts();
+
+        if (!is_array($totals)) {
+            return $normalized;
+        }
+
+        foreach ($normalized as $eventKey => $defaultValue) {
+            if (isset($totals[$eventKey]) && is_numeric($totals[$eventKey])) {
+                $normalized[$eventKey] = max(0, (int) $totals[$eventKey]);
+            } else {
+                $normalized[$eventKey] = $defaultValue;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param mixed $daily
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function normalizeDaily($daily): array
+    {
+        if (!is_array($daily)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($daily as $date => $counts) {
+            $dateKey = $this->sanitizeDateKey($date);
+            if ($dateKey === null) {
+                continue;
+            }
+
+            $normalized[$dateKey] = $this->normalizeTotals($counts);
+        }
+
+        ksort($normalized);
+        if (count($normalized) > self::MAX_DAILY_BUCKETS) {
+            $normalized = array_slice($normalized, -self::MAX_DAILY_BUCKETS, null, true);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param mixed $profiles
+     *
+     * @return array<string, array{label: string, is_fallback: bool, totals: array<string, int>}>
+     */
+    private function normalizeProfiles($profiles): array
+    {
+        if (!is_array($profiles)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($profiles as $profileId => $profileData) {
+            $id = $this->sanitizeProfileId($profileId);
+            if ($id === '') {
+                continue;
+            }
+
+            $label = '';
+            if (is_array($profileData) && isset($profileData['label'])) {
+                $label = $this->sanitizeLabel($profileData['label']);
+            }
+
+            $isFallback = false;
+            if (is_array($profileData) && !empty($profileData['is_fallback'])) {
+                $isFallback = true;
+            }
+
+            $totals = [];
+            if (is_array($profileData) && isset($profileData['totals'])) {
+                $totals = $this->normalizeTotals($profileData['totals']);
+            } else {
+                $totals = $this->getEmptyEventCounts();
+            }
+
+            $normalized[$id] = [
+                'label' => $label,
+                'is_fallback' => $isFallback,
+                'totals' => $totals,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param mixed $targets
+     *
+     * @return array<string, array<string, int>>
+     */
+    private function normalizeTargets($targets): array
+    {
+        if (!is_array($targets)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($targets as $eventKey => $distribution) {
+            $normalizedEvent = $this->normalizeEventKey($eventKey);
+            if ($normalizedEvent === null || !is_array($distribution)) {
+                continue;
+            }
+
+            $normalized[$normalizedEvent] = [];
+            foreach ($distribution as $targetKey => $count) {
+                $target = $this->sanitizeTarget($targetKey);
+                if ($target === null) {
+                    continue;
+                }
+
+                $normalized[$normalizedEvent][$target] = max(0, (int) $count);
+            }
+
+            if ($normalized[$normalizedEvent] !== []) {
+                arsort($normalized[$normalizedEvent]);
+                if (count($normalized[$normalizedEvent]) > 10) {
+                    $normalized[$normalizedEvent] = array_slice($normalized[$normalizedEvent], 0, 10, true);
+                }
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function sanitizeDateKey($date): ?string
+    {
+        if (!is_string($date)) {
+            return null;
+        }
+
+        $trimmed = trim($date);
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $trimmed)) {
+            return null;
+        }
+
+        return $trimmed;
+    }
+
+    private function sanitizeProfileId($profileId): string
+    {
+        if (!is_string($profileId)) {
+            return '';
+        }
+
+        $normalized = sanitize_key($profileId);
+
+        return $normalized;
+    }
+
+    private function sanitizeLabel($label): string
+    {
+        if (!is_string($label)) {
+            return '';
+        }
+
+        return sanitize_text_field($label);
+    }
+
+    private function sanitizeTarget($target): ?string
+    {
+        if (!is_string($target)) {
+            return null;
+        }
+
+        $normalized = sanitize_key($target);
+        if ($normalized === '') {
+            $normalized = preg_replace('/[^a-z0-9\-]+/i', '_', strtolower($target));
+            $normalized = trim((string) $normalized, '_-');
+        }
+
+        if ($normalized === '' || $normalized === null) {
+            return null;
+        }
+
+        return substr((string) $normalized, 0, 48);
+    }
+
+    private function normalizeDateTime($value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function normalizeEventKey($event): ?string
+    {
+        if (!is_string($event)) {
+            return null;
+        }
+
+        $normalized = sanitize_key($event);
+
+        return in_array($normalized, self::ALLOWED_EVENTS, true) ? $normalized : null;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array{
+     *     totals: array<string, int>,
+     *     daily: array<string, array<string, int>>,
+     *     profiles: array<string, array{label: string, is_fallback: bool, totals: array<string, int>}>,
+     *     targets: array<string, array<string, int>>,
+     *     last_event_at: ?string,
+     *     last_event_type: ?string
+     * }
+     */
+    private function buildSummaryFromData(array $data): array
+    {
+        return [
+            'totals' => $this->normalizeTotals($data['totals'] ?? []),
+            'daily' => $this->normalizeDaily($data['daily'] ?? []),
+            'profiles' => $this->normalizeProfiles($data['profiles'] ?? []),
+            'targets' => $this->normalizeTargets($data['targets'] ?? []),
+            'last_event_at' => $this->normalizeDateTime($data['last_event_at'] ?? null),
+            'last_event_type' => $this->normalizeEventKey($data['last_event_type'] ?? ''),
+        ];
+    }
+}

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -7,6 +7,8 @@ use JLG\Sidebar\Icons\IconLibrary;
 use JLG\Sidebar\Settings\SettingsRepository;
 use JLG\Sidebar\Settings\ValueNormalizer;
 use JLG\Sidebar\Settings\TypographyOptions;
+use function admin_url;
+use function wp_create_nonce;
 
 class SidebarRenderer
 {
@@ -339,6 +341,20 @@ class SidebarRenderer
                 'missingElements' => __('Sidebar JLG : menu introuvable.', 'sidebar-jlg'),
             ],
         ];
+
+        $analyticsConfig = [
+            'enabled' => !empty($options['enable_analytics']),
+        ];
+
+        if (!empty($options['enable_analytics'])) {
+            $analyticsConfig['endpoint'] = admin_url('admin-ajax.php');
+            $analyticsConfig['nonce'] = wp_create_nonce('jlg_track_event');
+            $analyticsConfig['action'] = 'jlg_track_event';
+            $analyticsConfig['profile_id'] = $localizedOptions['active_profile_id'];
+            $analyticsConfig['profile_is_fallback'] = $localizedOptions['is_fallback_profile'];
+        }
+
+        $localizedOptions['analytics'] = $analyticsConfig;
 
         wp_localize_script('sidebar-jlg-public-js', 'sidebarSettings', $localizedOptions);
     }

--- a/sidebar-jlg/src/Plugin.php
+++ b/sidebar-jlg/src/Plugin.php
@@ -5,6 +5,7 @@ namespace JLG\Sidebar;
 use JLG\Sidebar\Admin\MenuPage;
 use JLG\Sidebar\Admin\SettingsSanitizer;
 use JLG\Sidebar\Admin\View\ColorPickerField;
+use JLG\Sidebar\Analytics\AnalyticsRepository;
 use JLG\Sidebar\Ajax\Endpoints;
 use JLG\Sidebar\Cache\MenuCache;
 use JLG\Sidebar\Frontend\Blocks\SearchBlock;
@@ -24,6 +25,7 @@ class Plugin
     private SettingsRepository $settings;
     private MenuCache $cache;
     private SettingsSanitizer $sanitizer;
+    private AnalyticsRepository $analytics;
     private MenuPage $menuPage;
     private ProfileSelector $profileSelector;
     private RequestContextResolver $requestContextResolver;
@@ -40,6 +42,7 @@ class Plugin
         $this->settings = new SettingsRepository($this->defaults, $this->icons);
         $this->cache = new MenuCache();
         $this->sanitizer = new SettingsSanitizer($this->defaults, $this->icons);
+        $this->analytics = new AnalyticsRepository();
         $this->requestContextResolver = new RequestContextResolver();
         $this->profileSelector = new ProfileSelector($this->settings, $this->requestContextResolver);
         $this->menuPage = new MenuPage(
@@ -47,6 +50,7 @@ class Plugin
             $this->sanitizer,
             $this->icons,
             new ColorPickerField(),
+            $this->analytics,
             $pluginFile,
             $version
         );
@@ -64,6 +68,7 @@ class Plugin
             $this->cache,
             $this->icons,
             $this->sanitizer,
+            $this->analytics,
             $pluginFile,
             $this->renderer
         );
@@ -219,6 +224,11 @@ class Plugin
     public function getSanitizer(): SettingsSanitizer
     {
         return $this->sanitizer;
+    }
+
+    public function getAnalyticsRepository(): AnalyticsRepository
+    {
+        return $this->analytics;
     }
 
     public function getSidebarRenderer(): SidebarRenderer

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -150,6 +150,7 @@ class DefaultSettings
     {
         return [
             'enable_sidebar'    => true,
+            'enable_analytics'  => false,
             'app_name'          => 'Sidebar JLG',
             'layout_style'      => 'full',
             'sidebar_position'  => 'left',

--- a/tests/analytics_repository_test.php
+++ b/tests/analytics_repository_test.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+namespace JLG\Sidebar\Analytics {
+    function current_time($type = 'timestamp', $gmt = 0)
+    {
+        $timestamp = $GLOBALS['analytics_test_current_time'] ?? time();
+
+        if ($type === 'timestamp') {
+            return $timestamp;
+        }
+
+        if ($type === 'mysql') {
+            return gmdate('Y-m-d H:i:s', $timestamp);
+        }
+
+        return $timestamp;
+    }
+}
+
+namespace {
+    use JLG\Sidebar\Analytics\AnalyticsRepository;
+
+    require __DIR__ . '/bootstrap.php';
+    require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+    $GLOBALS['wp_test_options'] = [];
+    delete_option('sidebar_jlg_analytics');
+
+    $testsPassed = true;
+
+    function assertSame($expected, $actual, string $message): void
+    {
+        global $testsPassed;
+
+        if ($expected === $actual) {
+            echo "[PASS] {$message}\n";
+
+            return;
+        }
+
+        $testsPassed = false;
+        echo "[FAIL] {$message}. Expected `" . var_export($expected, true) . "`, got `" . var_export($actual, true) . "`.\n";
+    }
+
+    function assertTrue($condition, string $message): void
+    {
+        assertSame(true, (bool) $condition, $message);
+    }
+
+    $repository = new AnalyticsRepository();
+
+    $initialSummary = $repository->getSummary();
+    assertSame(0, $initialSummary['totals']['sidebar_open'] ?? null, 'Initial totals start at zero');
+    assertSame([], $initialSummary['targets']['sidebar_open'] ?? [], 'Initial targets array is empty');
+
+    $GLOBALS['analytics_test_current_time'] = strtotime('2024-01-01 10:00:00');
+    $repository->recordEvent('sidebar_open', [
+        'profile_id' => 'default',
+        'target' => 'toggle_button',
+    ]);
+
+    $summaryAfterOpen = $repository->getSummary();
+    assertSame(1, $summaryAfterOpen['totals']['sidebar_open'] ?? null, 'Sidebar open increments total');
+    assertSame('toggle_button', array_key_first($summaryAfterOpen['targets']['sidebar_open'] ?? []) ?? null, 'Sidebar open target stored');
+
+    $GLOBALS['analytics_test_current_time'] = strtotime('2024-01-01 10:05:00');
+    $repository->recordEvent('cta_view', [
+        'profile_id' => 'profile-alpha',
+        'profile_label' => 'Alpha',
+        'target' => 'cta_hero',
+    ]);
+    $repository->recordEvent('cta_click', [
+        'profile_id' => 'profile-alpha',
+        'profile_label' => 'Alpha',
+        'target' => 'cta_button',
+    ]);
+
+    $summaryAfterCta = $repository->getSummary();
+    assertSame(1, $summaryAfterCta['profiles']['profile-alpha']['totals']['cta_click'] ?? null, 'Profile totals record CTA clicks');
+    assertSame('Alpha', $summaryAfterCta['profiles']['profile-alpha']['label'] ?? null, 'Profile label persisted');
+    assertSame('cta_button', array_key_first($summaryAfterCta['targets']['cta_click'] ?? []) ?? null, 'CTA click target tracked');
+
+    $reflection = new \ReflectionClass(AnalyticsRepository::class);
+    $maxBuckets = (int) $reflection->getConstant('MAX_DAILY_BUCKETS');
+
+    for ($day = 0; $day < $maxBuckets + 2; $day++) {
+        $GLOBALS['analytics_test_current_time'] = strtotime('2024-02-01 +' . $day . ' days');
+        $repository->recordEvent('menu_link_click', ['profile_id' => 'default']);
+    }
+
+    $summaryAfterRetention = $repository->getSummary();
+    assertSame($maxBuckets, count($summaryAfterRetention['daily']), 'Daily retention window enforced');
+
+    $repository->recordEvent('unknown_event', []);
+    $postUnknownSummary = $repository->getSummary();
+    assertTrue(!isset($postUnknownSummary['totals']['unknown_event']), 'Unknown events are ignored');
+
+    unset($GLOBALS['analytics_test_current_time']);
+
+    if ($testsPassed) {
+        echo "Analytics repository tests passed.\n";
+        exit(0);
+    }
+
+    echo "Analytics repository tests failed.\n";
+    exit(1);
+}

--- a/tests/sanitize_settings_corrupted_option_test.php
+++ b/tests/sanitize_settings_corrupted_option_test.php
@@ -57,6 +57,7 @@ $normalizedOverlayDefault = preg_replace('/\s+/', '', $defaultSettings['overlay_
 
 assertTrue(is_array($sanitized), 'Sanitized settings returns an array for corrupted stored options');
 assertSame(true, $sanitized['enable_sidebar'] ?? null, 'Enable sidebar flag keeps submitted truthy value');
+assertSame(false, $sanitized['enable_analytics'] ?? null, 'Enable analytics flag defaults to disabled when missing');
 assertSame($defaultSettings['layout_style'], $sanitized['layout_style'] ?? null, 'Layout style falls back to default when missing from input');
 assertSame($normalizedOverlayDefault, $sanitized['overlay_color'] ?? null, 'Overlay color falls back to default when missing from input');
 assertSame($defaultSettings['social_position'], $sanitized['social_position'] ?? null, 'Social position falls back to default when missing from input');


### PR DESCRIPTION
## Summary
- add an `AnalyticsRepository` to normalize, persist, and summarize sidebar interaction metrics
- expose Insights & Analytics tooling in the admin along with front-end event dispatching and AJAX endpoints
- cover the analytics flow with dedicated PHP unit tests for the repository and AJAX handler

## Testing
- php tests/analytics_repository_test.php
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e44818cc5c832e885cd7e21e3afcb4