### PR TITLE
docs: approfondir les pistes UX UI pro

### DIFF
--- a/docs/comparaison-pro.md
+++ b/docs/comparaison-pro.md
@@ -110,3 +110,54 @@ Cette note fait le point sur l'écart entre Sidebar JLG et les constructeurs de 
 ---
 
 En priorisant un éditeur visuel temps réel, des scénarios conditionnels avancés et un accompagnement accessibilité/analytics, Sidebar JLG pourra rivaliser avec les leaders tout en capitalisant sur son intégration WordPress native.
+
+## 9. Approfondissements UX/UI inspirés des suites professionnelles
+
+### 9.1 Palette de commande et regroupements contextuels
+
+Les onglets actuels reposent sur un ruban `nav-tab` classique et de longues tables de réglages, ce qui oblige à scroller pour retrouver un champ précis lors des itérations rapides.【F:sidebar-jlg/includes/admin-page.php†L96-L229】 Les constructeurs premium comme Elementor ou JetMenu proposent désormais une palette de commande (`Cmd/Ctrl + K`) et un moteur de recherche de réglages. Reproduisez ces usages en ajoutant :
+
+- Une barre de recherche persistante filtrant dynamiquement les champs visibles par mot-clé / catégorie.
+- Des "favoris" ou "raccourcis" pour accéder aux groupes utilisés récemment (p. ex. largeur, effets, analytics).
+- Un mode compact qui aligne les champs en deux colonnes au lieu d'une table pleine largeur, à la manière des panneaux latéraux de Figma.
+
+### 9.2 Mode "canvas" immersif pour l'aperçu
+
+L'aperçu AJAX actuel offre déjà des boutons de breakpoint et une bascule comparaison, mais reste encapsulé dans un panneau statique blanc.【F:sidebar-jlg/includes/admin-page.php†L107-L132】 Inspirez-vous des simulateurs de Framer ou ConvertBox pour proposer :
+
+- Un mode plein écran "canvas" qui verrouille l'interface et permet d'éditer directement les textes/icônes dans l'aperçu.
+- Des cadres d'appareils (smartphone, tablette, desktop) avec fond personnalisable et repères de grille pour valider les espacements.
+- Des overlays d'analyse (contraste, focus, zones chaudes) alimentés par les métriques internes pour détecter les éléments sous-performants.
+
+### 9.3 Tableau de bord narratif
+
+Le tab "Insights & Analytics" synthétise déjà les totaux, l'historique 7 jours et la répartition par profil au format tableau.【F:sidebar-jlg/includes/admin-page.php†L942-L1099】 Pour se rapprocher de la narration visuelle des solutions marketing (OptinMonster, ConvertBox) :
+
+- Convertissez les KPI clés en cartes visuelles (sparklines, jauges, mini heatmaps) et ajoutez des annotations automatiques (ex. "+12 % vs. semaine dernière").
+- Mettez en avant les profils et surfaces en surperformance via des badges/couleurs, et suggérez des actions ("Dupliquez ce profil sur mobile") générées à partir des données.
+- Offrez une timeline interactive des événements (ouvertures, clics CTA) avec segmentation par déclencheur pour expliquer les pics.
+
+### 9.4 Atelier de profils contextuels
+
+L'éditeur de profils propose déjà un planificateur horaire, des filtres par taxonomie et des actions de clonage, mais sans visualisation synthétique des cibles ni prévisualisation contextuelle.【F:sidebar-jlg/includes/admin-page.php†L900-L923】 Alignez-vous sur les "Audience Builders" professionnels en ajoutant :
+
+- Un résumé graphique des critères (pays, rôles, heures) avec badges colorés, états actifs/inactifs et alertes lorsque des règles se chevauchent.
+- Une prévisualisation instantanée qui recharge l'aperçu avec le profil sélectionné pour valider les contenus/styles sans quitter l'onglet.
+- Des suggestions de profils préconfigurés ("Week-end mobile", "VIP connectés") que l'utilisateur peut activer en un clic.
+
+### 9.5 Design system cohérent et composables
+
+Les styles admin reposent encore majoritairement sur les classes WordPress (`form-table`, `widefat`) avec quelques cartes/presets dédiées.【F:sidebar-jlg/assets/css/admin-style.css†L1-L180】 Construisez un mini design system pour :
+
+- Remplacer les tables par des `fieldset` modulaires avec titres collants, descriptions contextuelles et icônes d'aide.
+- Décliner les préréglages existants en cartes interactives utilisables partout (menus, CTA, badges) afin de préparer un futur builder visuel.【F:sidebar-jlg/src/Settings/DefaultSettings.php†L7-L142】
+- Définir des tokens (couleurs, rayons, ombres) et des composants React/JS réutilisables si vous basculez vers une interface type SPA.
+
+### 9.6 Micro-interactions front & mobile
+
+Le script public gère déjà le tracking Analytics, les CTA et l'accessibilité clavier, mais reste focalisé sur les clics et l'ouverture via le bouton toggle.【F:sidebar-jlg/assets/js/public-script.js†L36-L219】 Pour atteindre le niveau d'apps mobiles premium :
+
+- Ajoutez des gestes tactiles (swipe edge, pull to close) et retours haptiques via l'API `navigator.vibrate` lorsqu'elle est disponible.
+- Implémentez un "smart reopen" qui se souvient du dernier sous-menu ouvert/localise les CTA cliqués via `localStorage` afin de réduire les frictions.
+- Synchronisez les animations avec `prefers-reduced-motion`, mais proposez aussi des transitions contextuelles (rebond, effet ressort) inspirées de Craft ou InVision pour les utilisateurs qui recherchent une expérience plus vivante.
+


### PR DESCRIPTION
## Summary
- enrichit la note de benchmark UX/UI avec un chapitre dédié aux approfondissements inspirés des suites professionnelles
- détaille de nouvelles pistes sur la commande rapide, le canvas d’aperçu, l’analytics narratif, l’atelier de profils et les micro-interactions

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e4d275cbf4832ead3488ef2ad6deee