### PR TITLE
Fix overlay accessibility toggling in public sidebar script

### DIFF
--- a/sidebar-jlg/assets/js/__tests__/public-script.test.js
+++ b/sidebar-jlg/assets/js/__tests__/public-script.test.js
@@ -199,6 +199,8 @@ describe('public-script.js', () => {
   test('opens and closes the sidebar via UI controls', () => {
     loadScript();
 
+    expect(overlay.getAttribute('aria-hidden')).toBe('true');
+
     hamburgerBtn.click();
     jest.runOnlyPendingTimers();
 
@@ -207,6 +209,7 @@ describe('public-script.js', () => {
     expect(hamburgerBtn.getAttribute('aria-expanded')).toBe('true');
     expect(hamburgerBtn.getAttribute('aria-label')).toBe('Fermer');
     expect(overlay.classList.contains('is-visible')).toBe(true);
+    expect(overlay.getAttribute('aria-hidden')).toBe('false');
     const focusableContent = getVisibleFocusable();
     expect(document.activeElement).toBe(focusableContent[0]);
 
@@ -216,6 +219,7 @@ describe('public-script.js', () => {
     expect(hamburgerBtn.classList.contains('is-active')).toBe(false);
     expect(hamburgerBtn.getAttribute('aria-expanded')).toBe('false');
     expect(hamburgerBtn.getAttribute('aria-label')).toBe('Ouvrir');
+    expect(overlay.getAttribute('aria-hidden')).toBe('true');
     expect(document.activeElement).toBe(hamburgerBtn);
   });
 

--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -33,6 +33,11 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
+    if (overlay) {
+        const overlayIsVisible = overlay.classList.contains('is-visible');
+        overlay.setAttribute('aria-hidden', overlayIsVisible ? 'false' : 'true');
+    }
+
     const analyticsSettings = typeof sidebarSettings !== 'undefined' ? sidebarSettings.analytics : null;
     const analyticsConfig = analyticsSettings
         && analyticsSettings.enabled
@@ -913,7 +918,10 @@ document.addEventListener('DOMContentLoaded', function() {
         if (closeLabel) {
             hamburgerBtn.setAttribute('aria-label', closeLabel);
         }
-        if (overlay) overlay.classList.add('is-visible');
+        if (overlay) {
+            overlay.classList.add('is-visible');
+            overlay.setAttribute('aria-hidden', 'false');
+        }
         if (sidebarInner && shouldRememberState && typeof persistedState.scrollTop === 'number') {
             sidebarInner.scrollTop = persistedState.scrollTop;
         }
@@ -951,7 +959,10 @@ document.addEventListener('DOMContentLoaded', function() {
         if (openLabel) {
             hamburgerBtn.setAttribute('aria-label', openLabel);
         }
-        if (overlay) overlay.classList.remove('is-visible');
+        if (overlay) {
+            overlay.classList.remove('is-visible');
+            overlay.setAttribute('aria-hidden', 'true');
+        }
         clearScrollLockCompensation();
         if (returnFocus) {
             hamburgerBtn.focus();


### PR DESCRIPTION
## Summary
- ensure the front-end overlay initializes its aria-hidden attribute and updates it whenever the sidebar opens or closes
- extend the public sidebar Jest test to cover the overlay accessibility state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e551f2fe80832e875f1eaee221b54b