### PR TITLE
Add behavioral auto-open triggers and analytics comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Une extension WordPress qui fournit une sidebar animée et entièrement personna
 ### Interface d'administration complète
 
 - Page de configuration unique avec regroupement logique des réglages (contenu, styles, comportements) et champs spécialisés : color picker natif, sélection d'icônes, tri et drag & drop des éléments de menu. 
-- Prévisualisation embarquée de la sidebar, synchronisée via AJAX (`jlg_render_preview`) pour valider instantanément les variations graphiques et la sélection de profil actif. 
-- Bibliothèque d'icônes prête à l'emploi (manifest JSON), outils de téléversement sécurisé (limites MIME/taille) et récupération du SVG pour les besoins spécifiques. 
+- Prévisualisation embarquée de la sidebar, synchronisée via AJAX (`jlg_render_preview`) pour valider instantanément les variations graphiques et la sélection de profil actif.
+- Déclencheurs comportementaux directement configurables (timer, profondeur de scroll) pour ouvrir automatiquement la sidebar sans recourir au code.
+- Bibliothèque d'icônes prête à l'emploi (manifest JSON), outils de téléversement sécurisé (limites MIME/taille) et récupération du SVG pour les besoins spécifiques.
 - Outils d'import/export JSON versionnés, remise à zéro contrôlée et sélection directe de contenus WordPress (articles, pages, catégories) grâce aux points d'entrée AJAX dédiés. 
 - Préréglages de style (`style_presets`) comprenant visuels de comparaison avant/après pour accélérer la mise en production.
 - Nouveau preset « Radix Neutrals » inspiré de Radix UI : surfaces superposées, bordures subtiles et accents violets prêts à l’emploi.
@@ -59,6 +60,7 @@ Une extension WordPress qui fournit une sidebar animée et entièrement personna
 
 - Tableau de bord dédié dans l’administration (« Insights & Analytics ») pour suivre les ouvertures, clics de navigation et conversions CTA.
 - Répartition par profil actif et historique des sept derniers jours afin de comparer rapidement les campagnes contextuelles.
+- Comparatif 7j/30j intégré pour visualiser le poids de la dernière semaine dans le volume global d'interactions.
 - Collecte optionnelle activable dans l’onglet Général pour respecter les environnements sensibles aux métriques.
 
 ## Installation

--- a/sidebar-jlg/includes/admin-page.php
+++ b/sidebar-jlg/includes/admin-page.php
@@ -431,6 +431,39 @@ $textTransformLabels = [
                     </td>
                 </tr>
                 <tr>
+                    <th scope="row"><?php esc_html_e( 'Déclencheurs comportementaux', 'sidebar-jlg' ); ?></th>
+                    <td>
+                        <p>
+                            <label for="sidebar-jlg-auto-open-delay"><?php esc_html_e( 'Ouvrir automatiquement après (secondes)', 'sidebar-jlg' ); ?></label>
+                            <input
+                                type="number"
+                                id="sidebar-jlg-auto-open-delay"
+                                name="sidebar_jlg_settings[auto_open_time_delay]"
+                                min="0"
+                                max="600"
+                                step="1"
+                                value="<?php echo esc_attr( (string) (int) ( $options['auto_open_time_delay'] ?? 0 ) ); ?>"
+                                class="small-text"
+                            />
+                        </p>
+                        <p>
+                            <label for="sidebar-jlg-auto-open-scroll"><?php esc_html_e( 'Ouvrir après un pourcentage de scroll', 'sidebar-jlg' ); ?></label>
+                            <input
+                                type="number"
+                                id="sidebar-jlg-auto-open-scroll"
+                                name="sidebar_jlg_settings[auto_open_scroll_depth]"
+                                min="0"
+                                max="100"
+                                step="5"
+                                value="<?php echo esc_attr( (string) (int) ( $options['auto_open_scroll_depth'] ?? 0 ) ); ?>"
+                                class="small-text"
+                            />
+                            <span class="description" style="margin-left: 0.5rem;">%</span>
+                        </p>
+                        <p class="description"><?php esc_html_e( 'Définissez 0 pour désactiver un déclencheur. La sidebar ne se rouvrira pas automatiquement si l’utilisateur l’a refermée manuellement.', 'sidebar-jlg' ); ?></p>
+                    </td>
+                </tr>
+                <tr>
                     <th scope="row"><?php esc_html_e( 'Libellé ARIA de la navigation', 'sidebar-jlg' ); ?></th>
                     <td>
                         <input type="text" class="regular-text" name="sidebar_jlg_settings[nav_aria_label]" value="<?php echo esc_attr( $options['nav_aria_label'] ?? '' ); ?>" />
@@ -959,6 +992,7 @@ $textTransformLabels = [
                     $analyticsDaily         = isset( $analyticsSummary['daily'] ) && is_array( $analyticsSummary['daily'] ) ? $analyticsSummary['daily'] : [];
                     $analyticsProfilesData  = isset( $analyticsSummary['profiles'] ) && is_array( $analyticsSummary['profiles'] ) ? $analyticsSummary['profiles'] : [];
                     $analyticsTargets       = isset( $analyticsSummary['targets'] ) && is_array( $analyticsSummary['targets'] ) ? $analyticsSummary['targets'] : [];
+                    $analyticsWindows       = isset( $analyticsSummary['windows'] ) && is_array( $analyticsSummary['windows'] ) ? $analyticsSummary['windows'] : [];
                     $sidebarOpensTotal      = (int) ( $analyticsTotals['sidebar_open'] ?? 0 );
                     $menuClicksTotal        = (int) ( $analyticsTotals['menu_link_click'] ?? 0 );
                     $ctaViewsTotal          = (int) ( $analyticsTotals['cta_view'] ?? 0 );
@@ -993,6 +1027,12 @@ $textTransformLabels = [
                         'cta_view'        => __( 'Vues CTA', 'sidebar-jlg' ),
                         'cta_click'       => __( 'Clics CTA', 'sidebar-jlg' ),
                     ];
+                    $windowLast7 = isset( $analyticsWindows['last7'] ) && is_array( $analyticsWindows['last7'] ) ? $analyticsWindows['last7'] : [];
+                    $windowLast30 = isset( $analyticsWindows['last30'] ) && is_array( $analyticsWindows['last30'] ) ? $analyticsWindows['last30'] : [];
+                    $last7Totals = isset( $windowLast7['totals'] ) && is_array( $windowLast7['totals'] ) ? $windowLast7['totals'] : [];
+                    $last30Totals = isset( $windowLast30['totals'] ) && is_array( $windowLast30['totals'] ) ? $windowLast30['totals'] : [];
+                    $last7Days = isset( $windowLast7['days'] ) ? (int) $windowLast7['days'] : 0;
+                    $last30Days = isset( $windowLast30['days'] ) ? (int) $windowLast30['days'] : 0;
                     ?>
                     <?php if ( $totalInteractions === 0 ) : ?>
                         <p><?php esc_html_e( 'Les métriques apparaîtront dès que vos visiteurs interagiront avec la sidebar.', 'sidebar-jlg' ); ?></p>
@@ -1022,6 +1062,43 @@ $textTransformLabels = [
                                 <tr><td><?php esc_html_e( 'Taux de clic navigation / ouverture', 'sidebar-jlg' ); ?></td><td><?php echo esc_html( sidebar_jlg_format_percentage_label( $clickRate ) ); ?></td></tr>
                             </tbody>
                         </table>
+                        <?php
+                        $hasWindowComparison = array_sum( array_map( 'intval', $last7Totals ) ) > 0 || array_sum( array_map( 'intval', $last30Totals ) ) > 0;
+                        if ( $hasWindowComparison ) :
+                            ?>
+                            <h3><?php esc_html_e( 'Comparatif 7j / 30j', 'sidebar-jlg' ); ?></h3>
+                            <p class="description"><?php esc_html_e( 'Visualisez le poids de la dernière semaine par rapport à la fenêtre des 30 derniers jours.', 'sidebar-jlg' ); ?></p>
+                            <table class="widefat striped">
+                                <thead>
+                                    <tr>
+                                        <th scope="col"><?php esc_html_e( 'Événement', 'sidebar-jlg' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( '7 derniers jours', 'sidebar-jlg' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( '30 derniers jours', 'sidebar-jlg' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Part des 7 derniers jours', 'sidebar-jlg' ); ?></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ( $eventLabels as $eventKey => $eventLabel ) :
+                                        $value7 = (int) ( $last7Totals[ $eventKey ] ?? 0 );
+                                        $value30 = (int) ( $last30Totals[ $eventKey ] ?? 0 );
+                                        $share = $value30 > 0 ? ( $value7 / $value30 ) * 100 : ( $value7 > 0 ? 100 : 0 );
+                                        ?>
+                                        <tr>
+                                            <td><?php echo esc_html( $eventLabel ); ?></td>
+                                            <td><?php echo esc_html( sidebar_jlg_format_metric_number( $value7 ) ); ?></td>
+                                            <td><?php echo esc_html( sidebar_jlg_format_metric_number( $value30 ) ); ?></td>
+                                            <td><?php echo esc_html( sidebar_jlg_format_percentage_label( $share ) ); ?></td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                            <?php if ( $last30Days > 0 && $last30Days < 30 ) : ?>
+                                <p class="description"><?php printf( esc_html__( 'Fenêtre 30j calculée sur %s jour(s) de données disponibles.', 'sidebar-jlg' ), esc_html( sidebar_jlg_format_metric_number( $last30Days ) ) ); ?></p>
+                            <?php endif; ?>
+                            <?php if ( $last7Days > 0 && $last7Days < 7 ) : ?>
+                                <p class="description"><?php printf( esc_html__( 'Fenêtre 7j calculée sur %s jour(s) de données disponibles.', 'sidebar-jlg' ), esc_html( sidebar_jlg_format_metric_number( $last7Days ) ) ); ?></p>
+                            <?php endif; ?>
+                        <?php endif; ?>
                         <?php if ( ! empty( $recentDaily ) ) : ?>
                             <h3><?php esc_html_e( '7 derniers jours', 'sidebar-jlg' ); ?></h3>
                             <table class="widefat striped">

--- a/sidebar-jlg/src/Admin/SettingsSanitizer.php
+++ b/sidebar-jlg/src/Admin/SettingsSanitizer.php
@@ -282,6 +282,10 @@ class SettingsSanitizer
         $sanitized['close_on_link_click'] = !empty($input['close_on_link_click']);
         // Checkbox for remembering sidebar state across navigations.
         $sanitized['remember_last_state'] = !empty($input['remember_last_state']);
+        $timeDelay = $this->sanitizeIntegerOption($input, 'auto_open_time_delay', $existingOptions, $defaults);
+        $sanitized['auto_open_time_delay'] = max(0, min(600, $timeDelay));
+        $scrollDepth = $this->sanitizeIntegerOption($input, 'auto_open_scroll_depth', $existingOptions, $defaults);
+        $sanitized['auto_open_scroll_depth'] = max(0, min(100, $scrollDepth));
         $sanitized['nav_aria_label'] = sanitize_text_field($input['nav_aria_label'] ?? $existingOptions['nav_aria_label']);
         $sanitized['toggle_open_label'] = sanitize_text_field($input['toggle_open_label'] ?? $existingOptions['toggle_open_label']);
         $sanitized['toggle_close_label'] = sanitize_text_field($input['toggle_close_label'] ?? $existingOptions['toggle_close_label']);

--- a/sidebar-jlg/src/Frontend/SidebarRenderer.php
+++ b/sidebar-jlg/src/Frontend/SidebarRenderer.php
@@ -334,6 +334,10 @@ class SidebarRenderer
             'animation_type' => $options['animation_type'] ?? 'slide-left',
             'close_on_link_click' => $options['close_on_link_click'] ?? '',
             'remember_last_state' => $options['remember_last_state'] ?? false,
+            'behavior_triggers' => [
+                'time_delay' => max(0, min(600, (int) ($options['auto_open_time_delay'] ?? 0))),
+                'scroll_depth' => max(0, min(100, (int) ($options['auto_open_scroll_depth'] ?? 0))),
+            ],
             'debug_mode' => (string) ($options['debug_mode'] ?? '0'),
             'sidebar_position' => $this->resolveSidebarPosition($options),
             'active_profile_id' => isset($profile['id']) ? (string) $profile['id'] : 'default',

--- a/sidebar-jlg/src/Settings/DefaultSettings.php
+++ b/sidebar-jlg/src/Settings/DefaultSettings.php
@@ -213,6 +213,9 @@ class DefaultSettings
             'close_on_link_click' => false,
             // Persist open state, scroll position and interactions between page loads.
             'remember_last_state' => false,
+            // Auto-open helpers triggered by visitor behaviour. Values set to 0 disable the trigger.
+            'auto_open_time_delay' => 0,
+            'auto_open_scroll_depth' => 0,
             'nav_aria_label'   => '',
             'toggle_open_label'  => '',
             'toggle_close_label' => '',

--- a/tests/sanitize_general_settings_test.php
+++ b/tests/sanitize_general_settings_test.php
@@ -130,6 +130,26 @@ $result_remember_zero = $method->invoke($sanitizer, $input_remember_zero, $exist
 
 assertSame(false, $result_remember_zero['remember_last_state'] ?? null, 'Remember state option treats "0" as disabled');
 
+$input_auto_open_valid = [
+    'auto_open_time_delay' => '45',
+    'auto_open_scroll_depth' => '60',
+];
+
+$result_auto_open_valid = $method->invoke($sanitizer, $input_auto_open_valid, $existing_options);
+
+assertSame(45, $result_auto_open_valid['auto_open_time_delay'] ?? null, 'Auto-open timer accepts valid delay');
+assertSame(60, $result_auto_open_valid['auto_open_scroll_depth'] ?? null, 'Auto-open scroll accepts valid depth');
+
+$input_auto_open_out_of_range = [
+    'auto_open_time_delay' => '7200',
+    'auto_open_scroll_depth' => '140',
+];
+
+$result_auto_open_out_of_range = $method->invoke($sanitizer, $input_auto_open_out_of_range, $existing_options);
+
+assertSame(600, $result_auto_open_out_of_range['auto_open_time_delay'] ?? null, 'Auto-open timer is capped at 600 seconds');
+assertSame(100, $result_auto_open_out_of_range['auto_open_scroll_depth'] ?? null, 'Auto-open scroll depth capped at 100');
+
 $existing_numeric_general = array_merge($defaults->all(), [
     'border_width'     => 4,
     'width_desktop'    => 360,


### PR DESCRIPTION
## Summary
- add configurable timer and scroll depth triggers to the general settings tab and hydrate them for the front-end script
- update the public script to auto-open once triggers fire while respecting manual dismissals, persistence, and analytics, with dedicated Jest coverage
- extend analytics summaries with 7/30 day windows, render the comparison table in the admin dashboard, and document the new capabilities

## Testing
- npm run test:js
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e5763f5514832eb4927489cd3656c3