### PR TITLE
Sécurise la normalisation des URL de contexte

### DIFF
--- a/tests/normalize_url_for_comparison_test.php
+++ b/tests/normalize_url_for_comparison_test.php
@@ -43,6 +43,9 @@ $_SERVER['HTTPS'] = 'on';
 $assertNormalized('//cdn.example.com/assets/logo.svg', 'https://cdn.example.com/assets/logo.svg', 'Protocol-relative URLs inherit HTTPS when the request is secure');
 
 $resetServer();
+$assertNormalized('https://[2001:DB8::1]:8042/archive', 'https://[2001:db8::1]:8042/archive', 'IPv6 hosts retain brackets, are lowercased and preserve custom ports');
+
+$resetServer();
 
 if ($testsPassed) {
     echo "Normalize URL comparison tests passed.\n";


### PR DESCRIPTION
## Summary
- renforce RequestContextResolver pour ignorer les en-têtes Host malformés, assainir REQUEST_URI et préserver la syntaxe IPv6 lors de la normalisation
- adapte les tests du résolveur de contexte pour couvrir les ports non standards, les hôtes invalides et les adresses IPv6
- ajoute un test de normalisation dédié aux URL IPv6 et synchronise l’assertion sur les IDs de taxonomie

## Testing
- vendor/bin/phpunit tests/request_context_resolver_test.php
- vendor/bin/phpunit tests/normalize_url_for_comparison_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e63a0b2290832ea8f822a6ea59948a