### PR TITLE
Prevent undefined social position notices in sidebar template

### DIFF
--- a/sidebar-jlg/includes/sidebar-template.php
+++ b/sidebar-jlg/includes/sidebar-template.php
@@ -35,6 +35,16 @@ if (isset($options['social_orientation']) && is_string($options['social_orientat
     $socialOrientation = $options['social_orientation'];
 }
 
+$socialIcons = [];
+if (!empty($options['social_icons']) && is_array($options['social_icons'])) {
+    $socialIcons = $options['social_icons'];
+}
+
+$socialPosition = '';
+if (isset($options['social_position']) && is_string($options['social_position'])) {
+    $socialPosition = $options['social_position'];
+}
+
 $defaultNavAriaLabel = __('Navigation principale', 'sidebar-jlg');
 $navAriaLabelOption = '';
 if (isset($options['nav_aria_label']) && is_string($options['nav_aria_label'])) {
@@ -250,8 +260,8 @@ ob_start();
     <ul class="<?php echo esc_attr($menuClassAttr); ?>">
         <?php echo $renderMenuNodes($menuNodes, $layoutStyle); ?>
 
-        <?php if (($options['social_position'] ?? '') === 'in-menu' && !empty($options['social_icons']) && is_array($options['social_icons'])) : ?>
-            <?php $menuSocialIcons = Templating::renderSocialIcons($options['social_icons'], $allIcons, $socialOrientation); ?>
+        <?php if ($socialPosition === 'in-menu' && $socialIcons !== []) : ?>
+            <?php $menuSocialIcons = Templating::renderSocialIcons($socialIcons, $allIcons, $socialOrientation); ?>
             <?php if ($menuSocialIcons !== '') : ?>
                 <li class="menu-separator" aria-hidden="true"><hr></li>
                 <li class="social-icons-wrapper"><?php echo $menuSocialIcons; ?></li>
@@ -261,8 +271,8 @@ ob_start();
 </nav>
 
 <?php
-if ($options['social_position'] === 'footer' && !empty($options['social_icons']) && is_array($options['social_icons'])) {
-    $footerSocialIcons = Templating::renderSocialIcons($options['social_icons'], $allIcons, $socialOrientation);
+if ($socialPosition === 'footer' && $socialIcons !== []) {
+    $footerSocialIcons = Templating::renderSocialIcons($socialIcons, $allIcons, $socialOrientation);
     if ($footerSocialIcons !== '') {
         echo '<div class="sidebar-footer">' . $footerSocialIcons . '</div>';
     }

--- a/tests/render_sidebar_missing_social_position_test.php
+++ b/tests/render_sidebar_missing_social_position_test.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+use JLG\Sidebar\Icons\IconLibrary;
+use JLG\Sidebar\Settings\DefaultSettings;
+
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../sidebar-jlg/sidebar-jlg.php';
+
+$testsPassed = true;
+
+function assertTrue($condition, string $message): void
+{
+    global $testsPassed;
+    if (!$condition) {
+        $testsPassed = false;
+        echo "Assertion failed: {$message}.\n";
+    }
+}
+
+$defaults = new DefaultSettings();
+$options = $defaults->all();
+
+unset($options['social_position']);
+
+$iconLibrary = new IconLibrary(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php');
+$allIcons = $iconLibrary->getAllIcons();
+
+$capturedNotices = [];
+set_error_handler(static function (int $severity, string $message) use (&$capturedNotices): bool {
+    if (in_array($severity, [E_WARNING, E_NOTICE, E_USER_WARNING, E_USER_NOTICE], true)) {
+        $capturedNotices[] = $message;
+        return true;
+    }
+
+    return false;
+});
+
+ob_start();
+include __DIR__ . '/../sidebar-jlg/includes/sidebar-template.php';
+$html = ob_get_clean();
+restore_error_handler();
+
+assertTrue($capturedNotices === [], 'Rendering template without social_position should not trigger notices');
+assertTrue(is_string($html) && $html !== '', 'Template rendered non-empty markup');
+
+if (!$testsPassed) {
+    exit(1);
+}
+
+echo "Render sidebar missing social position tests passed.\n";


### PR DESCRIPTION
## Summary
- guard the social icon rendering against missing `social_position` in the sidebar template
- reuse the sanitized social icon data for menu and footer rendering to avoid duplicated lookups
- add a regression test that ensures the template renders without notices when `social_position` is absent

## Testing
- composer test
- npm test
- php tests/render_sidebar_missing_social_position_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e64f805ed0832eb1f4ab913567aa3a