### PR TITLE
Defer costly plugin maintenance to admin lifecycle

### DIFF
--- a/tests/sidebar_locale_cache_test.php
+++ b/tests/sidebar_locale_cache_test.php
@@ -312,6 +312,19 @@ $GLOBALS['wp_test_options']['sidebar_jlg_settings'] = [
 $revalidatingPlugin = new SidebarPlugin(__DIR__ . '/../sidebar-jlg/sidebar-jlg.php', SIDEBAR_JLG_VERSION);
 $revalidatingPlugin->register();
 
+if (isset($registeredHooks['admin_init'])) {
+    foreach ($registeredHooks['admin_init'] as $listener) {
+        $callback = $listener['callback'];
+        $acceptedArgs = $listener['accepted_args'];
+
+        if ($acceptedArgs > 0) {
+            call_user_func_array($callback, array_fill(0, $acceptedArgs, null));
+        } else {
+            call_user_func($callback);
+        }
+    }
+}
+
 assertTrue(
     !isset($GLOBALS['wp_test_transients']['sidebar_jlg_full_html_fr_FR_default']),
     'Cache transient cleared when revalidation updates corrupted options'


### PR DESCRIPTION
## Summary
- ensure maintenance and option revalidation run only once per lifecycle instead of every request
- trigger maintenance tasks on admin init and plugin upgrades while keeping activation notice guarded
- adjust locale cache regression test to simulate the new admin_init maintenance hook

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e66b83b7b0832ebf7b7bf157a24fe3