### PR TITLE
Guard stubbed functions in ajax endpoints test

### DIFF
--- a/tests/ajax_endpoints_test.php
+++ b/tests/ajax_endpoints_test.php
@@ -199,18 +199,22 @@ function sanitize_text_field($value)
 
     return trim($value);
 }
-function wp_strip_all_tags($string, $remove_breaks = false): string
-{
-    $string = strip_tags((string) $string);
+if (!function_exists('wp_strip_all_tags')) {
+    function wp_strip_all_tags($string, $remove_breaks = false): string
+    {
+        $string = strip_tags((string) $string);
 
-    if ($remove_breaks) {
-        $string = preg_replace('/[\r\n\t ]+/', ' ', $string);
+        if ($remove_breaks) {
+            $string = preg_replace('/[\r\n\t ]+/', ' ', $string);
+        }
+
+        return trim($string);
     }
-
-    return trim($string);
 }
 function add_menu_page(...$args): void {}
-function register_setting(...$args): void {}
+if (!function_exists('register_setting')) {
+    function register_setting(...$args): void {}
+}
 function esc_attr($value)
 {
     return $value;


### PR DESCRIPTION
## Summary
- guard the ajax endpoints test stubs for `register_setting` and `wp_strip_all_tags` so they only load when WordPress core doesn't provide them

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68e6784092b4832e99aee35d97e836fc