### PR TITLE
Add accessibility status attributes to form widget success message

### DIFF
--- a/sidebar-jlg/assets/js/public-script.js
+++ b/sidebar-jlg/assets/js/public-script.js
@@ -2023,8 +2023,18 @@ document.addEventListener('DOMContentLoaded', function() {
         const successMessage = widgetElement.querySelector('[data-widget-success-message]');
         if (successMessage) {
             successMessage.classList.add('is-visible');
-            successMessage.setAttribute('role', 'status');
-            successMessage.setAttribute('aria-live', 'polite');
+
+            if (!successMessage.hasAttribute('role')) {
+                successMessage.setAttribute('role', 'status');
+            }
+
+            if (!successMessage.hasAttribute('aria-live')) {
+                successMessage.setAttribute('aria-live', 'polite');
+            }
+
+            if (!successMessage.hasAttribute('aria-atomic')) {
+                successMessage.setAttribute('aria-atomic', 'true');
+            }
         }
 
         if (form.hasAttribute('data-widget-form')) {

--- a/sidebar-jlg/templates/widgets/widget-form.php
+++ b/sidebar-jlg/templates/widgets/widget-form.php
@@ -99,7 +99,13 @@ $style_attribute = $style_rules !== [] ? ' style="' . esc_attr( implode( ';', $s
         </div>
 
         <?php if ( $success_message !== '' ) : ?>
-            <p class="sidebar-widget__success" data-widget-success-message><?php echo esc_html( $success_message ); ?></p>
+            <p
+                class="sidebar-widget__success"
+                data-widget-success-message
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+            ><?php echo esc_html( $success_message ); ?></p>
         <?php endif; ?>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add ARIA status attributes to the form widget success message markup
- ensure the public script preserves existing accessibility attributes and adds aria-atomic when needed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd6f5abef8832ea7dbea1e2f76e5fc